### PR TITLE
Steam audio v4.7.0 update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus-sys"
-version = "4.6.2-fmodwwise.2"
+version = "4.7.0-rc.1"
 dependencies = [
  "bindgen 0.71.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "audionimbus"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "audionimbus-sys",
  "bitflags 2.8.0",

--- a/audionimbus-sys/Cargo.toml
+++ b/audionimbus-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus-sys"
 description = "Rust bindings for Steam Audio."
-version = "4.6.2-fmodwwise.2"
+version = "4.7.0-rc.1"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -20,7 +20,7 @@ Before installation, make sure that Clang 9.0 or later is installed on your syst
 
 `audionimbus-sys` requires linking against the Steam Audio library during compilation.
 
-To do so, download `steamaudio_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+To do so, download `steamaudio_4.7.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
 Locate the relevant library for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 
@@ -43,7 +43,7 @@ Finally, add `audionimbus-sys` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus-sys = "4.6.2-fmodwwise.2"
+audionimbus-sys = "4.7.0"
 ```
 
 ## FMOD Studio Integration
@@ -52,7 +52,7 @@ audionimbus-sys = "4.6.2-fmodwwise.2"
 
 It requires linking against both the Steam Audio library and the FMOD integration library during compilation:
 
-1. Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+1. Download `steamaudio_fmod_4.7.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
 2. Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 
@@ -75,7 +75,7 @@ It requires linking against both the Steam Audio library and the FMOD integratio
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmodwwise.2", features = ["fmod"] }
+audionimbus-sys = { version = "4.7.0", features = ["fmod"] }
 ```
 
 ## Wwise Integration
@@ -84,7 +84,7 @@ audionimbus-sys = { version = "4.6.2-fmodwwise.2", features = ["fmod"] }
 
 It requires linking against both the Steam Audio library and the Wwise integration library during compilation:
 
-1. Download `steamaudio_wwise_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+1. Download `steamaudio_wwise_4.7.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
 2. Locate the two relevant libraries for your target platform and place them in a location listed in [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
 
@@ -94,7 +94,7 @@ It requires linking against both the Steam Audio library and the Wwise integrati
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmodwwise.2", features = ["wwise"] }
+audionimbus-sys = { version = "4.7.0", features = ["wwise"] }
 ```
 
 ## Documentation

--- a/audionimbus-sys/build.rs
+++ b/audionimbus-sys/build.rs
@@ -142,12 +142,6 @@ fn version() -> Version {
         .parse::<u32>()
         .unwrap();
 
-    // TODO: remove statement upon release of Steam Audio v4.6.2.
-    // The version of audionimbus-sys is temporarily ahead of Steam Audio's
-    // to allow for the introduction of new features, so we need to explicitly
-    // pin the version.
-    let patch = 1;
-
     Version {
         major,
         minor,

--- a/audionimbus-sys/src/lib.rs
+++ b/audionimbus-sys/src/lib.rs
@@ -19,7 +19,7 @@ Before installation, make sure that Clang 9.0 or later is installed on your syst
 
 `audionimbus-sys` requires linking against the Steam Audio library during compilation.
 
-To do so, download `steamaudio_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+To do so, download `steamaudio_4.7.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
 Locate the relevant library for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 
@@ -42,7 +42,7 @@ Finally, add `audionimbus-sys` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus-sys = "4.6.2-fmodwwise.2"
+audionimbus-sys = "4.7.0"
 ```
 
 ## FMOD Studio Integration
@@ -51,7 +51,7 @@ audionimbus-sys = "4.6.2-fmodwwise.2"
 
 It requires linking against both the Steam Audio library and the FMOD integration library during compilation:
 
-1. Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+1. Download `steamaudio_fmod_4.7.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
 2. Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 
@@ -74,7 +74,7 @@ It requires linking against both the Steam Audio library and the FMOD integratio
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmodwwise.2", features = ["fmod"] }
+audionimbus-sys = { version = "4.7.0", features = ["fmod"] }
 ```
 
 ## Wwise Integration
@@ -83,7 +83,7 @@ audionimbus-sys = { version = "4.6.2-fmodwwise.2", features = ["fmod"] }
 
 It requires linking against both the Steam Audio library and the Wwise integration library during compilation:
 
-1. Download `steamaudio_wwise_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+1. Download `steamaudio_wwise_4.7.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
 2. Locate the two relevant libraries for your target platform and place them in a location listed in [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
 
@@ -93,7 +93,7 @@ It requires linking against both the Steam Audio library and the Wwise integrati
 
 ```toml
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmodwwise.2", features = ["wwise"] }
+audionimbus-sys = { version = "4.7.0", features = ["wwise"] }
 ```
 
 ## Documentation

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.0] - 2025-08-19
+
+### Added
+
+- Support for Steam Audio v.4.6.1 via `audionimbus-sys` v.4.6.1.
+- Support for custom pathing deviation model.
+
 ## [0.7.2] - 2025-08-08
 
 ### Fixed

--- a/audionimbus/Cargo.toml
+++ b/audionimbus/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/MaxenceMaire/audionimbus"
 readme = "README.md"
 
 [dependencies]
-audionimbus-sys = { version = "4.6.2-fmodwwise.2", path = "../audionimbus-sys" }
+audionimbus-sys = { version = "4.7.0-rc.1", path = "../audionimbus-sys" }
 bitflags = "2.8.0"
 
 [features]

--- a/audionimbus/Cargo.toml
+++ b/audionimbus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "audionimbus"
 description = "A safe wrapper around Steam Audio that provides spatial audio capabilities with realistic occlusion, reverb, and HRTF effects, accounting for physical attributes and scene geometry."
-version = "0.7.2"
+version = "0.8.0"
 edition = "2021"
 authors = ["Maxence Maire <maire.maxence@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/audionimbus/README.md
+++ b/audionimbus/README.md
@@ -48,7 +48,7 @@ Finally, add `audionimbus` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = "0.7.2"
+audionimbus = "0.8.0"
 ```
 
 ## Example
@@ -157,7 +157,7 @@ It requires linking against both the Steam Audio library and the FMOD integratio
 
 ```toml
 [dependencies]
-audionimbus = { version = "0.7.2", features = ["fmod"] }
+audionimbus = { version = "0.8.0", features = ["fmod"] }
 ```
 
 ## Wwise Integration
@@ -176,7 +176,7 @@ It requires linking against both the Steam Audio library and the Wwise integrati
 
 ```toml
 [dependencies]
-audionimbus = { version = "0.7.2", features = ["wwise"] }
+audionimbus = { version = "0.8.0", features = ["wwise"] }
 ```
 
 ## Documentation

--- a/audionimbus/src/device/open_cl.rs
+++ b/audionimbus/src/device/open_cl.rs
@@ -130,6 +130,41 @@ impl OpenClDeviceList {
 
         Ok(Self(open_cl_device_list))
     }
+
+    /// Returns the number of devices in the OpenCL device list.
+    pub fn num_devices(&self) -> usize {
+        unsafe { audionimbus_sys::iplOpenCLDeviceListGetNumDevices(self.raw_ptr()) as usize }
+    }
+
+    /// Retrieves information about a specific device in an OpenCL device list.
+    pub fn device_descriptor(&self, device_index: usize) -> OpenClDeviceDescriptor {
+        assert!(
+            device_index < self.num_devices(),
+            "device index out of bounds"
+        );
+
+        let mut device_descriptor =
+            std::mem::MaybeUninit::<audionimbus_sys::IPLOpenCLDeviceDesc>::uninit();
+
+        unsafe {
+            audionimbus_sys::iplOpenCLDeviceListGetDeviceDesc(
+                self.raw_ptr(),
+                device_index as i32,
+                device_descriptor.as_mut_ptr(),
+            );
+
+            let device_descriptor = device_descriptor.assume_init();
+            OpenClDeviceDescriptor::try_from(&device_descriptor).expect("invalid C string")
+        }
+    }
+
+    pub fn raw_ptr(&self) -> audionimbus_sys::IPLOpenCLDeviceList {
+        self.0
+    }
+
+    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLOpenCLDeviceList {
+        &mut self.0
+    }
 }
 
 impl std::ops::Deref for OpenClDeviceList {
@@ -242,5 +277,100 @@ impl From<OpenClDeviceType> for audionimbus_sys::IPLOpenCLDeviceType {
             OpenClDeviceType::Cpu => audionimbus_sys::IPLOpenCLDeviceType::IPL_OPENCLDEVICETYPE_CPU,
             OpenClDeviceType::Gpu => audionimbus_sys::IPLOpenCLDeviceType::IPL_OPENCLDEVICETYPE_GPU,
         }
+    }
+}
+
+impl From<audionimbus_sys::IPLOpenCLDeviceType> for OpenClDeviceType {
+    fn from(device_type: audionimbus_sys::IPLOpenCLDeviceType) -> Self {
+        match device_type {
+            audionimbus_sys::IPLOpenCLDeviceType::IPL_OPENCLDEVICETYPE_ANY => OpenClDeviceType::Any,
+            audionimbus_sys::IPLOpenCLDeviceType::IPL_OPENCLDEVICETYPE_CPU => OpenClDeviceType::Cpu,
+            audionimbus_sys::IPLOpenCLDeviceType::IPL_OPENCLDEVICETYPE_GPU => OpenClDeviceType::Gpu,
+        }
+    }
+}
+
+/// Describes the properties of an OpenCL device.
+/// This information can be used to select the most suitable device for your application.
+#[derive(Debug)]
+pub struct OpenClDeviceDescriptor {
+    /// The OpenCL platform id.
+    pub platform: *mut std::ffi::c_void,
+
+    /// The OpenCL platform name.
+    pub platform_name: String,
+
+    /// The OpenCL platform vendor's name.
+    pub platform_vendor: String,
+
+    /// The OpenCL platform version.
+    pub platform_version: String,
+
+    /// The OpenCL device id.
+    pub device: *mut std::ffi::c_void,
+
+    /// The OpenCL device name.
+    pub device_name: String,
+
+    /// The OpenCL device vendor's name.
+    pub device_vendor: String,
+
+    /// The OpenCL device version.
+    pub device_version: String,
+
+    /// The type of OpenCL device.
+    pub device_type: OpenClDeviceType,
+
+    /// The number of CUs reserved for convolution.
+    /// May be 0 if CU reservation is not supported.
+    pub num_convolution_cus: i32,
+
+    /// The number of CUs reserved for IR update.
+    /// May be 0 if CU reservation is not supported.
+    pub num_ir_update_cus: i32,
+
+    /// The CU reservation granularity.
+    /// CUs can only be reserved on this device in multiples of this number.
+    pub granularity: i32,
+
+    /// A relative performance score of a single CU of this device.
+    /// Only applicable to supported AMD GPUs.
+    pub perf_score: f32,
+}
+
+/// Helper function to safely convert a C string pointer to a Rust String
+///
+/// # Safety
+/// The caller must ensure that the pointer is valid and points to a null-terminated C string.
+unsafe fn cstr_to_string(ptr: *const std::ffi::c_char) -> Result<String, std::str::Utf8Error> {
+    if ptr.is_null() {
+        return Ok(String::new());
+    }
+
+    let c_str = std::ffi::CStr::from_ptr(ptr);
+    c_str.to_str().map(|s| s.to_string())
+}
+
+impl TryFrom<&audionimbus_sys::IPLOpenCLDeviceDesc> for OpenClDeviceDescriptor {
+    type Error = std::str::Utf8Error;
+
+    fn try_from(
+        ipl_descriptor: &audionimbus_sys::IPLOpenCLDeviceDesc,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            platform: ipl_descriptor.platform,
+            platform_name: unsafe { cstr_to_string(ipl_descriptor.platformName)? },
+            platform_vendor: unsafe { cstr_to_string(ipl_descriptor.platformVendor)? },
+            platform_version: unsafe { cstr_to_string(ipl_descriptor.platformVersion)? },
+            device: ipl_descriptor.device,
+            device_name: unsafe { cstr_to_string(ipl_descriptor.deviceName)? },
+            device_vendor: unsafe { cstr_to_string(ipl_descriptor.deviceVendor)? },
+            device_version: unsafe { cstr_to_string(ipl_descriptor.deviceVersion)? },
+            device_type: ipl_descriptor.type_.into(),
+            num_convolution_cus: ipl_descriptor.numConvolutionCUs,
+            num_ir_update_cus: ipl_descriptor.numIRUpdateCUs,
+            granularity: ipl_descriptor.granularity,
+            perf_score: ipl_descriptor.perfScore,
+        })
     }
 }

--- a/audionimbus/src/device/open_cl.rs
+++ b/audionimbus/src/device/open_cl.rs
@@ -31,6 +31,46 @@ impl OpenClDevice {
         Ok(open_cl_device)
     }
 
+    /// Creates an OpenCL device from an existing OpenCL device created by your application. Steam Audio will use up to two command queues that you provide for enqueuing OpenCL computations.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    /// - `convolution_queue` and `ir_update_queue` are valid OpenCL command queue handles.
+    /// - They remain valid for the lifetime of the created device.
+    ///
+    /// # Arguments
+    ///
+    /// - `context`: the context used to initialize AudioNimbus.
+    /// - `convolution_queue`: the command queue to use for enqueueing convolution work.
+    /// - `ir_update_queue`: the command queue to use for enqueueing IR update work.
+    ///
+    /// # Returns
+    ///
+    /// The created OpenCL device, or an error.
+    pub unsafe fn from_existing(
+        context: &Context,
+        convolution_queue: *mut std::ffi::c_void,
+        ir_update_queue: *mut std::ffi::c_void,
+    ) -> Result<Self, SteamAudioError> {
+        let mut open_cl_device = Self(std::ptr::null_mut());
+
+        let status = unsafe {
+            audionimbus_sys::iplOpenCLDeviceCreateFromExisting(
+                context.raw_ptr(),
+                convolution_queue,
+                ir_update_queue,
+                open_cl_device.raw_ptr_mut(),
+            )
+        };
+
+        if let Some(error) = to_option_error(status) {
+            return Err(error);
+        }
+
+        Ok(open_cl_device)
+    }
+
     pub fn null() -> Self {
         Self(std::ptr::null_mut())
     }

--- a/audionimbus/src/effect/path.rs
+++ b/audionimbus/src/effect/path.rs
@@ -269,6 +269,11 @@ pub fn bake_path(
     }
 }
 
+/// Cancels any running bakes of pathing data.
+pub fn cancel_bake_path(context: &Context) {
+    unsafe { audionimbus_sys::iplPathBakerCancelBake(context.raw_ptr()) }
+}
+
 /// Parameters used to control how pathing data is baked.
 #[derive(Debug)]
 pub struct PathBakeParams<'a> {

--- a/audionimbus/src/effect/path.rs
+++ b/audionimbus/src/effect/path.rs
@@ -197,6 +197,11 @@ pub struct PathEffectParams {
     /// The position and orientation of the listener.
     /// Only used if [`PathEffectSettings::spatialization`] is `Some` and [`Self::binaural`] is set to `true`.
     pub listener: CoordinateSystem,
+
+    /// If `true`, the values in [`Self::eq_coeffs`] will be normalized before being used, i.e., each value in [`Self::eq_coeffs`] will be divided by the largest value in [`Self::eq_coeffs`].
+    /// This can help counteract overly-aggressive filtering due to a physics-based deviation model.
+    /// If `false`, the values in [`Self::eq_coeffs`] will be used as-is.
+    pub normalize_eq: bool,
 }
 
 impl From<audionimbus_sys::IPLPathEffectParams> for PathEffectParams {
@@ -208,6 +213,7 @@ impl From<audionimbus_sys::IPLPathEffectParams> for PathEffectParams {
             binaural: params.binaural == audionimbus_sys::IPLbool::IPL_TRUE,
             hrtf: params.hrtf,
             listener: params.listener.into(),
+            normalize_eq: params.normalizeEQ == audionimbus_sys::IPLbool::IPL_TRUE,
         }
     }
 }
@@ -225,6 +231,11 @@ impl PathEffectParams {
             },
             hrtf: self.hrtf,
             listener: self.listener.into(),
+            normalizeEQ: if self.normalize_eq {
+                audionimbus_sys::IPLbool::IPL_TRUE
+            } else {
+                audionimbus_sys::IPLbool::IPL_FALSE
+            },
         };
 
         FFIWrapper::new(path_effect_params)

--- a/audionimbus/src/effect/reflection.rs
+++ b/audionimbus/src/effect/reflection.rs
@@ -516,6 +516,11 @@ pub fn bake_reflections(
     }
 }
 
+/// Cancels any running bakes of pathing data.
+pub fn cancel_bake_reflections(context: &Context) {
+    unsafe { audionimbus_sys::iplReflectionsBakerCancelBake(context.raw_ptr()) }
+}
+
 /// Parameters used to control how reflections data is baked.
 #[derive(Debug, Copy, Clone)]
 pub struct ReflectionsBakeParams<'a> {

--- a/audionimbus/src/energy_field.rs
+++ b/audionimbus/src/energy_field.rs
@@ -96,7 +96,7 @@ impl EnergyField {
         unsafe { std::slice::from_raw_parts(ptr, len as usize) }
     }
 
-    /// Resets all values stored in an energy field to zero.
+    /// Resets all values stored in the energy field to zero.
     pub fn reset(&mut self) {
         unsafe { audionimbus_sys::iplEnergyFieldReset(self.raw_ptr()) }
     }

--- a/audionimbus/src/energy_field.rs
+++ b/audionimbus/src/energy_field.rs
@@ -1,0 +1,213 @@
+use crate::audio_buffer::Sample;
+use crate::context::Context;
+use crate::error::{to_option_error, SteamAudioError};
+use crate::NUM_BANDS;
+
+/// An energy field.
+///
+/// Energy fields represent a histogram of sound energy arriving at a point, as a function of incident direction, frequency band, and arrival time.
+///
+/// Time is subdivided into “bins” of the histogram, with each bin corresponding to 10ms.
+/// For each bin, incident energy is stored separately for each frequency band.
+/// For a given frequency band and time bin, we store an Ambisonic representation of the variation of incident energy as a function of direction.
+///
+/// Energy field data is stored as a 3D array of size #channels * #bands * #bins, in row-major order.
+#[derive(Debug)]
+pub struct EnergyField(audionimbus_sys::IPLEnergyField);
+
+impl EnergyField {
+    pub fn try_new(
+        context: &Context,
+        energy_field_settings: &EnergyFieldSettings,
+    ) -> Result<Self, SteamAudioError> {
+        let mut energy_field = Self(std::ptr::null_mut());
+
+        let status = unsafe {
+            audionimbus_sys::iplEnergyFieldCreate(
+                context.raw_ptr(),
+                &mut audionimbus_sys::IPLEnergyFieldSettings::from(energy_field_settings),
+                energy_field.raw_ptr_mut(),
+            )
+        };
+
+        if let Some(error) = to_option_error(status) {
+            return Err(error);
+        }
+
+        Ok(energy_field)
+    }
+
+    /// Returns the number of channels in the energy field.
+    pub fn num_channels(&self) -> u32 {
+        unsafe { audionimbus_sys::iplEnergyFieldGetNumChannels(self.raw_ptr()) as u32 }
+    }
+
+    /// Returns the number of bins in the energy field.
+    pub fn num_bins(&self) -> u32 {
+        unsafe { audionimbus_sys::iplEnergyFieldGetNumBins(self.raw_ptr()) as u32 }
+    }
+
+    /// Returns the data stored in the energy field, in row-major order.
+    pub fn data(&self) -> &[Sample] {
+        let ptr = unsafe { audionimbus_sys::iplEnergyFieldGetData(self.raw_ptr()) };
+        let len = self.num_channels() * NUM_BANDS * self.num_bins();
+        unsafe { std::slice::from_raw_parts(ptr, len as usize) }
+    }
+
+    /// Returns the data stored in the energy field for the given channel, in row-major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `channel_index` is out of bounds.
+    pub fn channel(&self, channel_index: u32) -> &[Sample] {
+        assert!(
+            channel_index < self.num_channels(),
+            "channel index out of bounds",
+        );
+
+        let ptr = unsafe {
+            audionimbus_sys::iplEnergyFieldGetChannel(self.raw_ptr(), channel_index as i32)
+        };
+        let len = NUM_BANDS * self.num_bins();
+        unsafe { std::slice::from_raw_parts(ptr, len as usize) }
+    }
+
+    /// Returns the data stored in the energy field for the given channel and band, in row-major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `channel_index` or `band_index` are out of bounds.
+    pub fn band(&self, channel_index: u32, band_index: u32) -> &[Sample] {
+        assert!(
+            channel_index < self.num_channels(),
+            "channel index out of bounds",
+        );
+
+        assert!(band_index < NUM_BANDS, "band index out of bounds",);
+
+        let ptr = unsafe {
+            audionimbus_sys::iplEnergyFieldGetBand(
+                self.raw_ptr(),
+                channel_index as i32,
+                band_index as i32,
+            )
+        };
+        let len = self.num_bins();
+        unsafe { std::slice::from_raw_parts(ptr, len as usize) }
+    }
+
+    /// Resets all values stored in an energy field to zero.
+    pub fn reset(&mut self) {
+        unsafe { audionimbus_sys::iplEnergyFieldReset(self.raw_ptr()) }
+    }
+
+    /// Copies data from `self` into the `dst` energy field.
+    ///
+    /// If the source and destination energy fields have different numbers of channels, only the smaller of the two numbers of channels will be copied.
+    ///
+    /// If the source and destination energy fields have different numbers of bins, only the smaller of the two numbers of bins will be copied.
+    pub fn copy_into(&self, dst: &mut EnergyField) {
+        unsafe { audionimbus_sys::iplEnergyFieldCopy(self.raw_ptr(), dst.raw_ptr()) }
+    }
+
+    /// Swaps the data contained in one energy field with the data contained in another energy field.
+    ///
+    /// The two energy fields may contain different numbers of channels or bins.
+    pub fn swap(&mut self, other: &mut EnergyField) {
+        unsafe { audionimbus_sys::iplEnergyFieldSwap(self.raw_ptr(), other.raw_ptr()) }
+    }
+
+    /// Adds the values stored in the `other` energy field to those in `self`.
+    ///
+    /// If the energy fields have different numbers of channels, only the smallest of the three numbers of channels will be added.
+    ///
+    /// If the energy fields have different numbers of bins, only the smallest of the three numbers of bins will be added.
+    pub fn add(&mut self, other: &EnergyField) {
+        unsafe {
+            audionimbus_sys::iplEnergyFieldAdd(self.raw_ptr(), other.raw_ptr(), self.raw_ptr())
+        }
+    }
+
+    /// Scales the values stored in the energy field by a scalar.
+    pub fn scale(&mut self, scalar: f32) {
+        unsafe { audionimbus_sys::iplEnergyFieldScale(self.raw_ptr(), scalar, self.raw_ptr()) }
+    }
+
+    pub fn raw_ptr(&self) -> audionimbus_sys::IPLEnergyField {
+        self.0
+    }
+
+    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLEnergyField {
+        &mut self.0
+    }
+}
+
+impl Clone for EnergyField {
+    fn clone(&self) -> Self {
+        unsafe {
+            audionimbus_sys::iplEnergyFieldRetain(self.0);
+        }
+        Self(self.0)
+    }
+}
+
+impl Drop for EnergyField {
+    fn drop(&mut self) {
+        unsafe { audionimbus_sys::iplEnergyFieldRelease(&mut self.0) }
+    }
+}
+
+unsafe impl Send for EnergyField {}
+unsafe impl Sync for EnergyField {}
+
+/// Settings used to create an [`EnergyField`].
+#[derive(Debug)]
+pub struct EnergyFieldSettings {
+    /// Total duration (in seconds) of the energy field.
+    ///
+    /// This determines the number of bins in each channel and band.
+    pub duration: f32,
+
+    /// The Ambisonic order.
+    ///
+    /// This determines the number of channels.
+    pub order: usize,
+}
+
+impl From<&EnergyFieldSettings> for audionimbus_sys::IPLEnergyFieldSettings {
+    fn from(settings: &EnergyFieldSettings) -> Self {
+        Self {
+            duration: settings.duration,
+            order: settings.order as i32,
+        }
+    }
+}
+
+/// Adds the values stored in two energy fields, and stores the result in a third energy field.
+///
+/// If the energy fields have different numbers of channels, only the smallest of the three numbers of channels will be added.
+///
+/// If the energy fields have different numbers of bins, only the smallest of the three numbers of bins will be added.
+pub fn add_energy_fields(in1: &EnergyField, in2: &EnergyField, out: &mut EnergyField) {
+    unsafe { audionimbus_sys::iplEnergyFieldAdd(in1.raw_ptr(), in2.raw_ptr(), out.raw_ptr()) }
+}
+
+/// Scales the values stored in an energy field by a scalar, and stores the result in the `out` energy field.
+///
+/// If the energy fields have different numbers of channels, only the smallest of the two numbers of channels will be scaled.
+///
+/// If the energy fields have different numbers of bins, only the smallest of the two numbers of bins will be scaled.
+pub fn scale_energy_field(energy_field: &EnergyField, scalar: f32, out: &mut EnergyField) {
+    unsafe { audionimbus_sys::iplEnergyFieldScale(energy_field.raw_ptr(), scalar, out.raw_ptr()) }
+}
+
+/// Scales the values stored in an energy field by a scalar, and adds the result to a second energy field.
+///
+/// If the energy fields have different numbers of channels, only the smallest of the two numbers of channels will be added.
+///
+/// If the energy fields have different numbers of bins, only the smallest of the two numbers of bins will be added.
+pub fn scale_accum_energy_field(energy_field: &EnergyField, scalar: f32, out: &mut EnergyField) {
+    unsafe {
+        audionimbus_sys::iplEnergyFieldScaleAccum(energy_field.raw_ptr(), scalar, out.raw_ptr())
+    }
+}

--- a/audionimbus/src/energy_field.rs
+++ b/audionimbus/src/energy_field.rs
@@ -13,7 +13,7 @@ use crate::NUM_BANDS;
 ///
 /// Energy field data is stored as a 3D array of size #channels * #bands * #bins, in row-major order.
 #[derive(Debug)]
-pub struct EnergyField(audionimbus_sys::IPLEnergyField);
+pub struct EnergyField(pub(crate) audionimbus_sys::IPLEnergyField);
 
 impl EnergyField {
     pub fn try_new(

--- a/audionimbus/src/fmod.rs
+++ b/audionimbus/src/fmod.rs
@@ -43,12 +43,12 @@ pub fn set_hrtf_disabled(disabled: bool) {
 /// A handle to a [`Source`] that can be used in C# scripts.
 pub type SourceHandle = i32;
 
-/// Registers a source, and returns the corresponding handle.
+/// Registers a source for use by Steam Audio DSP effects in the audio thread, and returns the corresponding handle.
 pub fn add_source(source: &Source) -> SourceHandle {
     unsafe { audionimbus_sys::fmod::iplFMODAddSource(source.raw_ptr()) }
 }
 
-/// Unregisters a [`Source`] associated with the given handle.
+/// Unregisters a [`Source`] associated with the given handle, so the Steam Audio DSP effects can no longer use it.
 pub fn remove_source(handle: SourceHandle) {
     unsafe { audionimbus_sys::fmod::iplFMODRemoveSource(handle as audionimbus_sys::IPLint32) }
 }

--- a/audionimbus/src/geometry/mod.rs
+++ b/audionimbus/src/geometry/mod.rs
@@ -20,7 +20,7 @@ mod material;
 pub use material::Material;
 
 mod scene;
-pub use scene::{Scene, SceneParams, SceneSettings};
+pub use scene::{relative_direction, Scene, SceneParams, SceneSettings};
 
 mod static_mesh;
 pub use static_mesh::{StaticMesh, StaticMeshSettings};

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -1,24 +1,97 @@
 use super::{InstancedMesh, Matrix, StaticMesh};
+use crate::callback::{CallbackInformation, ProgressCallback};
 use crate::context::Context;
 use crate::device::embree::EmbreeDevice;
 use crate::device::open_cl::OpenClDevice;
 use crate::device::radeon_rays::RadeonRaysDevice;
 use crate::error::{to_option_error, SteamAudioError};
+use crate::serialized_object::SerializedObject;
 
 /// A 3D scene, which can contain geometry objects that can interact with acoustic rays.
 ///
 /// The scene object itself doesn’t contain any geometry, but is a container for [`StaticMesh`] and [`InstancedMesh`] objects, which do contain geometry.
 #[derive(Debug)]
-pub struct Scene(audionimbus_sys::IPLScene);
+pub struct Scene {
+    inner: audionimbus_sys::IPLScene,
+
+    /// Used for validation when calling [`Self::save`].
+    uses_default_ray_tracer: bool,
+}
 
 impl Scene {
     pub fn try_new(context: &Context, settings: &SceneSettings) -> Result<Self, SteamAudioError> {
-        let mut scene = Self(std::ptr::null_mut());
+        let mut scene = Self {
+            inner: std::ptr::null_mut(),
+            uses_default_ray_tracer: matches!(settings, SceneSettings::Default),
+        };
 
         let status = unsafe {
             audionimbus_sys::iplSceneCreate(
                 context.raw_ptr(),
                 &mut audionimbus_sys::IPLSceneSettings::from(settings),
+                scene.raw_ptr_mut(),
+            )
+        };
+
+        if let Some(error) = to_option_error(status) {
+            return Err(error);
+        }
+
+        Ok(scene)
+    }
+
+    /// Loads a scene from a serialized object.
+    ///
+    /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    pub fn load(
+        context: &Context,
+        settings: &SceneSettings,
+        serialized_object: &SerializedObject,
+    ) -> Result<Self, SteamAudioError> {
+        let mut scene = Self {
+            inner: std::ptr::null_mut(),
+            uses_default_ray_tracer: matches!(settings, SceneSettings::Default),
+        };
+
+        let status = unsafe {
+            audionimbus_sys::iplSceneLoad(
+                context.raw_ptr(),
+                &mut audionimbus_sys::IPLSceneSettings::from(settings),
+                serialized_object.raw_ptr(),
+                None,
+                std::ptr::null_mut(),
+                scene.raw_ptr_mut(),
+            )
+        };
+
+        if let Some(error) = to_option_error(status) {
+            return Err(error);
+        }
+
+        Ok(scene)
+    }
+
+    /// Loads a scene from a serialized object.
+    ///
+    /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    pub fn load_with_callback(
+        context: &Context,
+        settings: &SceneSettings,
+        serialized_object: &SerializedObject,
+        progress_callback: CallbackInformation<ProgressCallback>,
+    ) -> Result<Self, SteamAudioError> {
+        let mut scene = Self {
+            inner: std::ptr::null_mut(),
+            uses_default_ray_tracer: matches!(settings, SceneSettings::Default),
+        };
+
+        let status = unsafe {
+            audionimbus_sys::iplSceneLoad(
+                context.raw_ptr(),
+                &mut audionimbus_sys::IPLSceneSettings::from(settings),
+                serialized_object.raw_ptr(),
+                Some(progress_callback.callback),
+                progress_callback.user_data,
                 scene.raw_ptr_mut(),
             )
         };
@@ -103,6 +176,23 @@ impl Scene {
         }
     }
 
+    /// Saves a scene to a serialized object.
+    ///
+    /// Typically, the serialized object will then be saved to disk.
+    ///
+    /// This function can only be called on a scene created with [`SceneSettings::Default`].
+    pub fn save(&self) -> SerializedObject {
+        assert!(self.uses_default_ray_tracer);
+
+        let serialized_object = SerializedObject(std::ptr::null_mut());
+
+        unsafe {
+            audionimbus_sys::iplSceneSave(self.raw_ptr(), serialized_object.raw_ptr());
+        }
+
+        serialized_object
+    }
+
     /// Saves a scene to an OBJ file.
     ///
     /// An OBJ file is a widely-supported 3D model file format, that can be displayed using a variety of software on most PC platforms.
@@ -119,26 +209,29 @@ impl Scene {
     }
 
     pub fn raw_ptr(&self) -> audionimbus_sys::IPLScene {
-        self.0
+        self.inner
     }
 
     pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLScene {
-        &mut self.0
+        &mut self.inner
     }
 }
 
 impl Clone for Scene {
     fn clone(&self) -> Self {
         unsafe {
-            audionimbus_sys::iplSceneRetain(self.0);
+            audionimbus_sys::iplSceneRetain(self.inner);
         }
-        Self(self.0)
+        Self {
+            inner: self.inner,
+            uses_default_ray_tracer: self.uses_default_ray_tracer,
+        }
     }
 }
 
 impl Drop for Scene {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplSceneRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplSceneRelease(&mut self.inner) }
     }
 }
 

--- a/audionimbus/src/geometry/sphere.rs
+++ b/audionimbus/src/geometry/sphere.rs
@@ -28,3 +28,12 @@ impl From<Sphere> for audionimbus_sys::IPLSphere {
         }
     }
 }
+
+impl From<audionimbus_sys::IPLSphere> for Sphere {
+    fn from(ipl_sphere: audionimbus_sys::IPLSphere) -> Self {
+        Self {
+            center: ipl_sphere.center.into(),
+            radius: ipl_sphere.radius,
+        }
+    }
+}

--- a/audionimbus/src/impulse_response.rs
+++ b/audionimbus/src/impulse_response.rs
@@ -1,0 +1,208 @@
+use crate::audio_buffer::Sample;
+use crate::context::Context;
+use crate::error::{to_option_error, SteamAudioError};
+
+/// An impulse response.
+///
+/// Impulse responses are represented in Ambisonics to allow for directional variation of propagated sound.
+///
+/// Impulse response data is stored as a 2D array of size #channels * #samples, in row-major order.
+#[derive(Debug)]
+pub struct ImpulseResponse(audionimbus_sys::IPLImpulseResponse);
+
+impl ImpulseResponse {
+    pub fn try_new(
+        context: &Context,
+        impulse_response_settings: &ImpulseResponseSettings,
+    ) -> Result<Self, SteamAudioError> {
+        let mut impulse_response = Self(std::ptr::null_mut());
+
+        let status = unsafe {
+            audionimbus_sys::iplImpulseResponseCreate(
+                context.raw_ptr(),
+                &mut audionimbus_sys::IPLImpulseResponseSettings::from(impulse_response_settings),
+                impulse_response.raw_ptr_mut(),
+            )
+        };
+
+        if let Some(error) = to_option_error(status) {
+            return Err(error);
+        }
+
+        Ok(impulse_response)
+    }
+
+    /// Returns the number of channels in the impulse response.
+    pub fn num_channels(&self) -> u32 {
+        unsafe { audionimbus_sys::iplImpulseResponseGetNumChannels(self.raw_ptr()) as u32 }
+    }
+
+    /// Returns the number of samples in the impulse response.
+    pub fn num_samples(&self) -> u32 {
+        unsafe { audionimbus_sys::iplImpulseResponseGetNumSamples(self.raw_ptr()) as u32 }
+    }
+
+    /// Returns a pointer to the data stored in the impulse response, , in row-major order.
+    pub fn data(&self) -> &[Sample] {
+        let ptr = unsafe { audionimbus_sys::iplImpulseResponseGetData(self.raw_ptr()) };
+        let len = self.num_channels() * self.num_samples();
+        unsafe { std::slice::from_raw_parts(ptr, len as usize) }
+    }
+
+    /// Returns a pointer to the data stored in the impulse response for the given channel, in row-major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `channel_index` is out of bounds.
+    pub fn channel(&self, channel_index: u32) -> &[Sample] {
+        assert!(
+            channel_index < self.num_channels(),
+            "channel index out of bounds",
+        );
+
+        let ptr = unsafe {
+            audionimbus_sys::iplImpulseResponseGetChannel(self.raw_ptr(), channel_index as i32)
+        };
+        let len = self.num_samples();
+        unsafe { std::slice::from_raw_parts(ptr, len as usize) }
+    }
+
+    /// Resets all values stored in the impulse response to zero.
+    pub fn reset(&mut self) {
+        unsafe { audionimbus_sys::iplImpulseResponseReset(self.raw_ptr()) }
+    }
+
+    /// Copies data from `self` into the `dst` impulse response.
+    ///
+    /// If the source and destination impulse responses have different numbers of channels, only the smaller of the two numbers of channels will be copied.
+    ///
+    /// If the source and destination impulse responses have different numbers of samples, only the smaller of the two numbers of samples will be copied.
+    pub fn copy_into(&self, dst: &mut ImpulseResponse) {
+        unsafe { audionimbus_sys::iplImpulseResponseCopy(self.raw_ptr(), dst.raw_ptr()) }
+    }
+
+    /// Swaps the data contained in one impulse response with the data contained in another impulse response.
+    ///
+    /// The two impulse responses may contain different numbers of channels or samples.
+    pub fn swap(&mut self, other: &mut ImpulseResponse) {
+        unsafe { audionimbus_sys::iplImpulseResponseSwap(self.raw_ptr(), other.raw_ptr()) }
+    }
+
+    /// Adds the values stored in the `other` impulse response to those in `self`.
+    ///
+    /// If the impulse responses have different numbers of channels, only the smallest of the three numbers of channels will be added.
+    ///
+    /// If the impulse responses have different numbers of samples, only the smallest of the three numbers of samples will be added.
+    pub fn add(&mut self, other: &ImpulseResponse) {
+        unsafe {
+            audionimbus_sys::iplImpulseResponseAdd(self.raw_ptr(), other.raw_ptr(), self.raw_ptr())
+        }
+    }
+
+    /// Scales the values stored in the impulse response by a scalar.
+    pub fn scale(&mut self, scalar: f32) {
+        unsafe { audionimbus_sys::iplImpulseResponseScale(self.raw_ptr(), scalar, self.raw_ptr()) }
+    }
+
+    pub fn raw_ptr(&self) -> audionimbus_sys::IPLImpulseResponse {
+        self.0
+    }
+
+    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLImpulseResponse {
+        &mut self.0
+    }
+}
+
+impl Clone for ImpulseResponse {
+    fn clone(&self) -> Self {
+        unsafe {
+            audionimbus_sys::iplImpulseResponseRetain(self.0);
+        }
+        Self(self.0)
+    }
+}
+
+impl Drop for ImpulseResponse {
+    fn drop(&mut self) {
+        unsafe { audionimbus_sys::iplImpulseResponseRelease(&mut self.0) }
+    }
+}
+
+unsafe impl Send for ImpulseResponse {}
+unsafe impl Sync for ImpulseResponse {}
+
+/// Settings used to create an impulse response.
+#[derive(Debug)]
+pub struct ImpulseResponseSettings {
+    /// Total duration (in seconds) of the impulse response.
+    ///
+    /// This determines the number of samples in each channel.
+    pub duration: f32,
+
+    /// The Ambisonic order.
+    ///
+    /// This determines the number of channels.
+    pub order: usize,
+
+    /// The sampling rate.
+    ///
+    /// This, together with the duration, determines the number of samples in each channel.
+    pub sampling_rate: usize,
+}
+
+impl From<&ImpulseResponseSettings> for audionimbus_sys::IPLImpulseResponseSettings {
+    fn from(settings: &ImpulseResponseSettings) -> Self {
+        Self {
+            duration: settings.duration,
+            order: settings.order as i32,
+            samplingRate: settings.sampling_rate as i32,
+        }
+    }
+}
+
+/// Adds the values stored in two impulse responses, and stores the result in a third impulse response.
+///
+/// If the impulse responses have different numbers of channels, only the smallest of the three numbers of channels will be added.
+///
+/// If the impulse responses have different numbers of bins, only the smallest of the three numbers of bins will be added.
+pub fn add_impulse_responses(
+    in1: &ImpulseResponse,
+    in2: &ImpulseResponse,
+    out: &mut ImpulseResponse,
+) {
+    unsafe { audionimbus_sys::iplImpulseResponseAdd(in1.raw_ptr(), in2.raw_ptr(), out.raw_ptr()) }
+}
+
+/// Scales the values stored in an impulse response by a scalar, and stores the result in the `out` impulse response.
+///
+/// If the impulse responses have different numbers of channels, only the smallest of the two numbers of channels will be scaled.
+///
+/// If the impulse responses have different numbers of bins, only the smallest of the two numbers of bins will be scaled.
+pub fn scale_impulse_response(
+    impulse_response: &ImpulseResponse,
+    scalar: f32,
+    out: &mut ImpulseResponse,
+) {
+    unsafe {
+        audionimbus_sys::iplImpulseResponseScale(impulse_response.raw_ptr(), scalar, out.raw_ptr())
+    }
+}
+
+/// Scales the values stored in an impulse response by a scalar, and adds the result to a second impulse response.
+///
+/// If the impulse responses have different numbers of channels, only the smallest of the two numbers of channels will be added.
+///
+/// If the impulse responses have different numbers of bins, only the smallest of the two numbers of bins will be added.
+pub fn scale_accum_impulse_response(
+    impulse_response: &ImpulseResponse,
+    scalar: f32,
+    out: &mut ImpulseResponse,
+) {
+    unsafe {
+        audionimbus_sys::iplImpulseResponseScaleAccum(
+            impulse_response.raw_ptr(),
+            scalar,
+            out.raw_ptr(),
+        )
+    }
+}

--- a/audionimbus/src/lib.rs
+++ b/audionimbus/src/lib.rs
@@ -243,6 +243,9 @@ pub use energy_field::*;
 pub mod impulse_response;
 pub use impulse_response::*;
 
+pub mod reconstructor;
+pub use reconstructor::*;
+
 #[cfg(feature = "fmod")]
 pub mod fmod;
 

--- a/audionimbus/src/lib.rs
+++ b/audionimbus/src/lib.rs
@@ -45,7 +45,7 @@ Finally, add `audionimbus` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-audionimbus = "0.7.2"
+audionimbus = "0.8.0"
 ```
 
 ## Example
@@ -152,7 +152,7 @@ It requires linking against both the Steam Audio library and the FMOD integratio
 
 ```toml
 [dependencies]
-audionimbus = { version = "0.7.2", features = ["fmod"] }
+audionimbus = { version = "0.8.0", features = ["fmod"] }
 ```
 
 ## Wwise Integration
@@ -171,7 +171,7 @@ It requires linking against both the Steam Audio library and the Wwise integrati
 
 ```toml
 [dependencies]
-audionimbus = { version = "0.7.2", features = ["wwise"] }
+audionimbus = { version = "0.8.0", features = ["wwise"] }
 ```
 
 ## Documentation

--- a/audionimbus/src/lib.rs
+++ b/audionimbus/src/lib.rs
@@ -240,6 +240,9 @@ pub use version::*;
 pub mod energy_field;
 pub use energy_field::*;
 
+pub mod impulse_response;
+pub use impulse_response::*;
+
 #[cfg(feature = "fmod")]
 pub mod fmod;
 

--- a/audionimbus/src/lib.rs
+++ b/audionimbus/src/lib.rs
@@ -191,6 +191,8 @@ You may choose either license when using the software.
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+pub const NUM_BANDS: u32 = 3;
+
 pub mod audio_buffer;
 pub use audio_buffer::*;
 
@@ -234,6 +236,9 @@ pub use simulation::*;
 
 pub mod version;
 pub use version::*;
+
+pub mod energy_field;
+pub use energy_field::*;
 
 #[cfg(feature = "fmod")]
 pub mod fmod;

--- a/audionimbus/src/model/deviation.rs
+++ b/audionimbus/src/model/deviation.rs
@@ -1,0 +1,63 @@
+/// A deviation model that can be used for modeling frequency-dependent attenuation of sound as it bends along the path from the source to the listener.
+#[derive(Debug, Copy, Clone)]
+pub enum DeviationModel {
+    /// The default deviation model.
+    /// This is a physics-based model, based on the Uniform Theory of Diffraction, with various additional assumptions.
+    Default,
+
+    /// An arbitrary deviation model, defined by a callback function.
+    Callback {
+        /// Callback for calculating how much to attenuate sound in a given frequency band based on the angle of deviation when the sound path bends around a corner as it propagated from the source to the listener.
+        ///
+        /// # Arguments
+        ///
+        /// - `angle`: angle (in radians) that the sound path deviates (bends) by.
+        /// - `band`: index of the frequency band for which to calculate air absorption.
+        /// - `user_data`: pointer to the arbitrary data specified.
+        ///
+        /// # Returns
+        ///
+        /// The frequency-dependent attenuation to apply, between 0.0 and 1.0.
+        /// 0.0 = sound in the frequency band is not audible; 1.0 = sound in the frequency band is not attenuated.
+        callback: unsafe extern "C" fn(
+            angle: f32,
+            band: std::ffi::c_int,
+            user_data: *mut std::ffi::c_void,
+        ) -> f32,
+
+        /// Pointer to arbitrary data that will be provided to the callback function whenever it is called. May be `NULL`.
+        user_data: *mut std::ffi::c_void,
+    },
+}
+
+impl Default for DeviationModel {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl From<&DeviationModel> for audionimbus_sys::IPLDeviationModel {
+    fn from(deviation_model: &DeviationModel) -> Self {
+        let (type_, callback, user_data) = match deviation_model {
+            DeviationModel::Default => (
+                audionimbus_sys::IPLDeviationModelType::IPL_DEVIATIONTYPE_DEFAULT,
+                None,
+                std::ptr::null_mut(),
+            ),
+            DeviationModel::Callback {
+                callback,
+                user_data,
+            } => (
+                audionimbus_sys::IPLDeviationModelType::IPL_DEVIATIONTYPE_CALLBACK,
+                Some(*callback),
+                *user_data,
+            ),
+        };
+
+        Self {
+            type_,
+            callback,
+            userData: user_data,
+        }
+    }
+}

--- a/audionimbus/src/model/mod.rs
+++ b/audionimbus/src/model/mod.rs
@@ -6,3 +6,6 @@ pub use air_absorption::*;
 
 pub mod directivity;
 pub use directivity::*;
+
+pub mod deviation;
+pub use deviation::*;

--- a/audionimbus/src/probe.rs
+++ b/audionimbus/src/probe.rs
@@ -35,6 +35,21 @@ impl ProbeArray {
         }
     }
 
+    /// Returns the number of probes in the probe array.
+    pub fn num_probes(&self) -> usize {
+        unsafe { audionimbus_sys::iplProbeArrayGetNumProbes(self.raw_ptr()) as usize }
+    }
+
+    /// Returns the probe at a given index in the probe array.
+    pub fn probe(&self, index: usize) -> Sphere {
+        assert!(index < self.num_probes(), "probe index out of bounds");
+
+        let ipl_sphere =
+            unsafe { audionimbus_sys::iplProbeArrayGetProbe(self.raw_ptr(), index as i32) };
+
+        Sphere::from(ipl_sphere)
+    }
+
     pub fn raw_ptr(&self) -> audionimbus_sys::IPLProbeArray {
         self.0
     }

--- a/audionimbus/src/reconstructor.rs
+++ b/audionimbus/src/reconstructor.rs
@@ -1,0 +1,184 @@
+use crate::context::Context;
+use crate::energy_field::EnergyField;
+use crate::error::{to_option_error, SteamAudioError};
+use crate::impulse_response::ImpulseResponse;
+
+/// An object that can convert energy fields to impulse responses.
+///
+/// Energy fields are typically much smaller in size than impulse responses, and therefore are used when storing baked reflections or reverb in a probe batch, but impulse responses are what is needed at runtime for convolution.
+#[derive(Debug)]
+pub struct Reconstructor {
+    inner: audionimbus_sys::IPLReconstructor,
+
+    /// Used for validation when calling [`Self::reconstruct`].
+    max_duration: f32,
+    max_order: usize,
+}
+
+impl Reconstructor {
+    pub fn try_new(
+        context: &Context,
+        reconstructor_settings: &ReconstructorSettings,
+    ) -> Result<Self, SteamAudioError> {
+        let mut reconstructor = Self {
+            inner: std::ptr::null_mut(),
+            max_duration: reconstructor_settings.max_duration,
+            max_order: reconstructor_settings.max_order,
+        };
+
+        let status = unsafe {
+            audionimbus_sys::iplReconstructorCreate(
+                context.raw_ptr(),
+                &mut audionimbus_sys::IPLReconstructorSettings::from(reconstructor_settings),
+                reconstructor.raw_ptr_mut(),
+            )
+        };
+
+        if let Some(error) = to_option_error(status) {
+            return Err(error);
+        }
+
+        Ok(reconstructor)
+    }
+
+    /// Reconstructs one or more impulse responses as a single batch of work.
+    pub fn reconstruct(
+        &self,
+        inputs: &[ReconstructorInputs],
+        shared_inputs: &ReconstructorSharedInputs,
+        outputs: &[ReconstructorOutputs],
+    ) {
+        assert!(shared_inputs.duration <= self.max_duration, "duration must be less than or equal to the max duration specified in the reconstructor's settings");
+        assert!(shared_inputs.order <= self.max_order, "order must be less than or equal to the max order specified in the reconstructor's settings");
+        assert_eq!(inputs.len(), outputs.len());
+
+        let c_inputs: Vec<audionimbus_sys::IPLReconstructorInputs> = inputs
+            .iter()
+            .map(audionimbus_sys::IPLReconstructorInputs::from)
+            .collect();
+
+        let c_outputs: Vec<audionimbus_sys::IPLReconstructorOutputs> = outputs
+            .iter()
+            .map(audionimbus_sys::IPLReconstructorOutputs::from)
+            .collect();
+
+        let c_shared_inputs = audionimbus_sys::IPLReconstructorSharedInputs::from(shared_inputs);
+
+        unsafe {
+            audionimbus_sys::iplReconstructorReconstruct(
+                self.raw_ptr(),
+                inputs.len() as i32,
+                c_inputs.as_ptr() as *mut audionimbus_sys::IPLReconstructorInputs,
+                &c_shared_inputs as *const audionimbus_sys::IPLReconstructorSharedInputs
+                    as *mut audionimbus_sys::IPLReconstructorSharedInputs,
+                c_outputs.as_ptr() as *mut audionimbus_sys::IPLReconstructorOutputs,
+            )
+        }
+    }
+
+    pub fn raw_ptr(&self) -> audionimbus_sys::IPLReconstructor {
+        self.inner
+    }
+
+    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLReconstructor {
+        &mut self.inner
+    }
+}
+
+impl Clone for Reconstructor {
+    fn clone(&self) -> Self {
+        unsafe {
+            audionimbus_sys::iplReconstructorRetain(self.inner);
+        }
+        Self {
+            inner: self.inner,
+            max_duration: self.max_duration,
+            max_order: self.max_order,
+        }
+    }
+}
+
+impl Drop for Reconstructor {
+    fn drop(&mut self) {
+        unsafe { audionimbus_sys::iplReconstructorRelease(&mut self.inner) }
+    }
+}
+
+unsafe impl Send for Reconstructor {}
+unsafe impl Sync for Reconstructor {}
+
+/// Settings used to create a reconstructor.
+#[derive(Debug)]
+pub struct ReconstructorSettings {
+    /// The largest possible duration (in seconds) of any impulse response that will be reconstructed using this reconstructor.
+    pub max_duration: f32,
+
+    /// The largest possible Ambisonic order of any impulse response that will be reconstructed using this reconstructor.
+    pub max_order: usize,
+
+    /// The sampling rate of impulse responses reconstructed using this reconstructor.
+    pub sampling_rate: usize,
+}
+
+impl From<&ReconstructorSettings> for audionimbus_sys::IPLReconstructorSettings {
+    fn from(settings: &ReconstructorSettings) -> Self {
+        Self {
+            maxDuration: settings.max_duration,
+            maxOrder: settings.max_order as i32,
+            samplingRate: settings.sampling_rate as i32,
+        }
+    }
+}
+
+/// Inputs common to all reconstruction operations specified in a single call to
+/// [`Reconstructor::reconstruct`].
+#[derive(Debug)]
+pub struct ReconstructorSharedInputs {
+    /// Duration of impulse responses to reconstruct.
+    ///
+    /// Must be less than or equal to maxDuration specified in [`ReconstructorSettings`].
+    pub duration: f32,
+
+    /// Ambisonic order of impulse responses to reconstruct.
+    ///
+    /// Must be less than or equal to maxOrder specified in [`ReconstructorSettings`].
+    pub order: usize,
+}
+
+impl From<&ReconstructorSharedInputs> for audionimbus_sys::IPLReconstructorSharedInputs {
+    fn from(reconstructor_shared_inputs: &ReconstructorSharedInputs) -> Self {
+        Self {
+            duration: reconstructor_shared_inputs.duration,
+            order: reconstructor_shared_inputs.order as i32,
+        }
+    }
+}
+
+/// The inputs for a single reconstruction operation.
+#[derive(Debug)]
+pub struct ReconstructorInputs<'a> {
+    /// The energy field from which to reconstruct an impulse response.
+    pub energy_field: &'a EnergyField,
+}
+
+impl From<&ReconstructorInputs<'_>> for audionimbus_sys::IPLReconstructorInputs {
+    fn from(reconstructor_inputs: &ReconstructorInputs) -> Self {
+        Self {
+            energyField: reconstructor_inputs.energy_field.raw_ptr(),
+        }
+    }
+}
+
+/// The outputs for a single reconstruction operation.
+#[derive(Debug)]
+pub struct ReconstructorOutputs<'a> {
+    pub impulse_response: &'a mut ImpulseResponse,
+}
+
+impl From<&ReconstructorOutputs<'_>> for audionimbus_sys::IPLReconstructorOutputs {
+    fn from(reconstructor_outputs: &ReconstructorOutputs) -> Self {
+        Self {
+            impulseResponse: reconstructor_outputs.impulse_response.raw_ptr(),
+        }
+    }
+}

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -1,6 +1,7 @@
 use crate::air_absorption::AirAbsorptionModel;
 use crate::callback::CallbackInformation;
 use crate::context::Context;
+use crate::deviation::DeviationModel;
 use crate::device::open_cl::OpenClDevice;
 use crate::device::radeon_rays::RadeonRaysDevice;
 use crate::device::true_audio_next::TrueAudioNextDevice;
@@ -879,6 +880,9 @@ pub struct PathingSimulationParameters<'a> {
 
     /// If `true`, and [`Self::enable_validation`] is `true`, then if a baked path is occluded by dynamic geometry, path finding is re-run in real-time to find alternate paths that take into account the dynamic geometry.
     pub find_alternate_paths: bool,
+
+    /// The deviation model to use for this source.
+    pub deviation: DeviationModel,
 }
 
 impl From<SimulationInputs<'_>> for audionimbus_sys::IPLSimulationInputs {
@@ -1097,6 +1101,7 @@ impl From<SimulationInputs<'_>> for audionimbus_sys::IPLSimulationInputs {
             pathing_order,
             enable_validation,
             find_alternate_paths,
+            deviation_model,
         ) = if let Some(pathing_simulation_parameters) = pathing_simulation {
             flags |= audionimbus_sys::IPLSimulationFlags::IPL_SIMULATIONFLAGS_PATHING;
 
@@ -1108,6 +1113,8 @@ impl From<SimulationInputs<'_>> for audionimbus_sys::IPLSimulationInputs {
                 pathing_simulation_parameters.pathing_order,
                 pathing_simulation_parameters.enable_validation,
                 pathing_simulation_parameters.find_alternate_paths,
+                // FIXME: Potential memory leak: this prevents dangling pointers, but there is no guarantee it will be freed by the C library.
+                Box::into_raw(Box::new((&pathing_simulation_parameters.deviation).into())),
             )
         } else {
             (
@@ -1118,6 +1125,7 @@ impl From<SimulationInputs<'_>> for audionimbus_sys::IPLSimulationInputs {
                 usize::default(),
                 bool::default(),
                 bool::default(),
+                std::ptr::null_mut(),
             )
         };
 
@@ -1152,6 +1160,7 @@ impl From<SimulationInputs<'_>> for audionimbus_sys::IPLSimulationInputs {
                 audionimbus_sys::IPLbool::IPL_FALSE
             },
             numTransmissionRays: num_transmission_rays as i32,
+            deviationModel: deviation_model,
         }
     }
 }

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -193,6 +193,8 @@ impl<D, R, P> Simulator<D, R, P> {
     }
 
     /// Adds a source to the set of sources processed by a simulator in subsequent simulations.
+    ///
+    /// Call [`Self::commit`] after calling this function for the changes to take effect.
     pub fn add_source(&mut self, source: &Source) {
         unsafe {
             audionimbus_sys::iplSourceAdd(source.raw_ptr(), self.raw_ptr());
@@ -200,6 +202,8 @@ impl<D, R, P> Simulator<D, R, P> {
     }
 
     /// Removes a source from the set of sources processed by a simulator in subsequent simulations.
+    ///
+    /// Call [`Self::commit`] after calling this function for the changes to take effect.
     pub fn remove_source(&mut self, source: &Source) {
         unsafe {
             audionimbus_sys::iplSourceRemove(source.raw_ptr(), self.raw_ptr());

--- a/audionimbus/tests/integration_tests.rs
+++ b/audionimbus/tests/integration_tests.rs
@@ -546,6 +546,7 @@ fn test_simulation() {
             pathing_order: 1,
             enable_validation: true,
             find_alternate_paths: true,
+            deviation: audionimbus::DeviationModel::default(),
         }),
     };
     source.set_inputs(audionimbus::SimulationFlags::DIRECT, simulation_inputs);
@@ -819,6 +820,7 @@ fn test_pathing() {
             pathing_order: 1,
             enable_validation: true,
             find_alternate_paths: true,
+            deviation: audionimbus::DeviationModel::default(),
         }),
     };
     source.set_inputs(audionimbus::SimulationFlags::PATHING, simulation_inputs);


### PR DESCRIPTION
This PR updates AudioNimbus to support Steam Audio v4.7.0. See the full release notes [here](https://github.com/ValveSoftware/steam-audio/releases/tag/v4.7.0).

In particular, this PR adds support for the newly introduced EnergyField, ImpulseResponse, and Reconstructor API objects and related functions.

When migrating to the new version, please make sure to replace the Steam Audio shared libraries to match version 4.7.0 (see the README for more information).

Closes #14 