### PR TITLE
Add support for Wwise integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus-sys"
-version = "4.6.2-fmod.3"
+version = "4.6.2-fmod-wwise"
 dependencies = [
  "bindgen 0.71.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus-sys"
-version = "4.6.2-fmod-wwise"
+version = "4.6.2-fmodwwise"
 dependencies = [
  "bindgen 0.71.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "audionimbus-sys",
  "bitflags 2.8.0",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ AudioNimbus provides a safe and ergonomic Rust interface to Steam Audio, enablin
 * [`audionimbus`](audionimbus): A high-level, safe wrapper around Steam Audio.
 * [`audionimbus-sys`](audionimbus-sys): Automatically generated raw bindings to the Steam Audio C API.
 
-Both can integrate with FMOD Studio.
+Both can integrate with FMOD Studio and Wwise.
 
 ## Features
 

--- a/audionimbus-sys/Cargo.toml
+++ b/audionimbus-sys/Cargo.toml
@@ -26,5 +26,5 @@ fmod = []
 wwise = []
 
 [package.metadata.docs.rs]
-features = ["fmod", "wwise"]
+features = ["fmod"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/audionimbus-sys/Cargo.toml
+++ b/audionimbus-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus-sys"
 description = "Rust bindings for Steam Audio."
-version = "4.6.2-fmod.3"
+version = "4.6.2-fmod-wwise"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -13,6 +13,8 @@ exclude = [
   "steam-audio/**",
   "!steam-audio/core/src/core/**/*.h",
   "!steam-audio/fmod/src/**/*.h",
+  "!steam-audio/fmod/include/**",
+  "!steam-audio/wwise/src/**/*.h",
   "!steam-audio/fmod/include/**"
 ]
 
@@ -21,7 +23,8 @@ bindgen = "0.71.1"
 
 [features]
 fmod = []
+wwise = []
 
 [package.metadata.docs.rs]
-features = ["fmod"]
+features = ["fmod", "wwise"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/audionimbus-sys/Cargo.toml
+++ b/audionimbus-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus-sys"
 description = "Rust bindings for Steam Audio."
-version = "4.6.2-fmod-wwise"
+version = "4.6.2-fmodwwise"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ exclude = [
   "!steam-audio/fmod/src/**/*.h",
   "!steam-audio/fmod/include/**",
   "!steam-audio/wwise/src/**/*.h",
-  "!steam-audio/fmod/include/**"
+  "!steam-audio/wwise/include/**"
 ]
 
 [build-dependencies]

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -73,7 +73,7 @@ It requires linking against both the Steam Audio library and the FMOD integratio
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod-wwise", features = ["fmod"] }
+audionimbus-sys = { version = "4.6.2-fmodwwise", features = ["fmod"] }
 ```
 
 ## Wwise Integration
@@ -92,7 +92,7 @@ It requires linking against both the Steam Audio library and the Wwise integrati
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod-wwise", features = ["wwise"] }
+audionimbus-sys = { version = "4.6.2-fmodwwise", features = ["wwise"] }
 ```
 
 ## Documentation

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -101,6 +101,9 @@ Documentation is available at [docs.rs](https://docs.rs/audionimbus-sys/latest).
 
 Since this crate strictly follows Steam Audio’s C API, you can also refer to the [Steam Audio C API reference](https://valvesoftware.github.io/steam-audio/doc/capi/reference.html) for additional details.
 
+Note that because the Wwise integration depends on files that are local to your system, documentation for the `wwise` module is not available on docs.rs.
+However, it can be generated locally using `cargo doc --open --features wwise`.
+
 ## License
 
 `audionimbus-sys` is dual-licensed under the [MIT License](LICENSE-MIT) and the [Apache-2.0 License](LICENSE-APACHE).

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -8,7 +8,7 @@ This crate is not meant to be used directly; most users should use [`audionimbus
 `audionimbus-sys` exposes raw bindings to the [Steam Audio C library](steam-audio).
 It is inherently unsafe, as it interfaces with external C code; for a safe API, refer to [`audionimbus`](../audionimbus).
 
-`audionimbus-sys` can also integrate with FMOD studio.
+`audionimbus-sys` can also integrate with FMOD studio and Wwise.
 
 ## Version compatibility
 
@@ -44,15 +44,15 @@ Finally, add `audionimbus-sys` to your `Cargo.toml`:
 audionimbus-sys = "4.6.1"
 ```
 
-## Steam Audio FMOD Studio Integration
+## FMOD Studio Integration
 
 `audionimbus-sys` can be used to add spatial audio to an FMOD Studio project.
 
-It requires linking against both the Steam Audio library and the FMOD integration library during compilation, similarly to the steps described in the [Installation](#Installation) section.
+It requires linking against both the Steam Audio library and the FMOD integration library during compilation:
 
-Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+1. Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
-Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
+2. Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 
 | Platform | Library Directory | Library To Link |
 | --- | --- | --- |
@@ -67,13 +67,32 @@ Locate the two relevant libraries for your target platform (`SDKROOT` refers to 
 | Android x64 | `SDKROOT/lib/android-x64` | `libphonon.so`, `libphonon_fmod.so` |
 | iOS ARMv8/AArch64 | `SDKROOT/lib/ios` | `libphonon.a`, `libphonon_fmod.a` |
 
-Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+3. Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
 
-Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.toml`:
+4. Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod.3", features = ["fmod"] }
+audionimbus-sys = { version = "4.6.2-fmod-wwise", features = ["fmod"] }
+```
+
+## Wwise Integration
+
+`audionimbus-sys` can be used to add spatial audio to a Wwise project.
+
+It requires linking against both the Steam Audio library and the Wwise integration library during compilation:
+
+1. Download `steamaudio_wwise_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+
+2. Locate the two relevant libraries for your target platform and place them in a location listed in [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+
+3. Set the `WWISESDK` environment variable to the path of the Wwise SDK installed on your system (e.g. `export WWISESDK="/path/to/Audiokinetic/Wwise2024.1.3.8749/SDK"`).
+
+4. Finally, add `audionimbus-sys` with the `wwise` feature enabled to your `Cargo.toml`:
+
+```toml
+[dependencies]
+audionimbus-sys = { version = "4.6.2-fmod-wwise", features = ["wwise"] }
 ```
 
 ## Documentation

--- a/audionimbus-sys/src/lib.rs
+++ b/audionimbus-sys/src/lib.rs
@@ -100,6 +100,9 @@ Documentation is available at [docs.rs](https://docs.rs/audionimbus-sys/latest).
 
 Since this crate strictly follows Steam Audio’s C API, you can also refer to the [Steam Audio C API reference](https://valvesoftware.github.io/steam-audio/doc/capi/reference.html) for additional details.
 
+Note that because the Wwise integration depends on files that are local to your system, documentation for the `wwise` module is not available on docs.rs.
+However, it can be generated locally using `cargo doc --open --features wwise`.
+
 ## License
 
 `audionimbus-sys` is dual-licensed under the [MIT License](https://github.com/MaxenceMaire/audionimbus/blob/master/LICENSE-MIT) and the [Apache-2.0 License](https://github.com/MaxenceMaire/audionimbus/blob/master/LICENSE-APACHE).

--- a/audionimbus-sys/src/lib.rs
+++ b/audionimbus-sys/src/lib.rs
@@ -43,15 +43,15 @@ Finally, add `audionimbus-sys` to your `Cargo.toml`:
 audionimbus-sys = "4.6.1"
 ```
 
-## Steam Audio FMOD Studio Integration
+## FMOD Studio Integration
 
 `audionimbus-sys` can be used to add spatial audio to an FMOD Studio project.
 
-It requires linking against both the Steam Audio library and the FMOD integration library during compilation, similarly to the steps described in the [Installation](#Installation) section.
+It requires linking against both the Steam Audio library and the FMOD integration library during compilation:
 
-Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+1. Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
-Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
+2. Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 
 | Platform | Library Directory | Library To Link |
 | --- | --- | --- |
@@ -66,13 +66,32 @@ Locate the two relevant libraries for your target platform (`SDKROOT` refers to 
 | Android x64 | `SDKROOT/lib/android-x64` | `libphonon.so`, `libphonon_fmod.so` |
 | iOS ARMv8/AArch64 | `SDKROOT/lib/ios` | `libphonon.a`, `libphonon_fmod.a` |
 
-Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+3. Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
 
-Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.toml`:
+4. Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod.3", features = ["fmod"] }
+audionimbus-sys = { version = "4.6.2-fmod-wwise", features = ["fmod"] }
+```
+
+## Wwise Integration
+
+`audionimbus-sys` can be used to add spatial audio to a Wwise project.
+
+It requires linking against both the Steam Audio library and the Wwise integration library during compilation:
+
+1. Download `steamaudio_wwise_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+
+2. Locate the two relevant libraries for your target platform and place them in a location listed in [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+
+3. Set the `WWISESDK` environment variable to the path of the Wwise SDK installed on your system (e.g. `export WWISESDK="/path/to/Audiokinetic/Wwise2024.1.3.8749/SDK"`).
+
+4. Finally, add `audionimbus-sys` with the `wwise` feature enabled to your `Cargo.toml`:
+
+```toml
+[dependencies]
+audionimbus-sys = { version = "4.6.2-fmod-wwise", features = ["wwise"] }
 ```
 
 ## Documentation
@@ -96,3 +115,8 @@ pub use phonon::*;
 pub mod fmod;
 #[cfg(feature = "fmod")]
 pub use fmod::*;
+
+#[cfg(feature = "wwise")]
+pub mod wwise;
+#[cfg(feature = "wwise")]
+pub use wwise::*;

--- a/audionimbus-sys/src/lib.rs
+++ b/audionimbus-sys/src/lib.rs
@@ -72,7 +72,7 @@ It requires linking against both the Steam Audio library and the FMOD integratio
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod-wwise", features = ["fmod"] }
+audionimbus-sys = { version = "4.6.2-fmodwwise", features = ["fmod"] }
 ```
 
 ## Wwise Integration
@@ -91,7 +91,7 @@ It requires linking against both the Steam Audio library and the Wwise integrati
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod-wwise", features = ["wwise"] }
+audionimbus-sys = { version = "4.6.2-fmodwwise", features = ["wwise"] }
 ```
 
 ## Documentation

--- a/audionimbus-sys/src/wwise.rs
+++ b/audionimbus-sys/src/wwise.rs
@@ -1,0 +1,14 @@
+/*!
+Wwise integration.
+*/
+
+#![allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    rustdoc::broken_intra_doc_links
+)]
+
+use crate::phonon::*;
+
+include!(concat!(env!("OUT_DIR"), "/phonon_wwise.rs"));

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.3] - 2025-04-15
+
+### Added
+
+- Support for the Steam Audio Wwise integration.
+
 ## [0.6.2] - 2025-04-14
 
 ### Added

--- a/audionimbus/Cargo.toml
+++ b/audionimbus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus"
 description = "A safe wrapper around Steam Audio that provides spatial audio capabilities with realistic occlusion, reverb, and HRTF effects, accounting for physical attributes and scene geometry."
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -11,11 +11,12 @@ repository = "https://github.com/MaxenceMaire/audionimbus"
 readme = "README.md"
 
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod.3", path = "../audionimbus-sys" }
+audionimbus-sys = { version = "4.6.2-fmod-wwise", path = "../audionimbus-sys" }
 bitflags = "2.8.0"
 
 [features]
 fmod = ["audionimbus-sys/fmod"]
+wwise = ["audionimbus-sys/wwise"]
 
 [package.metadata.docs.rs]
 features = ["fmod"]

--- a/audionimbus/Cargo.toml
+++ b/audionimbus/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/MaxenceMaire/audionimbus"
 readme = "README.md"
 
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmod-wwise", path = "../audionimbus-sys" }
+audionimbus-sys = { version = "4.6.2-fmodwwise", path = "../audionimbus-sys" }
 bitflags = "2.8.0"
 
 [features]

--- a/audionimbus/README.md
+++ b/audionimbus/README.md
@@ -46,7 +46,7 @@ Finally, add `audionimbus` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = "0.6.2"
+audionimbus = "0.6.3"
 ```
 
 ## Example
@@ -130,11 +130,11 @@ For additional examples, you can explore the [tests](./tests), which closely fol
 
 `audionimbus` can be used to add spatial audio to an FMOD Studio project.
 
-It requires linking against both the Steam Audio library and the FMOD integration library during compilation, similarly to the steps described in the [Installation](#Installation) section.
+It requires linking against both the Steam Audio library and the FMOD integration library during compilation:
 
-Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+1. Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
-Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
+2. Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 
 | Platform | Library Directory | Library To Link |
 | --- | --- | --- |
@@ -149,13 +149,32 @@ Locate the two relevant libraries for your target platform (`SDKROOT` refers to 
 | Android x64 | `SDKROOT/lib/android-x64` | `libphonon.so`, `libphonon_fmod.so` |
 | iOS ARMv8/AArch64 | `SDKROOT/lib/ios` | `libphonon.a`, `libphonon_fmod.a` |
 
-Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+3. Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
 
-Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
+4. Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = { version = "0.6.2", features = ["fmod"] }
+audionimbus = { version = "0.6.3", features = ["fmod"] }
+```
+
+## Wwise Integration
+
+`audionimbus` can be used to add spatial audio to a Wwise project.
+
+It requires linking against both the Steam Audio library and the Wwise integration library during compilation:
+
+1. Download `steamaudio_wwise_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+
+2. Locate the two relevant libraries for your target platform and place them in a location listed in [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+
+3. Set the `WWISESDK` environment variable to the path of the Wwise SDK installed on your system (e.g. `export WWISESDK="/path/to/Audiokinetic/Wwise2024.1.3.8749/SDK"`).
+
+4. Finally, add `audionimbus` with the `wwise` feature enabled to your `Cargo.toml`:
+
+```toml
+[dependencies]
+audionimbus = { version = "0.6.3", features = ["wwise"] }
 ```
 
 ## Documentation

--- a/audionimbus/README.md
+++ b/audionimbus/README.md
@@ -183,6 +183,9 @@ Documentation is available at [doc.rs](https://docs.rs/audionimbus/latest).
 
 For more details on Steam Audio's concepts, see the [Steam Audio SDK documentation](https://valvesoftware.github.io/steam-audio/doc/capi/index.html).
 
+Note that because the Wwise integration depends on files that are local to your system, documentation for the `wwise` module is not available on docs.rs.
+However, it can be generated locally using `cargo doc --open --features wwise`.
+
 ## License
 
 `audionimbus` is dual-licensed under the [MIT License](LICENSE-MIT) and the [Apache-2.0 License](LICENSE-APACHE).

--- a/audionimbus/README.md
+++ b/audionimbus/README.md
@@ -126,7 +126,7 @@ For a complete demonstration featuring HRTF, Ambisonics, reflections and reverb 
 
 For additional examples, you can explore the [tests](./tests), which closely follow [Steam Audio's Programmer's Guide](https://valvesoftware.github.io/steam-audio/doc/capi/guide.html).
 
-## Steam Audio FMOD Studio Integration
+## FMOD Studio Integration
 
 `audionimbus` can be used to add spatial audio to an FMOD Studio project.
 

--- a/audionimbus/src/fmod.rs
+++ b/audionimbus/src/fmod.rs
@@ -6,14 +6,14 @@ use crate::simulation::{SimulationSettings, Source};
 ///
 /// This function must be called before creating any Steam Audio DSP effects.
 pub fn initialize(context: &Context) {
-    unsafe { audionimbus_sys::iplFMODInitialize(context.raw_ptr()) }
+    unsafe { audionimbus_sys::fmod::iplFMODInitialize(context.raw_ptr()) }
 }
 
 /// Shuts down the FMOD Studio integration.
 ///
 /// This function must be called after all Steam Audio DSP effects have been destroyed.
 pub fn terminate() {
-    unsafe { audionimbus_sys::iplFMODTerminate() }
+    unsafe { audionimbus_sys::fmod::iplFMODTerminate() }
 }
 
 /// Specifies the simulation settings used by the game engine for simulating direct and/or indirect sound propagation.

--- a/audionimbus/src/lib.rs
+++ b/audionimbus/src/lib.rs
@@ -43,7 +43,7 @@ Finally, add `audionimbus` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = "0.6.2"
+audionimbus = "0.6.3"
 ```
 
 ## Example
@@ -121,15 +121,15 @@ To implement real-time audio processing and playback in your game, check out the
 
 For additional examples, you can explore the [tests](https://github.com/MaxenceMaire/audionimbus/tree/master/audionimbus/tests), which closely follow [Steam Audio's Programmer's Guide](https://valvesoftware.github.io/steam-audio/doc/capi/guide.html).
 
-## Steam Audio FMOD Studio Integration
+## FMOD Studio Integration
 
 `audionimbus` can be used to add spatial audio to an FMOD Studio project.
 
-It requires linking against both the Steam Audio library and the FMOD integration library during compilation, similarly to the steps described in the [Installation](#Installation) section.
+It requires linking against both the Steam Audio library and the FMOD integration library during compilation:
 
-Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+1. Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
-Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
+2. Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 
 | Platform | Library Directory | Library To Link |
 | --- | --- | --- |
@@ -144,13 +144,32 @@ Locate the two relevant libraries for your target platform (`SDKROOT` refers to 
 | Android x64 | `SDKROOT/lib/android-x64` | `libphonon.so`, `libphonon_fmod.so` |
 | iOS ARMv8/AArch64 | `SDKROOT/lib/ios` | `libphonon.a`, `libphonon_fmod.a` |
 
-Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+3. Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
 
-Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
+4. Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = { version = "0.6.2", features = ["fmod"] }
+audionimbus = { version = "0.6.3", features = ["fmod"] }
+```
+
+## Wwise Integration
+
+`audionimbus` can be used to add spatial audio to a Wwise project.
+
+It requires linking against both the Steam Audio library and the Wwise integration library during compilation:
+
+1. Download `steamaudio_wwise_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+
+2. Locate the two relevant libraries for your target platform and place them in a location listed in [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+
+3. Set the `WWISESDK` environment variable to the path of the Wwise SDK installed on your system (e.g. `export WWISESDK="/path/to/Audiokinetic/Wwise2024.1.3.8749/SDK"`).
+
+4. Finally, add `audionimbus` with the `wwise` feature enabled to your `Cargo.toml`:
+
+```toml
+[dependencies]
+audionimbus = { version = "0.6.3", features = ["wwise"] }
 ```
 
 ## Documentation
@@ -213,3 +232,6 @@ pub use version::*;
 
 #[cfg(feature = "fmod")]
 pub mod fmod;
+
+#[cfg(feature = "wwise")]
+pub mod wwise;

--- a/audionimbus/src/lib.rs
+++ b/audionimbus/src/lib.rs
@@ -178,6 +178,9 @@ Documentation is available at [doc.rs](https://docs.rs/audionimbus/latest).
 
 For more details on Steam Audio's concepts, see the [Steam Audio SDK documentation](https://valvesoftware.github.io/steam-audio/doc/capi/index.html).
 
+Note that because the Wwise integration depends on files that are local to your system, documentation for the `wwise` module is not available on docs.rs.
+However, it can be generated locally using `cargo doc --open --features wwise`.
+
 ## License
 
 `audionimbus` is dual-licensed under the [MIT License](https://github.com/MaxenceMaire/audionimbus/blob/master/LICENSE-MIT) and the [Apache-2.0 License](https://github.com/MaxenceMaire/audionimbus/blob/master/LICENSE-APACHE).

--- a/audionimbus/src/wwise.rs
+++ b/audionimbus/src/wwise.rs
@@ -1,0 +1,102 @@
+use crate::context::Context;
+use crate::hrtf::Hrtf;
+use crate::simulation::{SimulationSettings, Source};
+
+#[derive(Debug, Copy, Clone)]
+/// Settings used for initializing the Steam Audio Wwise integration.
+pub struct WwiseSettings {
+    /// Scaling factor to apply when converting from game engine units to Steam Audio units (which are in meters).
+    pub meters_per_unit: f32,
+}
+
+/// Initializes the Wwise integration.
+///
+/// This function must be called before creating any Steam Audio DSP effects.
+pub fn initialize(context: &Context, settings: Option<WwiseSettings>) {
+    let mut ffi_settings = settings.map(|s| audionimbus_sys::IPLWwiseSettings {
+        metersPerUnit: s.meters_per_unit,
+    });
+
+    let ipl_settings = ffi_settings
+        .as_mut()
+        .map(|s| s as *mut _)
+        .unwrap_or(std::ptr::null_mut());
+
+    unsafe { audionimbus_sys::wwise::iplWwiseInitialize(context.raw_ptr(), ipl_settings) }
+}
+
+/// Shuts down the Wwise integration.
+///
+/// This function must be called after all Steam Audio DSP effects have been destroyed.
+pub fn terminate() {
+    unsafe { audionimbus_sys::wwise::iplWwiseTerminate() }
+}
+
+/// Specifies the simulation settings used by the game engine for simulating direct and/or indirect sound propagation.
+///
+/// This function must be called once during initialization, after [`initialize`].
+pub fn set_simulation_settings(simulation_settings: SimulationSettings) {
+    unsafe {
+        audionimbus_sys::wwise::iplWwiseSetSimulationSettings(
+            audionimbus_sys::IPLSimulationSettings::from(simulation_settings),
+        )
+    }
+}
+
+/// Specifies the HRTF to use for spatialization in subsequent audio frames.
+///
+/// This function must be called once during initialization, after [`initialize`].
+/// It should also be called whenever the game engine needs to change the HRTF.
+pub fn set_hrtf(hrtf: &Hrtf) {
+    unsafe { audionimbus_sys::wwise::iplWwiseSetHRTF(hrtf.raw_ptr()) }
+}
+
+/// Wwise game object ID.
+pub type WwiseGameObjectId = u64;
+
+/// Specifies the [`Source`] used by the game engine for simulating occlusion, reflections, etc. for the given Wwise game object (identified by its AkGameObjectID).
+pub fn add_source(game_object_id: WwiseGameObjectId, source: &Source) {
+    unsafe { audionimbus_sys::wwise::iplWwiseAddSource(game_object_id, source.raw_ptr()) }
+}
+
+/// Remove any [`Source`] associated the given Wwise game object ID.
+///
+/// This should be called when the game engine no longer needs to render occlusion, reflections, etc. for the given game object.
+pub fn remove_source(game_object_id: WwiseGameObjectId) {
+    unsafe { audionimbus_sys::wwise::iplWwiseRemoveSource(game_object_id) }
+}
+
+/// Specifies the [`Source`] used by the game engine for simulating reverb.
+///
+/// Typically, listener-centric reverb is simulated by creating a [`Source`] with the same position as the listener, and simulating reflections.
+/// To render this simulated reverb, call this function and pass it the [`Source`] used.
+pub fn set_reverb_source(source: &Source) {
+    unsafe { audionimbus_sys::wwise::iplWwiseSetReverbSource(source.raw_ptr()) }
+}
+
+/// Returns the version of the Wwise integration being used.
+pub fn version() -> WwiseIntegrationVersion {
+    use std::os::raw::c_uint;
+
+    let mut major: c_uint = 0;
+    let mut minor: c_uint = 0;
+    let mut patch: c_uint = 0;
+
+    unsafe {
+        audionimbus_sys::wwise::iplWwiseGetVersion(&mut major, &mut minor, &mut patch);
+    }
+
+    WwiseIntegrationVersion {
+        major: major as usize,
+        minor: minor as usize,
+        patch: patch as usize,
+    }
+}
+
+/// The version of the Wwise integration.
+#[derive(Copy, Clone, Debug)]
+pub struct WwiseIntegrationVersion {
+    pub major: usize,
+    pub minor: usize,
+    pub patch: usize,
+}


### PR DESCRIPTION
This PR adds support for the Steam Audio Wwise integration to both `audionimbus` and `audionimbus-sys`.

The integration can be enabled using the `wwise` feature and requires extra linking (see the [installation section](https://github.com/MaxenceMaire/audionimbus/tree/770b8351ca91585d2b932c5962dd986086bdab8c/audionimbus#wwise-integration)).

Note that `audionimbus-sys` must maintain version parity with Steam Audio (currently 4.6.1), so the new version of `audionimbus-sys` supporting the Wwise integration cannot get ahead of 4.6.1. For this reason, `audionimbus-sys` is being released as release candidate `4.6.2-fmod-wwise` rather than strictly incrementing the main version number.