### PR TITLE
Remove explicit flag type casting to let the compiler infer C types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus"
-version = "0.4.0"
+version = "0.5.0-rc.1"
 dependencies = [
  "audionimbus-sys",
  "bitflags 2.8.0",

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Casting `u32` flags into `std::os::raw::c_uint` would fail on systems expecting `std::os::raw::c_int` IPL flags.
+
 ## [0.4.0] - 2025-04-01
 
 ### Added

--- a/audionimbus/Cargo.toml
+++ b/audionimbus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus"
 description = "A safe wrapper around Steam Audio that provides spatial audio capabilities with realistic occlusion, reverb, and HRTF effects, accounting for physical attributes and scene geometry."
-version = "0.4.0"
+version = "0.5.0-rc.1"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/audionimbus/src/context.rs
+++ b/audionimbus/src/context.rs
@@ -1,6 +1,5 @@
 use crate::error::{to_option_error, SteamAudioError};
 use crate::version::SteamAudioVersion;
-use std::os::raw::c_uint;
 
 /// A context object, which controls low-level operations of Steam Audio.
 ///
@@ -170,6 +169,6 @@ bitflags::bitflags! {
 
 impl From<ContextFlags> for audionimbus_sys::IPLContextFlags {
     fn from(context_flags: ContextFlags) -> Self {
-        Self(context_flags.bits() as c_uint)
+        Self(context_flags.bits() as _)
     }
 }

--- a/audionimbus/src/effect/direct.rs
+++ b/audionimbus/src/effect/direct.rs
@@ -5,7 +5,6 @@ use crate::audio_settings::AudioSettings;
 use crate::context::Context;
 use crate::error::{to_option_error, SteamAudioError};
 use crate::ffi_wrapper::FFIWrapper;
-use std::os::raw::c_uint;
 
 /// Filters and attenuates an audio signal based on various properties of the direct path between a point source and the listener.
 #[derive(Debug)]
@@ -174,7 +173,7 @@ impl From<audionimbus_sys::IPLDirectEffectParams> for DirectEffectParams {
 
 impl DirectEffectParams {
     pub(crate) fn as_ffi(&self) -> FFIWrapper<'_, audionimbus_sys::IPLDirectEffectParams, Self> {
-        let mut flags = audionimbus_sys::IPLDirectEffectFlags(c_uint::default());
+        let mut flags = audionimbus_sys::IPLDirectEffectFlags(<_>::default());
 
         let distance_attenuation = self.distance_attenuation.unwrap_or_default();
         if self.distance_attenuation.is_some() {

--- a/audionimbus/src/effect/reflection.rs
+++ b/audionimbus/src/effect/reflection.rs
@@ -12,7 +12,6 @@ use crate::ffi_wrapper::FFIWrapper;
 use crate::geometry::{Scene, SceneParams};
 use crate::probe::ProbeBatch;
 use crate::simulation::BakedDataIdentifier;
-use std::os::raw::c_uint;
 
 #[cfg(doc)]
 use crate::simulation::BakedDataVariation;
@@ -633,7 +632,7 @@ bitflags::bitflags! {
 
 impl From<ReflectionsBakeFlags> for audionimbus_sys::IPLReflectionsBakeFlags {
     fn from(reflections_bake_flags: ReflectionsBakeFlags) -> Self {
-        Self(reflections_bake_flags.bits() as c_uint)
+        Self(reflections_bake_flags.bits() as _)
     }
 }
 

--- a/audionimbus/src/hrtf.rs
+++ b/audionimbus/src/hrtf.rs
@@ -91,7 +91,7 @@ impl From<&HrtfSettings> for audionimbus_sys::IPLHRTFSettings {
             audionimbus_sys::IPLHRTFType,
             *const std::os::raw::c_char,
             *const u8,
-            std::os::raw::c_int,
+            _,
         ) = if let Some(information) = &settings.sofa_information {
             match information {
                 Sofa::Filename(filename) => {

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -12,7 +12,6 @@ use crate::ffi_wrapper::FFIWrapper;
 use crate::geometry;
 use crate::geometry::{Scene, SceneParams};
 use crate::probe::ProbeBatch;
-use std::os::raw::c_uint;
 
 /// Manages direct and indirect sound propagation simulation for multiple sources.
 ///
@@ -521,7 +520,7 @@ bitflags::bitflags! {
 
 impl From<SimulationFlags> for audionimbus_sys::IPLSimulationFlags {
     fn from(simulation_flags: SimulationFlags) -> Self {
-        Self(simulation_flags.bits() as c_uint)
+        Self(simulation_flags.bits() as _)
     }
 }
 


### PR DESCRIPTION
Depending on the architecture, [`audionimbus_sys`](https://github.com/MaxenceMaire/audionimbus/tree/master/audionimbus-sys) binds to either `std::os::raw::c_uint` or `std::os::raw::c_int` for the inner types of IPL flags.

`audionimbus` would attempt to cast `u32` flags into `std::os::raw::c_uint`, which fails on systems expecting `std::os::raw::c_int`.

This PR removes the explicit type coercion to automatically match the IPL type instead.

The fix can be tested with version `0.5.0-rc.1`.

Closes #2 