### PR TITLE
fix segfault caused by running pathing with no committed probes

### DIFF
--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `Scene::remove_static_mesh` and `Scene::remove_instanced_mesh` now take handles as arguments instead of references to `StaticMesh` and `InstancedMesh`.
 - `Scene::add_probe` now takes the probe by value instead of by reference.
 - `Simulator::run_pathing` now returns an error if the simulator contains no probes.
+- `ProbeBatch::commit` now takes `&mut self` instead of `&self`.
 
 ### Added
 
@@ -30,6 +31,7 @@
 - Add `Matrix3` and `Matrix4` type aliases.
 - Add `StaticMeshHandle` and `InstancedMeshHandle` structs (returned by `Scene::add_static_mesh` and `Scene::add_instanced_mesh` respectively).
 - Add `slotmap` lib dependency.
+- Add method `ProbeBatch::committed_num_probes`.
 
 ### Removed
 

--- a/audionimbus/tests/simulation.rs
+++ b/audionimbus/tests/simulation.rs
@@ -190,7 +190,9 @@ fn test_pathing_without_probes() {
         },
     );
 
-    let probe_batch = ProbeBatch::try_new(&context).unwrap();
+    let mut probe_batch = ProbeBatch::try_new(&context).unwrap();
+    // Add a probe array without commit.
+    probe_batch.add_probe_array(&probe_array);
     // Add the probe batch to the simulator without any probes in it.
     simulator.add_probe_batch(&probe_batch);
 


### PR DESCRIPTION
Follow-up to #37, which fixed a segfault caused by running a pathing simulation without any probes.
The segfault would fail be be caught in the case where probes or probe arrays were added to the probe batch without calling `ProbeBatch::commit` subsequently.
This is due to `ProbeBatch::num_probes` returning the total number of probes added irrespective of whether the newly added probes were committed.
This PR introduces a new public `ProbeBatch::commtited_num_probes` method to get that information.