### PR TITLE
Relax trait constraints on AudioBuffer

### DIFF
--- a/audionimbus/tests/integration_tests.rs
+++ b/audionimbus/tests/integration_tests.rs
@@ -881,7 +881,7 @@ fn test_buffer_mix() {
     let mix_container = vec![0.2; FRAME_SIZE];
     let mut mix_buffer = audionimbus::AudioBuffer::try_with_data(&mix_container).unwrap();
 
-    mix_buffer.mix(&context, source_buffer);
+    mix_buffer.mix(&context, &source_buffer);
 
     assert_eq!(mix_container, vec![0.3; FRAME_SIZE]);
 }


### PR DESCRIPTION
Follows @CorvusPrudens's  [comment](https://github.com/MaxenceMaire/audionimbus/pull/20/files/61613b300df09c5e176a9367d51946eacd2a85a9#r2416611778) from https://github.com/MaxenceMaire/audionimbus/pull/20

This PR:
* Relaxes trait constraints for the `try_new` method of `AudioBuffer`, and removes the `try_new_borrowed` method
* Makes the `mix`, `downmix` and `convert_ambisonics_into` methods more generic to support different lifetimes
* Adds `try_from_slices` method to construct an `AudioBuffer` from `&[&[f32]]` data
* Adds a `channels_mut` method for iterating over mutable channels