### PR TITLE
Add feature to auto-install Steam Audio

### DIFF
--- a/audionimbus-sys/Cargo.toml
+++ b/audionimbus-sys/Cargo.toml
@@ -22,6 +22,7 @@ exclude = [
 bindgen = "0.71.1"
 
 [features]
+auto-install = []
 fmod = []
 wwise = []
 

--- a/audionimbus-sys/Cargo.toml
+++ b/audionimbus-sys/Cargo.toml
@@ -27,5 +27,4 @@ fmod = []
 wwise = []
 
 [package.metadata.docs.rs]
-features = ["fmod"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -14,19 +14,19 @@ It is inherently unsafe, as it interfaces with external C code; for a safe API, 
 
 `audionimbus-sys` mirrors the version of [Steam Audio](steam-audio).
 
-# Installation
+## Installation
 
-## Automatic Installation (Recommended)
+### Automatic Installation (Recommended)
 
 The easiest way to use `audionimbus-sys` is with automatic installation. This will automatically download and set up the required Steam Audio libraries for your target platform.
 
-### Requirements
+#### Requirements
 
 - **curl** or **wget** (for downloading)
 - **unzip** (for extraction)
 - **Clang 9.0 or later**
 
-### Basic Usage
+#### Basic Usage
 
 Add `audionimbus-sys` to your `Cargo.toml` with the `auto-install` feature:
 
@@ -35,7 +35,7 @@ Add `audionimbus-sys` to your `Cargo.toml` with the `auto-install` feature:
 audionimbus-sys = { version = "4.7.0", features = ["auto-install"] }
 ```
 
-### With FMOD Studio Integration
+#### With FMOD Studio Integration
 
 ```toml
 [dependencies]
@@ -44,7 +44,7 @@ audionimbus-sys = { version = "4.7.0", features = ["auto-install", "fmod"] }
 
 You also need to set the `FMODSDK` environment variable to the path of the FMOD SDK installed on your system (e.g. `export FMOD="/path/to/FMOD"`).
 
-### With Wwise Integration
+#### With Wwise Integration
 
 ```toml
 [dependencies]
@@ -53,7 +53,7 @@ audionimbus-sys = { version = "4.7.0", features = ["auto-install", "wwise"] }
 
 You also need to set the `WWISESDK` environment variable to the path of the Wwise SDK installed on your system (e.g. `export WWISESDK="/path/to/Audiokinetic/Wwise2024.1.3.8749/SDK"`).
 
-### How It Works
+#### How It Works
 
 When you build your project with the `auto-install` feature, the build script:
 
@@ -65,15 +65,15 @@ When you build your project with the `auto-install` feature, the build script:
 The downloaded files are cached in `$OUT_DIR/steam_audio_cache` and won't be re-downloaded unless the version changes.
 If you need to force a re-download, you can delete this directory.
 
-## Manual Installation
+### Manual Installation
 
 If you prefer manual installation or the automatic installation doesn't work for your setup, you can still install Steam Audio manually.
 
-### Requirements
+#### Requirements
 
 Before installation, make sure that Clang 9.0 or later is installed on your system.
 
-### Steps
+#### Steps
 
 `audionimbus-sys` requires linking against the Steam Audio library during compilation.
 
@@ -103,7 +103,7 @@ Finally, add `audionimbus-sys` to your `Cargo.toml`:
 audionimbus-sys = "4.7.0"
 ```
 
-### Manual FMOD Studio Integration
+#### Manual FMOD Studio Integration
 
 `audionimbus-sys` can be used to add spatial audio to an FMOD Studio project.
 
@@ -137,7 +137,7 @@ It requires linking against both the Steam Audio library and the FMOD integratio
 audionimbus-sys = { version = "4.7.0", features = ["fmod"] }
 ```
 
-### Manual Wwise Integration
+#### Manual Wwise Integration
 
 `audionimbus-sys` can be used to add spatial audio to a Wwise project.
 

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -14,9 +14,77 @@ It is inherently unsafe, as it interfaces with external C code; for a safe API, 
 
 `audionimbus-sys` mirrors the version of [Steam Audio](steam-audio).
 
-## Installation
+# Installation
+
+## Automatic Installation (Recommended)
+
+The easiest way to use `audionimbus-sys` is with automatic installation. This will automatically download and set up the required Steam Audio libraries for your target platform.
+
+### Requirements
+
+- **curl** or **wget** (for downloading)
+- **unzip** (for extraction)
+- **Clang 9.0 or later**
+
+### Basic Usage
+
+Add `audionimbus-sys` to your `Cargo.toml` with the `auto-install` feature:
+
+```toml
+[dependencies]
+audionimbus-sys = { version = "4.7.0", features = ["auto-install"] }
+```
+
+### With FMOD Studio Integration
+
+```toml
+[dependencies]
+audionimbus-sys = { version = "4.7.0", features = ["auto-install", "fmod"] }
+```
+
+You also need to set the `FMODSDK` environment variable to the path of the FMOD SDK installed on your system (e.g. `export FMOD="/path/to/FMOD"`).
+
+### With Wwise Integration
+
+```toml
+[dependencies]
+audionimbus-sys = { version = "4.7.0", features = ["auto-install", "wwise"] }
+```
+
+You also need to set the `WWISESDK` environment variable to the path of the Wwise SDK installed on your system (e.g. `export WWISESDK="/path/to/Audiokinetic/Wwise2024.1.3.8749/SDK"`).
+
+### How It Works
+
+When you build your project with the `auto-install` feature, the build script:
+
+1. Automatically detects your target platform and architecture
+2. Downloads the appropriate Steam Audio release zip file (cached to avoid re-downloading)
+3. Extracts only the required shared libraries for your platform
+4. Sets up the library search paths automatically
+
+The downloaded files are cached in your build directory and won't be re-downloaded unless the version changes.
+
+### Troubleshooting Auto-Install Issues
+
+If automatic installation fails:
+
+1. **Missing dependencies**: Ensure `curl` (or `wget`) and `unzip` are installed on your system
+2. **Network issues**: The build script downloads from GitHub releases. Ensure you have internet access
+3. **Permissions**: Make sure the build process has write permissions to the `OUT_DIR`
+
+You can always fall back to manual installation if automatic installation doesn't work.
+
+Downloaded files are cached in `$OUT_DIR/steam_audio_cache`. If you need to force a re-download, you can delete this directory.
+
+## Manual Installation
+
+If you prefer manual installation or the automatic installation doesn't work for your setup, you can still install Steam Audio manually.
+
+### Requirements
 
 Before installation, make sure that Clang 9.0 or later is installed on your system.
+
+### Steps
 
 `audionimbus-sys` requires linking against the Steam Audio library during compilation.
 
@@ -46,7 +114,7 @@ Finally, add `audionimbus-sys` to your `Cargo.toml`:
 audionimbus-sys = "4.7.0"
 ```
 
-## FMOD Studio Integration
+### Manual FMOD Studio Integration
 
 `audionimbus-sys` can be used to add spatial audio to an FMOD Studio project.
 
@@ -71,14 +139,16 @@ It requires linking against both the Steam Audio library and the FMOD integratio
 
 3. Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
 
-4. Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.toml`:
+4. Set the `FMODSDK` environment variable to the path of the FMOD SDK installed on your system (e.g. `export FMOD="/path/to/FMOD"`).
+
+5. Finally, add `audionimbus-sys` with the `fmod` feature enabled to your `Cargo.toml`:
 
 ```toml
 [dependencies]
 audionimbus-sys = { version = "4.7.0", features = ["fmod"] }
 ```
 
-## Wwise Integration
+### Manual Wwise Integration
 
 `audionimbus-sys` can be used to add spatial audio to a Wwise project.
 

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -65,6 +65,11 @@ When you build your project with the `auto-install` feature, the build script:
 The downloaded files are cached in `$OUT_DIR/steam_audio_cache` and won't be re-downloaded unless the version changes.
 If you need to force a re-download, you can delete this directory.
 
+> **Note**
+> The initial download can be quite large (≈180 MB for Steam Audio, ≈140 MB for the FMOD integration ≈52MB for the Wwise integration).
+> During this step, cargo build may look like it is stuck - it’s just downloading in the background.
+> The files are cached, so this only happens the first time (or when the version changes).
+
 ### Manual Installation
 
 If you prefer manual installation or the automatic installation doesn't work for your setup, you can still install Steam Audio manually.

--- a/audionimbus-sys/README.md
+++ b/audionimbus-sys/README.md
@@ -62,19 +62,8 @@ When you build your project with the `auto-install` feature, the build script:
 3. Extracts only the required shared libraries for your platform
 4. Sets up the library search paths automatically
 
-The downloaded files are cached in your build directory and won't be re-downloaded unless the version changes.
-
-### Troubleshooting Auto-Install Issues
-
-If automatic installation fails:
-
-1. **Missing dependencies**: Ensure `curl` (or `wget`) and `unzip` are installed on your system
-2. **Network issues**: The build script downloads from GitHub releases. Ensure you have internet access
-3. **Permissions**: Make sure the build process has write permissions to the `OUT_DIR`
-
-You can always fall back to manual installation if automatic installation doesn't work.
-
-Downloaded files are cached in `$OUT_DIR/steam_audio_cache`. If you need to force a re-download, you can delete this directory.
+The downloaded files are cached in `$OUT_DIR/steam_audio_cache` and won't be re-downloaded unless the version changes.
+If you need to force a re-download, you can delete this directory.
 
 ## Manual Installation
 
@@ -173,8 +162,8 @@ Documentation is available at [docs.rs](https://docs.rs/audionimbus-sys/latest).
 
 Since this crate strictly follows Steam Audio’s C API, you can also refer to the [Steam Audio C API reference](https://valvesoftware.github.io/steam-audio/doc/capi/reference.html) for additional details.
 
-Note that because the Wwise integration depends on files that are local to your system, documentation for the `wwise` module is not available on docs.rs.
-However, it can be generated locally using `cargo doc --open --features wwise`.
+Note that because the FMOD and Wwise integrations depend on files that are local to your system, documentation for the `fmod` and `wwise` modules is not available on docs.rs.
+However, it can be generated locally using `cargo doc --open --features fmod` (resp. `wwise`).
 
 ## License
 

--- a/audionimbus-sys/build.rs
+++ b/audionimbus-sys/build.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "auto-install")]
+use std::fs;
 use std::path::{Path, PathBuf};
 
 const PHONON_HEADER_PATH: &str = "steam-audio/core/src/core/phonon.h";
@@ -10,6 +12,14 @@ fn main() {
 
     let version = version();
 
+    // Handle automatic installation if feature is enabled
+    #[cfg(feature = "auto-install")]
+    {
+        if let Err(e) = handle_auto_install() {
+            panic!("auto-install failed: {}", e);
+        }
+    }
+
     generate_bindings_phonon(&out_dir.join("phonon.rs"), &version, out_dir);
 
     #[cfg(feature = "fmod")]
@@ -17,6 +27,482 @@ fn main() {
 
     #[cfg(feature = "wwise")]
     generate_bindings_phonon_wwise(&out_dir.join("phonon_wwise.rs"), &version, out_dir);
+}
+
+#[cfg(feature = "auto-install")]
+fn handle_auto_install() -> Result<(), Box<dyn std::error::Error>> {
+    let target_info = get_target_info()?;
+    println!(
+        "cargo:warning=Auto-installing Steam Audio for target: {} ({})",
+        target_info.platform, target_info.arch
+    );
+
+    // Create cache directory
+    let cache_dir = get_cache_dir()?;
+    fs::create_dir_all(&cache_dir)?;
+
+    // Install base Steam Audio
+    install_steam_audio(&cache_dir, &target_info)?;
+
+    // Install FMOD integration if feature is enabled
+    #[cfg(feature = "fmod")]
+    install_fmod_integration(&cache_dir, &target_info)?;
+
+    // Install Wwise integration if feature is enabled
+    #[cfg(feature = "wwise")]
+    install_wwise_integration(&cache_dir, &target_info)?;
+
+    Ok(())
+}
+
+#[cfg(feature = "auto-install")]
+#[derive(Debug, Clone)]
+struct TargetInfo {
+    platform: String,
+    arch: String,
+    lib_dir: String,
+    lib_names: Vec<String>,
+    _is_static: bool,
+}
+
+#[cfg(feature = "auto-install")]
+fn get_target_info() -> Result<TargetInfo, Box<dyn std::error::Error>> {
+    let target = std::env::var("TARGET")?;
+
+    let (platform, arch, lib_dir, lib_names, _is_static) = match target.as_str() {
+        t if t.contains("windows") && t.contains("i686") => (
+            "windows".to_string(),
+            "x86".to_string(),
+            "windows-x86".to_string(),
+            vec!["phonon.dll".to_string()],
+            false,
+        ),
+        t if t.contains("windows") && t.contains("x86_64") => (
+            "windows".to_string(),
+            "x64".to_string(),
+            "windows-x64".to_string(),
+            vec!["phonon.dll".to_string()],
+            false,
+        ),
+        t if t.contains("linux") && t.contains("i686") => (
+            "linux".to_string(),
+            "x86".to_string(),
+            "linux-x86".to_string(),
+            vec!["libphonon.so".to_string()],
+            false,
+        ),
+        t if t.contains("linux") && t.contains("x86_64") => (
+            "linux".to_string(),
+            "x64".to_string(),
+            "linux-x64".to_string(),
+            vec!["libphonon.so".to_string()],
+            false,
+        ),
+        t if t.contains("apple-darwin") => (
+            "macos".to_string(),
+            "universal".to_string(),
+            "osx".to_string(),
+            vec!["libphonon.dylib".to_string()],
+            false,
+        ),
+        t if t.contains("android") && t.contains("armv7") => (
+            "android".to_string(),
+            "armv7".to_string(),
+            "android-armv7".to_string(),
+            vec!["libphonon.so".to_string()],
+            false,
+        ),
+        t if t.contains("android") && (t.contains("aarch64") || t.contains("armv8")) => (
+            "android".to_string(),
+            "armv8".to_string(),
+            "android-armv8".to_string(),
+            vec!["libphonon.so".to_string()],
+            false,
+        ),
+        t if t.contains("android") && t.contains("i686") => (
+            "android".to_string(),
+            "x86".to_string(),
+            "android-x86".to_string(),
+            vec!["libphonon.so".to_string()],
+            false,
+        ),
+        t if t.contains("android") && t.contains("x86_64") => (
+            "android".to_string(),
+            "x64".to_string(),
+            "android-x64".to_string(),
+            vec!["libphonon.so".to_string()],
+            false,
+        ),
+        t if t.contains("ios") => (
+            "ios".to_string(),
+            "armv8".to_string(),
+            "ios".to_string(),
+            vec!["libphonon.a".to_string()],
+            true,
+        ),
+        _ => return Err(format!("Unsupported target: {}", target).into()),
+    };
+
+    Ok(TargetInfo {
+        platform,
+        arch,
+        lib_dir,
+        lib_names,
+        _is_static,
+    })
+}
+
+#[cfg(feature = "auto-install")]
+fn get_cache_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let out_dir = std::env::var("OUT_DIR")?;
+    let mut cache_dir = PathBuf::from(out_dir);
+    cache_dir.push("steam_audio_cache");
+    Ok(cache_dir)
+}
+
+#[cfg(feature = "auto-install")]
+fn install_steam_audio(
+    cache_dir: &Path,
+    target_info: &TargetInfo,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let version = version().to_string();
+    let zip_name = format!("steamaudio_{}.zip", version);
+    let zip_path = cache_dir.join(&zip_name);
+    let extract_dir = cache_dir.join("steamaudio_core");
+
+    // Check if already extracted and up to date
+    let version_marker = extract_dir.join(".version");
+    if version_marker.exists()
+        && fs::read_to_string(&version_marker)
+            .unwrap_or_default()
+            .trim()
+            == version
+    {
+        println!(
+            "cargo:warning=Steam Audio {} already installed, skipping download",
+            version
+        );
+    } else {
+        // Download if not cached
+        if !zip_path.exists() {
+            println!("cargo:warning=Downloading Steam Audio {}...", version);
+            download_file(
+                &format!("https://github.com/ValveSoftware/steam-audio/releases/download/v{}/steamaudio_{}.zip",
+                         version, version),
+                &zip_path
+            )?;
+        }
+
+        // Extract
+        println!("cargo:warning=Extracting Steam Audio...");
+        extract_zip(&zip_path, &extract_dir)?;
+
+        // Mark version
+        fs::write(&version_marker, version)?;
+    }
+
+    // Copy libraries to a location where they can be found
+    copy_libraries(&extract_dir.join("steamaudio"), target_info, &target_info.lib_names)?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "auto-install", feature = "fmod"))]
+fn install_fmod_integration(
+    cache_dir: &Path,
+    target_info: &TargetInfo,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let version = version().to_string();
+    let zip_name = format!("steamaudio_fmod_{}.zip", version);
+    let zip_path = cache_dir.join(&zip_name);
+    let extract_dir = cache_dir.join("steamaudio_fmod");
+
+    // Check if already extracted and up to date
+    let version_marker = extract_dir.join(".version");
+    if version_marker.exists()
+        && fs::read_to_string(&version_marker)
+            .unwrap_or_default()
+            .trim()
+            == version
+    {
+        println!(
+            "cargo:warning=Steam Audio FMOD {} already installed, skipping download",
+            version
+        );
+    } else {
+        // Download if not cached
+        if !zip_path.exists() {
+            println!(
+                "cargo:warning=Downloading Steam Audio FMOD integration {}...",
+                version
+            );
+            download_file(
+                &format!("https://github.com/ValveSoftware/steam-audio/releases/download/v{}/steamaudio_fmod_{}.zip",
+                         version, version),
+                &zip_path
+            )?;
+        }
+
+        // Extract
+        println!("cargo:warning=Extracting Steam Audio FMOD integration...");
+        extract_zip(&zip_path, &extract_dir)?;
+
+        // Mark version
+        fs::write(&version_marker, version)?;
+    }
+
+    // Copy FMOD libraries
+    let fmod_lib_name = match target_info.platform.as_str() {
+        "windows" => "phonon_fmod.dll",
+        "linux" | "android" => "libphonon_fmod.so",
+        "macos" => "libphonon_fmod.dylib",
+        "ios" => "libphonon_fmod.a",
+        _ => return Err("Unsupported platform for FMOD integration".into()),
+    };
+
+    copy_libraries(&extract_dir.join("steamaudio_fmod"), target_info, &[fmod_lib_name.to_string()])?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "auto-install", feature = "wwise"))]
+fn install_wwise_integration(
+    cache_dir: &Path,
+    target_info: &TargetInfo,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let version = version().to_string();
+    let zip_name = format!("steamaudio_wwise_{}.zip", version);
+    let zip_path = cache_dir.join(&zip_name);
+    let extract_dir = cache_dir.join("steamaudio_wwise");
+
+    // Check if already extracted and up to date
+    let version_marker = extract_dir.join(".version");
+    if version_marker.exists()
+        && fs::read_to_string(&version_marker)
+            .unwrap_or_default()
+            .trim()
+            == version
+    {
+        println!(
+            "cargo:warning=Steam Audio Wwise {} already installed, skipping download",
+            version
+        );
+    } else {
+        // Download if not cached
+        if !zip_path.exists() {
+            println!(
+                "cargo:warning=Downloading Steam Audio Wwise integration {}...",
+                version
+            );
+            download_file(
+                &format!("https://github.com/ValveSoftware/steam-audio/releases/download/v{}/steamaudio_wwise_{}.zip",
+                         version, version),
+                &zip_path
+            )?;
+        }
+
+        // Extract
+        println!("cargo:warning=Extracting Steam Audio Wwise integration...");
+        extract_zip(&zip_path, &extract_dir)?;
+
+        // Mark version
+        fs::write(&version_marker, version)?;
+    }
+
+    // Copy Wwise libraries - the actual library name might vary
+    let wwise_lib_name = "SteamAudioWwise"; // This might need adjustment based on actual file names
+    let lib_names = vec![
+        format!("lib{}.so", wwise_lib_name),
+        format!("lib{}.dylib", wwise_lib_name),
+        format!("{}.dll", wwise_lib_name),
+        format!("lib{}.a", wwise_lib_name),
+    ];
+
+    // Find which one exists and copy it
+    for lib_name in lib_names {
+        let src = extract_dir
+            .join("lib")
+            .join(&target_info.lib_dir)
+            .join(&lib_name);
+        if src.exists() {
+            copy_libraries(&extract_dir.join("steamaudio_wwise"), target_info, &[lib_name])?;
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "auto-install")]
+fn download_file(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    use std::process::Command;
+
+    // Remove any existing partial download
+    if dest.exists() {
+        fs::remove_file(dest)?;
+    }
+
+    // Try to use curl first with progress bar
+    let curl_result = Command::new("curl")
+        .args(&[
+            "-L",             // Follow redirects
+            "--progress-bar", // Show progress bar
+            "-f",             // Fail on HTTP errors
+            "--retry",
+            "3", // Retry on transient errors
+            "--retry-delay",
+            "1", // Wait 1 second between retries
+            "-o",
+            dest.to_str().unwrap(),
+            url,
+        ])
+        .status();
+
+    match curl_result {
+        Ok(status) if status.success() => {
+            // Verify the downloaded file is valid
+            validate_download(dest)?;
+            Ok(())
+        }
+        _ => {
+            // Clean up failed download
+            let _ = fs::remove_file(dest);
+
+            // Try wget as fallback with progress
+            println!("cargo:warning=curl failed, trying wget...");
+            let wget_result = Command::new("wget")
+                .args(&[
+                    "--progress=bar:force", // Show progress bar
+                    "--tries=3",            // Retry on failure
+                    "--waitretry=1",        // Wait between retries
+                    "-O",
+                    dest.to_str().unwrap(),
+                    url,
+                ])
+                .status();
+
+            match wget_result {
+                Ok(status) if status.success() => {
+                    validate_download(dest)?;
+                    Ok(())
+                }
+                Ok(_) => Err("wget failed to download file".into()),
+                Err(e) => Err(format!("Neither curl nor wget available: {}", e).into()),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "auto-install")]
+fn validate_download(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    // Try to verify it's a valid zip by checking the magic number
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut magic = [0u8; 4];
+    file.read_exact(&mut magic)?;
+
+    // Check for zip magic number (PK signature)
+    if &magic[0..2] != b"PK" {
+        return Err("Downloaded file is not a valid zip file".into());
+    }
+
+    println!(
+        "cargo:warning=Successfully downloaded and validated {}",
+        path.file_name().unwrap().to_string_lossy(),
+    );
+
+    Ok(())
+}
+
+#[cfg(feature = "auto-install")]
+fn extract_zip(zip_path: &Path, dest_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    use std::process::Command;
+
+    // First, verify the zip file one more time
+    validate_download(zip_path)?;
+
+    // Remove existing directory if it exists
+    if dest_dir.exists() {
+        fs::remove_dir_all(dest_dir)?;
+    }
+    fs::create_dir_all(dest_dir)?;
+
+    println!(
+        "cargo:warning=Extracting {} to {}...",
+        zip_path.file_name().unwrap().to_string_lossy(),
+        dest_dir.file_name().unwrap().to_string_lossy()
+    );
+
+    // Use system unzip command with verbose output for debugging
+    let output = Command::new("unzip")
+        .args(&[
+            "-q", // Quiet mode (less verbose)
+            "-o", // Overwrite files without prompting
+            zip_path.to_str().unwrap(),
+            "-d",
+            dest_dir.to_str().unwrap(),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        // If unzip failed, try to get more information
+        println!("cargo:warning=unzip stdout: {}", stdout);
+        println!("cargo:warning=unzip stderr: {}", stderr);
+
+        // Try to test the zip file
+        let test_output = Command::new("unzip")
+            .args(&["-t", zip_path.to_str().unwrap()])
+            .output()?;
+
+        if !test_output.status.success() {
+            let test_stderr = String::from_utf8_lossy(&test_output.stderr);
+            return Err(format!("Zip file is corrupted. Test output: {}", test_stderr).into());
+        }
+
+        return Err(format!("Failed to extract zip: {}", stderr).into());
+    }
+
+    println!("cargo:warning=Successfully extracted Steam Audio");
+
+    Ok(())
+}
+
+#[cfg(feature = "auto-install")]
+fn copy_libraries(
+    extract_dir: &Path,
+    target_info: &TargetInfo,
+    lib_names: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let lib_src_dir = extract_dir.join("lib").join(&target_info.lib_dir);
+
+    // Create a lib directory in OUT_DIR for the libraries
+    let out_dir = std::env::var("OUT_DIR")?;
+    let lib_dest_dir = Path::new(&out_dir).join("lib");
+    fs::create_dir_all(&lib_dest_dir)?;
+
+    for lib_name in lib_names {
+        let src = lib_src_dir.join(lib_name);
+        let dest = lib_dest_dir.join(lib_name);
+
+        if src.exists() {
+            println!(
+                "cargo:warning=Copying {} to {}",
+                src.display(),
+                dest.display()
+            );
+            fs::copy(&src, &dest)?;
+        } else {
+            return Err(format!("Required library not found: {}", src.display()).into());
+        }
+    }
+
+    // Tell cargo where to find the libraries
+    println!("cargo:rustc-link-search=native={}", lib_dest_dir.display());
+
+    Ok(())
 }
 
 fn generate_bindings_phonon(output_path: &Path, version: &Version, tmp_dir: &Path) {
@@ -55,12 +541,16 @@ fn generate_bindings_phonon_fmod(output_path: &Path, version: &Version, tmp_dir:
     let phonon_header = Path::new(PHONON_HEADER_PATH);
     let phonon_header_dir = phonon_header.parent().unwrap();
 
+    let fmod_sdk = std::env::var("FMODSDK").expect("env var FMODSDK not set");
+    let fmod_includes = Path::new(&fmod_sdk).join("api").join("core").join("inc");
+
     let bindings = bindgen::Builder::default()
         .header(PHONON_FMOD_HEADER_PATH)
         .clang_args(&[
             String::from("-xc++"),
             String::from("-std=c++14"),
             format!("-I{}", tmp_dir.display()),
+            format!("-I{}", fmod_includes.display()),
             format!("-I{}", phonon_header_dir.display()),
             format!("-I{}", "steam-audio/fmod/include"),
         ])
@@ -124,6 +614,12 @@ struct Version {
     major: u32,
     minor: u32,
     patch: u32,
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
 }
 
 fn version() -> Version {

--- a/audionimbus-sys/build.rs
+++ b/audionimbus-sys/build.rs
@@ -372,7 +372,6 @@ fn download_file(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Error
             println!("cargo:warning=curl failed, trying wget...");
             let wget_result = Command::new("wget")
                 .args(&[
-                    "--progress=bar:force", // Show progress bar
                     "--tries=3",            // Retry on failure
                     "--waitretry=1",        // Wait between retries
                     "-O",

--- a/audionimbus/Cargo.toml
+++ b/audionimbus/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = "2.8.0"
 [features]
 fmod = ["audionimbus-sys/fmod"]
 wwise = ["audionimbus-sys/wwise"]
+auto-install = ["audionimbus-sys/auto-install"]
 
 [package.metadata.docs.rs]
-features = ["fmod"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/audionimbus/README.md
+++ b/audionimbus/README.md
@@ -70,6 +70,11 @@ When you build your project with the `auto-install` feature, the build script:
 The downloaded files are cached in `$OUT_DIR/steam_audio_cache` and won't be re-downloaded unless the version changes.
 If you need to force a re-download, you can delete this directory.
 
+> **Note**
+> The initial download can be quite large (≈180 MB for Steam Audio, ≈140 MB for the FMOD integration ≈52MB for the Wwise integration).
+> During this step, cargo build may look like it is stuck - it’s just downloading in the background.
+> The files are cached, so this only happens the first time (or when the version changes).
+
 ### Manual Installation
 
 If you prefer manual installation or the automatic installation doesn't work for your setup, you can still install Steam Audio manually.

--- a/audionimbus/README.md
+++ b/audionimbus/README.md
@@ -14,18 +14,75 @@ To experience AudioNimbus in action, play the [interactive demo](https://github.
 
 ## Version compatibility
 
-`audionimbus` currently tracks Steam Audio 4.6.1.
+`audionimbus` currently tracks Steam Audio 4.7.0.
 
 Unlike `audionimbus-sys`, which mirrors Steam Audio's versioning, `audionimbus` introduces its own abstractions and is subject to breaking changes.
 As a result, it uses independent versioning.
 
 ## Installation
 
+### Automatic Installation (Recommended)
+
+The easiest way to use `audionimbus` is with automatic installation. This will automatically download and set up the required Steam Audio libraries for your target platform.
+
+#### Requirements
+
+- **curl** or **wget** (for downloading)
+- **unzip** (for extraction)
+- **Clang 9.0 or later**
+
+#### Basic Usage
+
+Add `audionimbus` to your `Cargo.toml` with the `auto-install` feature:
+
+```toml
+[dependencies]
+audionimbus = { version = "0.8.0", features = ["auto-install"] }
+```
+
+#### With FMOD Studio Integration
+
+```toml
+[dependencies]
+audionimbus = { version = "0.8.0", features = ["auto-install", "fmod"] }
+```
+
+You also need to set the `FMODSDK` environment variable to the path of the FMOD SDK installed on your system (e.g. `export FMOD="/path/to/FMOD"`).
+
+#### With Wwise Integration
+
+```toml
+[dependencies]
+audionimbus = { version = "0.8.0", features = ["auto-install", "wwise"] }
+```
+
+You also need to set the `WWISESDK` environment variable to the path of the Wwise SDK installed on your system (e.g. `export WWISESDK="/path/to/Audiokinetic/Wwise2024.1.3.8749/SDK"`).
+
+#### How It Works
+
+When you build your project with the `auto-install` feature, the build script:
+
+1. Automatically detects your target platform and architecture
+2. Downloads the appropriate Steam Audio release zip file (cached to avoid re-downloading)
+3. Extracts only the required shared libraries for your platform
+4. Sets up the library search paths automatically
+
+The downloaded files are cached in `$OUT_DIR/steam_audio_cache` and won't be re-downloaded unless the version changes.
+If you need to force a re-download, you can delete this directory.
+
+### Manual Installation
+
+If you prefer manual installation or the automatic installation doesn't work for your setup, you can still install Steam Audio manually.
+
+#### Requirements
+
 Before installation, make sure that Clang 9.0 or later is installed on your system.
+
+#### Steps
 
 `audionimbus` requires linking against the Steam Audio library during compilation.
 
-To do so, download `steamaudio_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+To do so, download `steamaudio_4.7.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
 
 Locate the relevant library for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
 
@@ -49,6 +106,57 @@ Finally, add `audionimbus` to your `Cargo.toml`:
 ```toml
 [dependencies]
 audionimbus = "0.8.0"
+```
+
+#### Manual FMOD Studio Integration
+
+`audionimbus` can be used to add spatial audio to an FMOD Studio project.
+
+It requires linking against both the Steam Audio library and the FMOD integration library during compilation:
+
+1. Download `steamaudio_fmod_4.7.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+
+2. Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
+
+| Platform | Library Directory | Library To Link |
+| --- | --- | --- |
+| Windows 32-bit | `SDKROOT/lib/windows-x86` | `phonon.dll`, `phonon_fmod.dll` |
+| Windows 64-bit | `SDKROOT/lib/windows-x64` | `phonon.dll`, `phonon_fmod.dll` |
+| Linux 32-bit | `SDKROOT/lib/linux-x86` | `libphonon.so`, `libphonon_fmod.so` |
+| Linux 64-bit | `SDKROOT/lib/linux-x64` | `libphonon.so`, `libphonon_fmod.so` |
+| macOS | `SDKROOT/lib/osx` | `libphonon.dylib`, `libphonon_fmod.dylib` |
+| Android ARMv7 | `SDKROOT/lib/android-armv7` | `libphonon.so`, `libphonon_fmod.so` |
+| Android ARMv8/AArch64 | `SDKROOT/lib/android-armv8` | `libphonon.so`, `libphonon_fmod.so` |
+| Android x86 | `SDKROOT/lib/android-x86` | `libphonon.so`, `libphonon_fmod.so` |
+| Android x64 | `SDKROOT/lib/android-x64` | `libphonon.so`, `libphonon_fmod.so` |
+| iOS ARMv8/AArch64 | `SDKROOT/lib/ios` | `libphonon.a`, `libphonon_fmod.a` |
+
+3. Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+
+4. Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
+
+```toml
+[dependencies]
+audionimbus = { version = "0.8.0", features = ["fmod"] }
+```
+
+#### Manual Wwise Integration
+
+`audionimbus` can be used to add spatial audio to a Wwise project.
+
+It requires linking against both the Steam Audio library and the Wwise integration library during compilation:
+
+1. Download `steamaudio_wwise_4.7.0.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
+
+2. Locate the two relevant libraries for your target platform and place them in a location listed in [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
+
+3. Set the `WWISESDK` environment variable to the path of the Wwise SDK installed on your system (e.g. `export WWISESDK="/path/to/Audiokinetic/Wwise2024.1.3.8749/SDK"`).
+
+4. Finally, add `audionimbus` with the `wwise` feature enabled to your `Cargo.toml`:
+
+```toml
+[dependencies]
+audionimbus = { version = "0.8.0", features = ["wwise"] }
 ```
 
 ## Example
@@ -127,57 +235,6 @@ To implement real-time audio processing and playback in your game, check out the
 For a complete demonstration featuring HRTF, Ambisonics, reflections and reverb in an interactive environment, see the [AudioNimbus Interactive Demo repository](https://github.com/MaxenceMaire/audionimbus-demo).
 
 For additional examples, you can explore the [tests](./tests), which closely follow [Steam Audio's Programmer's Guide](https://valvesoftware.github.io/steam-audio/doc/capi/guide.html).
-
-## FMOD Studio Integration
-
-`audionimbus` can be used to add spatial audio to an FMOD Studio project.
-
-It requires linking against both the Steam Audio library and the FMOD integration library during compilation:
-
-1. Download `steamaudio_fmod_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
-
-2. Locate the two relevant libraries for your target platform (`SDKROOT` refers to the directory in which you extracted the zip file):
-
-| Platform | Library Directory | Library To Link |
-| --- | --- | --- |
-| Windows 32-bit | `SDKROOT/lib/windows-x86` | `phonon.dll`, `phonon_fmod.dll` |
-| Windows 64-bit | `SDKROOT/lib/windows-x64` | `phonon.dll`, `phonon_fmod.dll` |
-| Linux 32-bit | `SDKROOT/lib/linux-x86` | `libphonon.so`, `libphonon_fmod.so` |
-| Linux 64-bit | `SDKROOT/lib/linux-x64` | `libphonon.so`, `libphonon_fmod.so` |
-| macOS | `SDKROOT/lib/osx` | `libphonon.dylib`, `libphonon_fmod.dylib` |
-| Android ARMv7 | `SDKROOT/lib/android-armv7` | `libphonon.so`, `libphonon_fmod.so` |
-| Android ARMv8/AArch64 | `SDKROOT/lib/android-armv8` | `libphonon.so`, `libphonon_fmod.so` |
-| Android x86 | `SDKROOT/lib/android-x86` | `libphonon.so`, `libphonon_fmod.so` |
-| Android x64 | `SDKROOT/lib/android-x64` | `libphonon.so`, `libphonon_fmod.so` |
-| iOS ARMv8/AArch64 | `SDKROOT/lib/ios` | `libphonon.a`, `libphonon_fmod.a` |
-
-3. Ensure the libraries are placed in a location listed in the [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
-
-4. Finally, add `audionimbus` with the `fmod` feature enabled to your `Cargo.toml`:
-
-```toml
-[dependencies]
-audionimbus = { version = "0.8.0", features = ["fmod"] }
-```
-
-## Wwise Integration
-
-`audionimbus` can be used to add spatial audio to a Wwise project.
-
-It requires linking against both the Steam Audio library and the Wwise integration library during compilation:
-
-1. Download `steamaudio_wwise_4.6.1.zip` from the [release page](https://github.com/ValveSoftware/steam-audio/releases).
-
-2. Locate the two relevant libraries for your target platform and place them in a location listed in [dynamic library search paths](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths) (e.g., `/usr/local/lib`).
-
-3. Set the `WWISESDK` environment variable to the path of the Wwise SDK installed on your system (e.g. `export WWISESDK="/path/to/Audiokinetic/Wwise2024.1.3.8749/SDK"`).
-
-4. Finally, add `audionimbus` with the `wwise` feature enabled to your `Cargo.toml`:
-
-```toml
-[dependencies]
-audionimbus = { version = "0.8.0", features = ["wwise"] }
-```
 
 ## Documentation
 


### PR DESCRIPTION
Manually linking AudioNimbus to Steam Audio can be tedious and error-prone. This PR introduces an auto-install feature that automatically downloads and installs the Steam Audio and FMOD/Wwise integration libraries, making the integration of AudioNimbus much smoother.

With `auto-install` enabled, the build script will:
1. Detect your target platform and architecture
2. Download the appropriate Steam Audio release (with caching to avoid re-downloading)
3. Extract only the required shared libraries for your platform
4. Configure library search paths automatically

If `auto-install` fails or you require a custom setup, you can still of course fall back to manual installation.