### PR TITLE
Add support for Steam Audio v4.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "audionimbus-sys",
  "bitflags 2.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus-sys"
-version = "4.6.0"
+version = "4.6.1"
 dependencies = [
  "bindgen 0.71.1",
 ]

--- a/audionimbus-sys/Cargo.toml
+++ b/audionimbus-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus-sys"
 description = "Rust bindings for Steam Audio."
-version = "4.6.0"
+version = "4.6.1"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -16,7 +16,7 @@ It is inherently unsafe, as it interfaces with external C code; for a safe API, 
 
 `audionimbus-sys` requires linking against the Steam Audio library during compilation.
 
-To do so, download `steamaudio_4.6.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+To do so, download `steamaudio_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
 Locate the relevant library for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 
@@ -39,7 +39,7 @@ Finally, add `audionimbus-sys` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus-sys = "4.6.0"
+audionimbus-sys = "4.6.1"
 ```
 
 ## Documentation

--- a/audionimbus-sys/src/lib.rs
+++ b/audionimbus-sys/src/lib.rs
@@ -17,7 +17,7 @@ It is inherently unsafe, as it interfaces with external C code; for a safe API, 
 
 `audionimbus-sys` requires linking against the Steam Audio library during compilation.
 
-To do so, download `steamaudio_4.6.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+To do so, download `steamaudio_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
 Locate the relevant library for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 
@@ -40,7 +40,7 @@ Finally, add `audionimbus-sys` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus-sys = "4.6.0"
+audionimbus-sys = "4.6.1"
 ```
 
 ## Documentation

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.1] - 2025-04-12
+
+### Added
+
+- Support for Steam Audio v.4.6.1 via `audionimbus-sys` v.4.6.1.
+
 ## [0.5.0] - 2025-04-10
 
 ### Fixed

--- a/audionimbus/Cargo.toml
+++ b/audionimbus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus"
 description = "A safe wrapper around Steam Audio that provides spatial audio capabilities with realistic occlusion, reverb, and HRTF effects, accounting for physical attributes and scene geometry."
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -11,5 +11,5 @@ repository = "https://github.com/MaxenceMaire/audionimbus"
 readme = "README.md"
 
 [dependencies]
-audionimbus-sys = { version = "4.6.0", path = "../audionimbus-sys" }
+audionimbus-sys = { version = "4.6.1", path = "../audionimbus-sys" }
 bitflags = "2.8.0"

--- a/audionimbus/README.md
+++ b/audionimbus/README.md
@@ -12,7 +12,7 @@ To experience AudioNimbus in action, play the [interactive demo](https://github.
 
 ## Version compatibility
 
-`audionimbus` currently tracks Steam Audio 4.6.0.
+`audionimbus` currently tracks Steam Audio 4.6.1.
 
 Unlike `audionimbus-sys`, which mirrors Steam Audio's versioning, `audionimbus` introduces its own abstractions and is subject to breaking changes.
 As a result, it uses independent versioning.
@@ -21,7 +21,7 @@ As a result, it uses independent versioning.
 
 `audionimbus` requires linking against the Steam Audio library during compilation.
 
-To do so, download `steamaudio_4.6.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+To do so, download `steamaudio_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
 Locate the relevant library for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 

--- a/audionimbus/src/lib.rs
+++ b/audionimbus/src/lib.rs
@@ -11,7 +11,7 @@ It builds upon [`audionimbus-sys`](https://github.com/MaxenceMaire/audionimbus/t
 
 ## Version compatibility
 
-`audionimbus` currently tracks Steam Audio 4.6.0.
+`audionimbus` currently tracks Steam Audio 4.6.1.
 
 Unlike `audionimbus-sys`, which mirrors Steam Audio's versioning, `audionimbus` introduces its own abstractions and is subject to breaking changes.
 As a result, it uses independent versioning.
@@ -20,7 +20,7 @@ As a result, it uses independent versioning.
 
 `audionimbus` requires linking against the Steam Audio library during compilation.
 
-To do so, download `steamaudio_4.6.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+To do so, download `steamaudio_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
 Locate the relevant library for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 


### PR DESCRIPTION
This PR adds support for [Steam Audio v4.6.1](https://github.com/ValveSoftware/steam-audio/releases/tag/v4.6.1).

When upgrading to `audionimbus` v0.5.1 or `audionimbus-sys` v4.6.1, make sure to install version 4.6.1 of the Steam Audio library on your system. Details on how to install the library can be found in the [installation section of the documentation](https://github.com/MaxenceMaire/audionimbus/blob/steam-audio-v4.6.1/audionimbus/README.md#installation).