### PR TITLE
chore: use https submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "audionimbus-sys/steam-audio"]
 	path = audionimbus-sys/steam-audio
-	url = git@github.com:ValveSoftware/steam-audio.git
+	url = https://github.com/valvesoftware/steam-audio


### PR DESCRIPTION
This PR replaces steam-audio submodule with https submodule, as https submodules does not require authentication.