### PR TITLE
Add support for FMOD integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus-sys"
-version = "4.6.2-fmod"
+version = "4.6.2-fmod.1"
 dependencies = [
  "bindgen 0.71.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "audionimbus-sys",
  "bitflags 2.8.0",
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus-sys"
-version = "4.6.1"
+version = "4.6.2-fmod"
 dependencies = [
  "bindgen 0.71.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "audionimbus-sys",
  "bitflags 2.8.0",
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus-sys"
-version = "4.6.2-fmod.1"
+version = "4.6.2-fmod.3"
 dependencies = [
  "bindgen 0.71.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "audionimbus-sys",
  "bitflags 2.8.0",

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ AudioNimbus provides a safe and ergonomic Rust interface to Steam Audio, enablin
 * [`audionimbus`](audionimbus): A high-level, safe wrapper around Steam Audio.
 * [`audionimbus-sys`](audionimbus-sys): Automatically generated raw bindings to the Steam Audio C API.
 
+Both can integrate with FMOD Studio.
+
 ## Features
 
 AudioNimbus supports a variety of spatial audio effects, including:

--- a/audionimbus-sys/Cargo.toml
+++ b/audionimbus-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus-sys"
 description = "Rust bindings for Steam Audio."
-version = "4.6.1"
+version = "4.6.2-fmod"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/audionimbus-sys/Cargo.toml
+++ b/audionimbus-sys/Cargo.toml
@@ -11,8 +11,12 @@ repository = "https://github.com/MaxenceMaire/audionimbus"
 readme = "README.md"
 exclude = [
   "steam-audio/**",
-  "!steam-audio/core/src/core/**"
+  "!steam-audio/core/src/core/**/*.h",
+  "!steam-audio/fmod/src/**/*.h"
 ]
 
 [build-dependencies]
 bindgen = "0.71.1"
+
+[features]
+fmod = []

--- a/audionimbus-sys/Cargo.toml
+++ b/audionimbus-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus-sys"
 description = "Rust bindings for Steam Audio."
-version = "4.6.2-fmod.1"
+version = "4.6.2-fmod.3"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,8 @@ readme = "README.md"
 exclude = [
   "steam-audio/**",
   "!steam-audio/core/src/core/**/*.h",
-  "!steam-audio/fmod/src/**/*.h"
+  "!steam-audio/fmod/src/**/*.h",
+  "!steam-audio/fmod/include/**"
 ]
 
 [build-dependencies]
@@ -20,3 +21,7 @@ bindgen = "0.71.1"
 
 [features]
 fmod = []
+
+[package.metadata.docs.rs]
+features = ["fmod"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/audionimbus-sys/Cargo.toml
+++ b/audionimbus-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus-sys"
 description = "Rust bindings for Steam Audio."
-version = "4.6.2-fmod"
+version = "4.6.2-fmod.1"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -73,7 +73,7 @@ Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.to
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod", features = ["fmod"] }
+audionimbus-sys = { version = "4.6.2-fmod.1", features = ["fmod"] }
 ```
 
 ## Documentation

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -8,6 +8,8 @@ This crate is not meant to be used directly; most users should use [`audionimbus
 `audionimbus-sys` exposes raw bindings to the [Steam Audio C library](steam-audio).
 It is inherently unsafe, as it interfaces with external C code; for a safe API, refer to [`audionimbus`](../audionimbus).
 
+`audionimbus-sys` can also integrate with FMOD studio.
+
 ## Version compatibility
 
 `audionimbus-sys` mirrors the version of [Steam Audio](steam-audio).

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -73,7 +73,7 @@ Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.to
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod.1", features = ["fmod"] }
+audionimbus-sys = { version = "4.6.2-fmod.3", features = ["fmod"] }
 ```
 
 ## Documentation

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -42,6 +42,38 @@ Finally, add `audionimbus-sys` to your `Cargo.toml`:
 audionimbus-sys = "4.6.1"
 ```
 
+## Steam Audio FMOD Studio Integration
+
+`audionimbus-sys` can be used to add spatial audio to an FMOD Studio project.
+
+It requires linking against both the Steam Audio library and the FMOD integration library during compilation, similarly to the steps described in the [Installation](#Installation) section.
+
+Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+
+Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
+
+| Platform | Library Directory | Library To Link |
+| --- | --- | --- |
+| Windows 32-bit | `SDKROOT/lib/windows-x86` | `phonon.dll`, `phonon_fmod.dll` |
+| Windows 64-bit | `SDKROOT/lib/windows-x64` | `phonon.dll`, `phonon_fmod.dll` |
+| Linux 32-bit | `SDKROOT/lib/linux-x86` | `libphonon.so`, `libphonon_fmod.so` |
+| Linux 64-bit | `SDKROOT/lib/linux-x64` | `libphonon.so`, `libphonon_fmod.so` |
+| macOS | `SDKROOT/lib/osx` | `libphonon.dylib`, `libphonon_fmod.dylib` |
+| Android ARMv7 | `SDKROOT/lib/android-armv7` | `libphonon.so`, `libphonon_fmod.so` |
+| Android ARMv8/AArch64 | `SDKROOT/lib/android-armv8` | `libphonon.so`, `libphonon_fmod.so` |
+| Android x86 | `SDKROOT/lib/android-x86` | `libphonon.so`, `libphonon_fmod.so` |
+| Android x64 | `SDKROOT/lib/android-x64` | `libphonon.so`, `libphonon_fmod.so` |
+| iOS ARMv8/AArch64 | `SDKROOT/lib/ios` | `libphonon.a`, `libphonon_fmod.a` |
+
+Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+
+Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.toml`:
+
+```toml
+[dependencies]
+audionimbus-sys = { version = "4.6.2-fmod", features = ["fmod"] }
+```
+
 ## Documentation
 
 Documentation is available at [docs.rs](https://docs.rs/audionimbus-sys/latest).

--- a/audionimbus-sys/build.rs
+++ b/audionimbus-sys/build.rs
@@ -1,56 +1,148 @@
+use std::path::{Path, PathBuf};
+
+const PHONON_HEADER_PATH: &str = "steam-audio/core/src/core/phonon.h";
+
 fn main() {
     println!("cargo::rerun-if-changed=steam-audio");
 
+    let out_dir_path = std::env::var("OUT_DIR").unwrap();
+    let out_dir = Path::new(&out_dir_path);
+
+    let version = version();
+
+    generate_bindings_phonon(&out_dir.join("phonon.rs"), &version);
+
+    #[cfg(feature = "fmod")]
+    generate_bindings_phonon_fmod(&out_dir.join("phonon_fmod.rs"), &version);
+}
+
+fn generate_bindings_phonon(output_path: &Path, version: &Version) {
     println!("cargo:rustc-link-lib=phonon");
 
-    let out_dir_path = std::env::var("OUT_DIR").unwrap();
-    let out_dir = std::path::Path::new(&out_dir_path);
-
-    let major_version = std::env::var("CARGO_PKG_VERSION_MAJOR")
-        .unwrap()
-        .parse::<u32>()
-        .unwrap();
-
-    let minor_version = std::env::var("CARGO_PKG_VERSION_MINOR")
-        .unwrap()
-        .parse::<u32>()
-        .unwrap();
-
-    let patch_version = std::env::var("CARGO_PKG_VERSION_PATCH")
-        .unwrap()
-        .parse::<u32>()
-        .unwrap();
-
-    let packed_version = major_version << 16 | minor_version << 8 | patch_version;
-
-    let phonon_version = format!(
-        r#"
-#ifndef IPL_PHONON_VERSION_H
-#define IPL_PHONON_VERSION_H
-
-#define STEAMAUDIO_VERSION_MAJOR {major_version}
-#define STEAMAUDIO_VERSION_MINOR {minor_version}
-#define STEAMAUDIO_VERSION_PATCH {patch_version}
-#define STEAMAUDIO_VERSION       {packed_version}
-
-#endif
-"#,
+    let phonon_header = Path::new(PHONON_HEADER_PATH);
+    let phonon_header_dir = phonon_header.parent().unwrap();
+    let _phonon_header_guard = temporary_version_header(
+        &phonon_header_dir.join("phonon_version.h"),
+        version,
+        "STEAMAUDIO",
     );
-    let phonon_version_header = out_dir.join("phonon_version.h");
-    std::fs::write(phonon_version_header.clone(), phonon_version).unwrap();
-
-    let header_dir = std::path::Path::new("steam-audio/core/src/core");
 
     let bindings = bindgen::Builder::default()
-        .header(header_dir.join("phonon.h").to_str().unwrap())
-        .clang_arg(format!("--include-directory={}", header_dir.display()))
-        .clang_arg(format!("--include-directory={}", out_dir.display()))
+        .header(phonon_header.to_str().unwrap())
+        .clang_arg(format!("-I{}", phonon_header_dir.display()))
         .rustified_enum(".*")
         .bitfield_enum(".*Flags")
         .generate()
         .unwrap();
 
-    std::fs::remove_file(phonon_version_header).unwrap();
+    bindings.write_to_file(output_path).unwrap();
+}
 
-    bindings.write_to_file(out_dir.join("phonon.rs")).unwrap();
+#[cfg(feature = "fmod")]
+fn generate_bindings_phonon_fmod(output_path: &Path, version: &Version) {
+    const PHONON_FMOD_HEADER_PATH: &str = "steam-audio/fmod/src/phonon_mod.h";
+
+    println!("cargo:rustc-link-lib=phonon_fmod");
+
+    let phonon_header = Path::new(PHONON_HEADER_PATH);
+    let phonon_header_dir = phonon_header.parent().unwrap();
+    let _phonon_header_guard = temporary_version_header(
+        &phonon_header_dir.join("phonon_version.h"),
+        version,
+        "STEAMAUDIO",
+    );
+
+    let phonon_fmod_header = Path::new(PHONON_FMOD_HEADER_PATH);
+    let phonon_fmod_header_dir = phonon_fmod_header.parent().unwrap();
+    let _phonon_fmod_header_guard = temporary_version_header(
+        &phonon_fmod_header_dir.join("steamaudio_fmod_version.h"),
+        version,
+        "STEAMAUDIO_FMOD",
+    );
+
+    let bindings = bindgen::Builder::default()
+        .header(
+            phonon_fmod_header_dir
+                .join("steamaudio_fmod.h")
+                .to_str()
+                .unwrap(),
+        )
+        .clang_args(&[
+            String::from("-xc++"),
+            String::from("-std=c++11"),
+            format!("-I{}", phonon_header_dir.display()),
+            format!("-I{}", phonon_fmod_header_dir.display()),
+            format!("-I{}", "steam-audio/fmod/include"),
+        ])
+        .rustified_enum(".*")
+        .bitfield_enum(".*Flags")
+        .blocklist_type("_?IPL.*")
+        .allowlist_function("iplFMOD.*")
+        .generate()
+        .unwrap();
+
+    bindings.write_to_file(output_path).unwrap();
+}
+
+struct Version {
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+fn version() -> Version {
+    let major = std::env::var("CARGO_PKG_VERSION_MAJOR")
+        .unwrap()
+        .parse::<u32>()
+        .unwrap();
+
+    let minor = std::env::var("CARGO_PKG_VERSION_MINOR")
+        .unwrap()
+        .parse::<u32>()
+        .unwrap();
+
+    let patch = std::env::var("CARGO_PKG_VERSION_PATCH")
+        .unwrap()
+        .parse::<u32>()
+        .unwrap();
+
+    Version {
+        major,
+        minor,
+        patch,
+    }
+}
+
+fn temporary_version_header(
+    path: &Path,
+    version: &Version,
+    prefix: &str,
+) -> TemporaryFileGuard {
+    let packed_version = (version.major << 16) | (version.minor << 8) | version.patch;
+    let version_header = format!(
+        r#"
+#ifndef IPL_PHONON_VERSION_H
+#define IPL_PHONON_VERSION_H
+
+#define {prefix}_VERSION_MAJOR {}
+#define {prefix}_VERSION_MINOR {}
+#define {prefix}_VERSION_PATCH {}
+#define {prefix}_VERSION       {packed_version}
+
+#endif
+"#,
+        version.major, version.minor, version.patch,
+    );
+    std::fs::write(path, version_header).unwrap();
+
+    TemporaryFileGuard(path.to_path_buf())
+}
+
+// The file this guard points to gets removed when the guard goes out of scope.
+struct TemporaryFileGuard(PathBuf);
+
+impl Drop for TemporaryFileGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
 }

--- a/audionimbus-sys/build.rs
+++ b/audionimbus-sys/build.rs
@@ -106,6 +106,12 @@ fn version() -> Version {
         .parse::<u32>()
         .unwrap();
 
+    // TODO: remove statement upon release of Steam Audio v4.6.2.
+    // The version of audionimbus-sys is temporarily ahead of Steam Audio's
+    // to allow for the introduction of new features, so we need to explicitly
+    // pin the version.
+    let patch = 1;
+
     Version {
         major,
         minor,

--- a/audionimbus-sys/build.rs
+++ b/audionimbus-sys/build.rs
@@ -10,26 +10,21 @@ fn main() {
 
     let version = version();
 
-    generate_bindings_phonon(&out_dir.join("phonon.rs"), &version);
+    generate_bindings_phonon(&out_dir.join("phonon.rs"), &version, out_dir);
 
     #[cfg(feature = "fmod")]
-    generate_bindings_phonon_fmod(&out_dir.join("phonon_fmod.rs"), &version);
+    generate_bindings_phonon_fmod(&out_dir.join("phonon_fmod.rs"), &version, out_dir);
 }
 
-fn generate_bindings_phonon(output_path: &Path, version: &Version) {
+fn generate_bindings_phonon(output_path: &Path, version: &Version, tmp_dir: &Path) {
     println!("cargo:rustc-link-lib=phonon");
 
-    let phonon_header = Path::new(PHONON_HEADER_PATH);
-    let phonon_header_dir = phonon_header.parent().unwrap();
-    let _phonon_header_guard = temporary_version_header(
-        &phonon_header_dir.join("phonon_version.h"),
-        version,
-        "STEAMAUDIO",
-    );
+    let _phonon_header_guard =
+        temporary_version_header(&tmp_dir.join("phonon_version.h"), version, "STEAMAUDIO");
 
     let bindings = bindgen::Builder::default()
-        .header(phonon_header.to_str().unwrap())
-        .clang_arg(format!("-I{}", phonon_header_dir.display()))
+        .header(PHONON_HEADER_PATH)
+        .clang_arg(format!("-I{}", tmp_dir.display()))
         .rustified_enum(".*")
         .bitfield_enum(".*Flags")
         .generate()
@@ -39,39 +34,30 @@ fn generate_bindings_phonon(output_path: &Path, version: &Version) {
 }
 
 #[cfg(feature = "fmod")]
-fn generate_bindings_phonon_fmod(output_path: &Path, version: &Version) {
-    const PHONON_FMOD_HEADER_PATH: &str = "steam-audio/fmod/src/phonon_mod.h";
+fn generate_bindings_phonon_fmod(output_path: &Path, version: &Version, tmp_dir: &Path) {
+    const PHONON_FMOD_HEADER_PATH: &str = "steam-audio/fmod/src/steamaudio_fmod.h";
 
     println!("cargo:rustc-link-lib=phonon_fmod");
 
-    let phonon_header = Path::new(PHONON_HEADER_PATH);
-    let phonon_header_dir = phonon_header.parent().unwrap();
-    let _phonon_header_guard = temporary_version_header(
-        &phonon_header_dir.join("phonon_version.h"),
-        version,
-        "STEAMAUDIO",
-    );
+    let _phonon_header_guard =
+        temporary_version_header(&tmp_dir.join("phonon_version.h"), version, "STEAMAUDIO");
 
-    let phonon_fmod_header = Path::new(PHONON_FMOD_HEADER_PATH);
-    let phonon_fmod_header_dir = phonon_fmod_header.parent().unwrap();
     let _phonon_fmod_header_guard = temporary_version_header(
-        &phonon_fmod_header_dir.join("steamaudio_fmod_version.h"),
+        &tmp_dir.join("steamaudio_fmod_version.h"),
         version,
         "STEAMAUDIO_FMOD",
     );
 
+    let phonon_header = Path::new(PHONON_HEADER_PATH);
+    let phonon_header_dir = phonon_header.parent().unwrap();
+
     let bindings = bindgen::Builder::default()
-        .header(
-            phonon_fmod_header_dir
-                .join("steamaudio_fmod.h")
-                .to_str()
-                .unwrap(),
-        )
+        .header(PHONON_FMOD_HEADER_PATH)
         .clang_args(&[
             String::from("-xc++"),
             String::from("-std=c++11"),
+            format!("-I{}", tmp_dir.display()),
             format!("-I{}", phonon_header_dir.display()),
-            format!("-I{}", phonon_fmod_header_dir.display()),
             format!("-I{}", "steam-audio/fmod/include"),
         ])
         .rustified_enum(".*")

--- a/audionimbus-sys/build.rs
+++ b/audionimbus-sys/build.rs
@@ -113,11 +113,7 @@ fn version() -> Version {
     }
 }
 
-fn temporary_version_header(
-    path: &Path,
-    version: &Version,
-    prefix: &str,
-) -> TemporaryFileGuard {
+fn temporary_version_header(path: &Path, version: &Version, prefix: &str) -> TemporaryFileGuard {
     let packed_version = (version.major << 16) | (version.minor << 8) | version.patch;
     let version_header = format!(
         r#"

--- a/audionimbus-sys/src/fmod.rs
+++ b/audionimbus-sys/src/fmod.rs
@@ -1,0 +1,10 @@
+#![allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    rustdoc::broken_intra_doc_links
+)]
+
+use crate::phonon::*;
+
+include!(concat!(env!("OUT_DIR"), "/phonon_fmod.rs"));

--- a/audionimbus-sys/src/fmod.rs
+++ b/audionimbus-sys/src/fmod.rs
@@ -1,3 +1,7 @@
+/*!
+FMOD Studio integration.
+*/
+
 #![allow(
     non_camel_case_types,
     non_snake_case,

--- a/audionimbus-sys/src/lib.rs
+++ b/audionimbus-sys/src/lib.rs
@@ -55,5 +55,10 @@ Since this crate strictly follows Steam Audio’s C API, you can also refer to t
 You may choose either license when using the software.
 */
 
-#![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
-include!(concat!(env!("OUT_DIR"), "/phonon.rs"));
+mod phonon;
+pub use phonon::*;
+
+#[cfg(feature = "fmod")]
+pub mod fmod;
+#[cfg(feature = "fmod")]
+pub use fmod::*;

--- a/audionimbus-sys/src/lib.rs
+++ b/audionimbus-sys/src/lib.rs
@@ -72,7 +72,7 @@ Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.to
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod", features = ["fmod"] }
+audionimbus-sys = { version = "4.6.2-fmod.1", features = ["fmod"] }
 ```
 
 ## Documentation

--- a/audionimbus-sys/src/lib.rs
+++ b/audionimbus-sys/src/lib.rs
@@ -43,6 +43,38 @@ Finally, add `audionimbus-sys` to your `Cargo.toml`:
 audionimbus-sys = "4.6.1"
 ```
 
+## Steam Audio FMOD Studio Integration
+
+`audionimbus-sys` can be used to add spatial audio to an FMOD Studio project.
+
+It requires linking against both the Steam Audio library and the FMOD integration library during compilation, similarly to the steps described in the [Installation](#Installation) section.
+
+Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+
+Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
+
+| Platform | Library Directory | Library To Link |
+| --- | --- | --- |
+| Windows 32-bit | `SDKROOT/lib/windows-x86` | `phonon.dll`, `phonon_fmod.dll` |
+| Windows 64-bit | `SDKROOT/lib/windows-x64` | `phonon.dll`, `phonon_fmod.dll` |
+| Linux 32-bit | `SDKROOT/lib/linux-x86` | `libphonon.so`, `libphonon_fmod.so` |
+| Linux 64-bit | `SDKROOT/lib/linux-x64` | `libphonon.so`, `libphonon_fmod.so` |
+| macOS | `SDKROOT/lib/osx` | `libphonon.dylib`, `libphonon_fmod.dylib` |
+| Android ARMv7 | `SDKROOT/lib/android-armv7` | `libphonon.so`, `libphonon_fmod.so` |
+| Android ARMv8/AArch64 | `SDKROOT/lib/android-armv8` | `libphonon.so`, `libphonon_fmod.so` |
+| Android x86 | `SDKROOT/lib/android-x86` | `libphonon.so`, `libphonon_fmod.so` |
+| Android x64 | `SDKROOT/lib/android-x64` | `libphonon.so`, `libphonon_fmod.so` |
+| iOS ARMv8/AArch64 | `SDKROOT/lib/ios` | `libphonon.a`, `libphonon_fmod.a` |
+
+Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+
+Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.toml`:
+
+```toml
+[dependencies]
+audionimbus-sys = { version = "4.6.2-fmod", features = ["fmod"] }
+```
+
 ## Documentation
 
 Documentation is available at [docs.rs](https://docs.rs/audionimbus-sys/latest).

--- a/audionimbus-sys/src/lib.rs
+++ b/audionimbus-sys/src/lib.rs
@@ -72,7 +72,7 @@ Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.to
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod.1", features = ["fmod"] }
+audionimbus-sys = { version = "4.6.2-fmod.3", features = ["fmod"] }
 ```
 
 ## Documentation
@@ -86,6 +86,8 @@ Since this crate strictly follows Steam Audio’s C API, you can also refer to t
 `audionimbus-sys` is dual-licensed under the [MIT License](https://github.com/MaxenceMaire/audionimbus/blob/master/LICENSE-MIT) and the [Apache-2.0 License](https://github.com/MaxenceMaire/audionimbus/blob/master/LICENSE-APACHE).
 You may choose either license when using the software.
 */
+
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod phonon;
 pub use phonon::*;

--- a/audionimbus-sys/src/phonon.rs
+++ b/audionimbus-sys/src/phonon.rs
@@ -1,0 +1,7 @@
+#![allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    rustdoc::broken_intra_doc_links
+)]
+include!(concat!(env!("OUT_DIR"), "/phonon.rs"));

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.2] - 2025-04-14
+
+### Added
+
+- Documentation generation for feature `fmod`.
+
+### Fixed
+
+- Version `4.6.2-fmod.2` of dependency `audionimbus-sys` would fail to compile when feature `fmod` was enabled. It has been updated to version `4.6.2-fmod.3`.
+
 ## [0.6.1] - 2025-04-13
 
 ### Fixed

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.1] - 2025-04-13
+
+### Fixed
+
+- Version `4.6.2-fmod` of dependency `audionimbus-sys` would prevent the documentation from being generated. It has been updated to version `4.6.2-fmod.1`.
+
 ## [0.6.0] - 2025-04-13
 
 ### Added

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.0] - 2025-04-13
+
+### Added
+
+- Support for the Steam Audio FMOD integration.
+
 ## [0.5.1] - 2025-04-12
 
 ### Added

--- a/audionimbus/Cargo.toml
+++ b/audionimbus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus"
 description = "A safe wrapper around Steam Audio that provides spatial audio capabilities with realistic occlusion, reverb, and HRTF effects, accounting for physical attributes and scene geometry."
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ repository = "https://github.com/MaxenceMaire/audionimbus"
 readme = "README.md"
 
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod", path = "../audionimbus-sys" }
+audionimbus-sys = { version = "4.6.2-fmod.1", path = "../audionimbus-sys" }
 bitflags = "2.8.0"
 
 [features]

--- a/audionimbus/Cargo.toml
+++ b/audionimbus/Cargo.toml
@@ -13,3 +13,6 @@ readme = "README.md"
 [dependencies]
 audionimbus-sys = { version = "4.6.1", path = "../audionimbus-sys" }
 bitflags = "2.8.0"
+
+[features]
+fmod = ["audionimbus-sys/fmod"]

--- a/audionimbus/Cargo.toml
+++ b/audionimbus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus"
 description = "A safe wrapper around Steam Audio that provides spatial audio capabilities with realistic occlusion, reverb, and HRTF effects, accounting for physical attributes and scene geometry."
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ repository = "https://github.com/MaxenceMaire/audionimbus"
 readme = "README.md"
 
 [dependencies]
-audionimbus-sys = { version = "4.6.1", path = "../audionimbus-sys" }
+audionimbus-sys = { version = "4.6.2-fmod", path = "../audionimbus-sys" }
 bitflags = "2.8.0"
 
 [features]

--- a/audionimbus/Cargo.toml
+++ b/audionimbus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus"
 description = "A safe wrapper around Steam Audio that provides spatial audio capabilities with realistic occlusion, reverb, and HRTF effects, accounting for physical attributes and scene geometry."
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -11,8 +11,12 @@ repository = "https://github.com/MaxenceMaire/audionimbus"
 readme = "README.md"
 
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod.1", path = "../audionimbus-sys" }
+audionimbus-sys = { version = "4.6.2-fmod.3", path = "../audionimbus-sys" }
 bitflags = "2.8.0"
 
 [features]
 fmod = ["audionimbus-sys/fmod"]
+
+[package.metadata.docs.rs]
+features = ["fmod"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/audionimbus/README.md
+++ b/audionimbus/README.md
@@ -44,7 +44,7 @@ Finally, add `audionimbus` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = "0.1.0"
+audionimbus = "0.6.0"
 ```
 
 ## Example
@@ -123,6 +123,38 @@ To implement real-time audio processing and playback in your game, check out the
 For a complete demonstration featuring HRTF, Ambisonics, reflections and reverb in an interactive environment, see the [AudioNimbus Interactive Demo repository](https://github.com/MaxenceMaire/audionimbus-demo).
 
 For additional examples, you can explore the [tests](./tests), which closely follow [Steam Audio's Programmer's Guide](https://valvesoftware.github.io/steam-audio/doc/capi/guide.html).
+
+## Steam Audio FMOD Studio Integration
+
+`audionimbus` can be used to add spatial audio to an FMOD Studio project.
+
+It requires linking against both the Steam Audio library and the FMOD integration library during compilation, similarly to the steps described in the [Installation](#Installation) section.
+
+Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+
+Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
+
+| Platform | Library Directory | Library To Link |
+| --- | --- | --- |
+| Windows 32-bit | `SDKROOT/lib/windows-x86` | `phonon.dll`, `phonon_fmod.dll` |
+| Windows 64-bit | `SDKROOT/lib/windows-x64` | `phonon.dll`, `phonon_fmod.dll` |
+| Linux 32-bit | `SDKROOT/lib/linux-x86` | `libphonon.so`, `libphonon_fmod.so` |
+| Linux 64-bit | `SDKROOT/lib/linux-x64` | `libphonon.so`, `libphonon_fmod.so` |
+| macOS | `SDKROOT/lib/osx` | `libphonon.dylib`, `libphonon_fmod.dylib` |
+| Android ARMv7 | `SDKROOT/lib/android-armv7` | `libphonon.so`, `libphonon_fmod.so` |
+| Android ARMv8/AArch64 | `SDKROOT/lib/android-armv8` | `libphonon.so`, `libphonon_fmod.so` |
+| Android x86 | `SDKROOT/lib/android-x86` | `libphonon.so`, `libphonon_fmod.so` |
+| Android x64 | `SDKROOT/lib/android-x64` | `libphonon.so`, `libphonon_fmod.so` |
+| iOS ARMv8/AArch64 | `SDKROOT/lib/ios` | `libphonon.a`, `libphonon_fmod.a` |
+
+Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+
+Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
+
+```toml
+[dependencies]
+audionimbus = { version = "0.6.0", features = ["fmod"] }
+```
 
 ## Documentation
 

--- a/audionimbus/README.md
+++ b/audionimbus/README.md
@@ -10,6 +10,8 @@ It builds upon [`audionimbus-sys`](../audionimbus-sys), which provides raw bindi
 
 To experience AudioNimbus in action, play the [interactive demo](https://github.com/MaxenceMaire/audionimbus-demo) or watch the [walkthrough video](https://www.youtube.com/watch?v=zlhW1maG0Is).
 
+`audionimbus` can also integrate with FMOD studio.
+
 ## Version compatibility
 
 `audionimbus` currently tracks Steam Audio 4.6.1.

--- a/audionimbus/README.md
+++ b/audionimbus/README.md
@@ -46,7 +46,7 @@ Finally, add `audionimbus` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = "0.6.1"
+audionimbus = "0.6.2"
 ```
 
 ## Example
@@ -155,7 +155,7 @@ Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = { version = "0.6.1", features = ["fmod"] }
+audionimbus = { version = "0.6.2", features = ["fmod"] }
 ```
 
 ## Documentation

--- a/audionimbus/README.md
+++ b/audionimbus/README.md
@@ -46,7 +46,7 @@ Finally, add `audionimbus` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = "0.6.0"
+audionimbus = "0.6.1"
 ```
 
 ## Example
@@ -155,7 +155,7 @@ Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = { version = "0.6.0", features = ["fmod"] }
+audionimbus = { version = "0.6.1", features = ["fmod"] }
 ```
 
 ## Documentation

--- a/audionimbus/src/fmod.rs
+++ b/audionimbus/src/fmod.rs
@@ -1,0 +1,89 @@
+use crate::context::Context;
+use crate::hrtf::Hrtf;
+use crate::simulation::{SimulationSettings, Source};
+
+/// Initializes the FMOD Studio integration.
+///
+/// This function must be called before creating any Steam Audio DSP effects.
+pub fn initialize(context: &Context) {
+    unsafe { audionimbus_sys::iplFMODInitialize(context.raw_ptr()) }
+}
+
+/// Shuts down the FMOD Studio integration.
+///
+/// This function must be called after all Steam Audio DSP effects have been destroyed.
+pub fn terminate() {
+    unsafe { audionimbus_sys::iplFMODTerminate() }
+}
+
+/// Specifies the simulation settings used by the game engine for simulating direct and/or indirect sound propagation.
+///
+/// This function must be called once during initialization, after [`initialize`].
+pub fn set_simulation_settings(simulation_settings: SimulationSettings) {
+    unsafe {
+        audionimbus_sys::fmod::iplFMODSetSimulationSettings(
+            audionimbus_sys::IPLSimulationSettings::from(simulation_settings),
+        )
+    }
+}
+
+/// Specifies the HRTF to use for spatialization in subsequent audio frames.
+///
+/// This function must be called once during initialization, after [`initialize`].
+/// It should also be called whenever the game engine needs to change the HRTF.
+pub fn set_hrtf(hrtf: &Hrtf) {
+    unsafe { audionimbus_sys::fmod::iplFMODSetHRTF(hrtf.raw_ptr()) }
+}
+
+/// Enables or disables HRTF.
+pub fn set_hrtf_disabled(disabled: bool) {
+    unsafe { audionimbus_sys::fmod::iplFMODSetHRTFDisabled(disabled) }
+}
+
+/// A handle to a [`Source`] that can be used in C# scripts.
+pub type SourceHandle = i32;
+
+/// Registers a source, and returns the corresponding handle.
+pub fn add_source(source: &Source) -> SourceHandle {
+    unsafe { audionimbus_sys::fmod::iplFMODAddSource(source.raw_ptr()) }
+}
+
+/// Unregisters a [`Source`] associated with the given handle.
+pub fn remove_source(handle: SourceHandle) {
+    unsafe { audionimbus_sys::fmod::iplFMODRemoveSource(handle as audionimbus_sys::IPLint32) }
+}
+
+/// Specifies the [`Source`] used by the game engine for simulating reverb.
+///
+/// Typically, listener-centric reverb is simulated by creating a [`Source`] with the same position as the listener, and simulating reflections.
+/// To render this simulated reverb, call this function and pass it the [`Source`] used.
+pub fn set_reverb_source(source: &Source) {
+    unsafe { audionimbus_sys::fmod::iplFMODSetReverbSource(source.raw_ptr()) }
+}
+
+/// Returns the version of the FMOD Studio integration being used.
+pub fn version() -> FmodStudioIntegrationVersion {
+    use std::os::raw::c_uint;
+
+    let mut major: c_uint = 0;
+    let mut minor: c_uint = 0;
+    let mut patch: c_uint = 0;
+
+    unsafe {
+        audionimbus_sys::fmod::iplFMODGetVersion(&mut major, &mut minor, &mut patch);
+    }
+
+    FmodStudioIntegrationVersion {
+        major: major as usize,
+        minor: minor as usize,
+        patch: patch as usize,
+    }
+}
+
+/// The version of the FMOD Studio integration.
+#[derive(Copy, Clone, Debug)]
+pub struct FmodStudioIntegrationVersion {
+    pub major: usize,
+    pub minor: usize,
+    pub patch: usize,
+}

--- a/audionimbus/src/lib.rs
+++ b/audionimbus/src/lib.rs
@@ -43,7 +43,7 @@ Finally, add `audionimbus` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = "0.1.0"
+audionimbus = "0.6.0"
 ```
 
 ## Example
@@ -120,6 +120,38 @@ let _effect_state =
 To implement real-time audio processing and playback in your game, check out the [demo crate](https://github.com/MaxenceMaire/audionimbus/tree/master/audionimbus/demo) for a more comprehensive example.
 
 For additional examples, you can explore the [tests](https://github.com/MaxenceMaire/audionimbus/tree/master/audionimbus/tests), which closely follow [Steam Audio's Programmer's Guide](https://valvesoftware.github.io/steam-audio/doc/capi/guide.html).
+
+## Steam Audio FMOD Studio Integration
+
+`audionimbus` can be used to add spatial audio to an FMOD Studio project.
+
+It requires linking against both the Steam Audio library and the FMOD integration library during compilation, similarly to the steps described in the [Installation](#Installation) section.
+
+Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+
+Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
+
+| Platform | Library Directory | Library To Link |
+| --- | --- | --- |
+| Windows 32-bit | `SDKROOT/lib/windows-x86` | `phonon.dll`, `phonon_fmod.dll` |
+| Windows 64-bit | `SDKROOT/lib/windows-x64` | `phonon.dll`, `phonon_fmod.dll` |
+| Linux 32-bit | `SDKROOT/lib/linux-x86` | `libphonon.so`, `libphonon_fmod.so` |
+| Linux 64-bit | `SDKROOT/lib/linux-x64` | `libphonon.so`, `libphonon_fmod.so` |
+| macOS | `SDKROOT/lib/osx` | `libphonon.dylib`, `libphonon_fmod.dylib` |
+| Android ARMv7 | `SDKROOT/lib/android-armv7` | `libphonon.so`, `libphonon_fmod.so` |
+| Android ARMv8/AArch64 | `SDKROOT/lib/android-armv8` | `libphonon.so`, `libphonon_fmod.so` |
+| Android x86 | `SDKROOT/lib/android-x86` | `libphonon.so`, `libphonon_fmod.so` |
+| Android x64 | `SDKROOT/lib/android-x64` | `libphonon.so`, `libphonon_fmod.so` |
+| iOS ARMv8/AArch64 | `SDKROOT/lib/ios` | `libphonon.a`, `libphonon_fmod.a` |
+
+Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+
+Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
+
+```toml
+[dependencies]
+audionimbus = { version = "0.6.0", features = ["fmod"] }
+```
 
 ## Documentation
 

--- a/audionimbus/src/lib.rs
+++ b/audionimbus/src/lib.rs
@@ -43,7 +43,7 @@ Finally, add `audionimbus` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = "0.6.1"
+audionimbus = "0.6.2"
 ```
 
 ## Example
@@ -150,7 +150,7 @@ Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = { version = "0.6.1", features = ["fmod"] }
+audionimbus = { version = "0.6.2", features = ["fmod"] }
 ```
 
 ## Documentation
@@ -164,6 +164,8 @@ For more details on Steam Audio's concepts, see the [Steam Audio SDK documentati
 `audionimbus` is dual-licensed under the [MIT License](https://github.com/MaxenceMaire/audionimbus/blob/master/LICENSE-MIT) and the [Apache-2.0 License](https://github.com/MaxenceMaire/audionimbus/blob/master/LICENSE-APACHE).
 You may choose either license when using the software.
 */
+
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod audio_buffer;
 pub use audio_buffer::*;

--- a/audionimbus/src/lib.rs
+++ b/audionimbus/src/lib.rs
@@ -176,3 +176,6 @@ pub use simulation::*;
 
 pub mod version;
 pub use version::*;
+
+#[cfg(feature = "fmod")]
+pub mod fmod;

--- a/audionimbus/src/lib.rs
+++ b/audionimbus/src/lib.rs
@@ -43,7 +43,7 @@ Finally, add `audionimbus` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = "0.6.0"
+audionimbus = "0.6.1"
 ```
 
 ## Example
@@ -150,7 +150,7 @@ Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = { version = "0.6.0", features = ["fmod"] }
+audionimbus = { version = "0.6.1", features = ["fmod"] }
 ```
 
 ## Documentation


### PR DESCRIPTION
This PR adds support for the Steam Audio FMOD Studio integration to both `audionimbus` and `audionimbus-sys`.

The integration can be enabled using the `fmod` feature and requires extra linking (see the [installation section](https://github.com/MaxenceMaire/audionimbus/tree/8d49bdc82bd8883af6126b8064eaf1f735e9c6a0/audionimbus#steam-audio-fmod-studio-integration)).

Note that `audionimbus-sys` must maintain version parity with Steam Audio (currently `4.6.1`), so the new version of `audionimbus-sys` supporting the FMOD integration cannot get ahead of `4.6.1`. For this reason, `audionimbus-sys` is being released as release candidate `4.6.2-fmod.3` rather than strictly incrementing the main version number.