### PR TITLE
Fix segmentation faults in audio effect methods by validating buffer channels

### DIFF
--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed a segmentation fault in bake_path when no progress callback was provided, caused by an upstream Steam Audio bug; a no-op callback is now used as a workaround.
 - Fixed a segmentation fault caused by running a pathing simulation without probes.
 - Fixed a segmentation fault caused by running a reflections simulation without having set a scene.
+- Fixed a segmentation fault when applying a direct effect on audio buffers that have a number of channels different from that specified when creating the effect.
 
 ### Changed
 
@@ -23,6 +24,7 @@
 - `Simulator::run_pathing` now returns an error if the simulator contains no probes.
 - `ProbeBatch::commit` now takes `&mut self` instead of `&self`.
 - `Simulator::run_reflections` now returns an error if a scene has not been set and committed to the simulator.
+- `DirectEffect::apply` now returns an `EffectError` when the input of output buffers have a number of channels different from that specified when creating the effect.
 
 ### Added
 
@@ -34,6 +36,8 @@
 - Add `StaticMeshHandle` and `InstancedMeshHandle` structs (returned by `Scene::add_static_mesh` and `Scene::add_instanced_mesh` respectively).
 - Add `slotmap` lib dependency.
 - Add method `ProbeBatch::committed_num_probes`.
+- `SpeakerLayout` now implements `Clone` and `Display`.
+- Add `EffectError` for errors that can occur when applying audio effects.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Fixed a segmentation fault when applying a reflection effect on an input buffer other than mono or with an output buffer that has a number of channels other than that of the impulse response specified when creating the effect.
 - Fixed a segmentation fault when calling `ReflectionEffect::tail` or `ReflectionEffect::tail_into_mixer` with an output buffer that has a number of channels other than that of the impulse response specified when creating the effect.
 - Fixed a segmentation fault where `ReflectionEffect::apply_into_mixer` was missing the output buffer.
+- Fixed a segmentation fault when applying a binaural effect on an input buffer other than mono or stereo, or passing an output buffer that has more than two channels.
+- Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that has more than two channels.
 
 ### Changed
 
@@ -36,6 +38,8 @@
 - `ReflectionEffect::apply_into_mixer` takes an additional `output_buffer` argument.
 - `ReflectionEffect::apply` and `ReflectionEffect::apply_into_mixer` now return an `EffectError` when the input buffer is not mono or the output buffer has a number of channels other than that of the impulse response specified when creating the effect.
 - `ReflectionEffect::tail` and `ReflectionEffect::tail_into_mixer` now return an `EffectError` when the output buffer has a number of channels other than that of the impulse response specified when creating the effect.
+- `BinauralEffect::apply` now returns an `EffectError` when the input buffer is not mono or stereo, or the output buffer has more than two channels.
+- `BinauralEffect::tail` now returns an `EffectError` when the output buffer has more than two channels
 
 ### Added
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `Simulator::run_reflections` now returns an error if a scene has not been set and committed to the simulator.
 - `DirectEffect::apply` now returns an `EffectError` when the input of output buffers have a number of channels different from that specified when creating the effect.
 - `PathEffect::apply` now returns an `EffectError` when the input buffer is not mono or the output buffer has a number of channels different from that needed for the ambisonics order specified when creating the effect.
+- `PathEffect::tail` now returns an `EffectError` when the output buffer has a number of channels different from that needed for the ambisonics order specified when creating the effect.
 
 ### Added
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Add method `ProbeBatch::committed_num_probes`.
 - `SpeakerLayout` now implements `Clone` and `Display`.
 - Add `EffectError` for errors that can occur when applying audio effects.
+- `SteamAudioError` implements `PartialEq`, `Copy` and `Clone`.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -11,8 +11,11 @@
 - Fixed a segmentation fault caused by running a reflections simulation without having set a scene.
 - Fixed a segmentation fault when applying a direct effect on audio buffers that have a number of channels different from that specified when creating the effect.
 - Fixed a segmentation fault when calling `DirectEffect::tail` with an output buffer that has a number of channels different from that specified when creating the effect.
-- Fixed a segmentation fault when applying a pathing effect on an input buffer other than mono.
+- Fixed a segmentation fault when applying a pathing effect on an input buffer other than mono or passing an output buffer that has a number of channels different from that needed for the ambisonics order specified when creating the effect.
 - Fixed a segmentation fault when calling `PathEffect::tail` with an output buffer that has a number of channels other than that needed for the ambisonics order specified when creating the effect.
+- Fixed a segmentation fault when applying a reflection effect on an input buffer other than mono or with an output buffer that has a number of channels other than that of the impulse response specified when creating the effect.
+- Fixed a segmentation fault when calling `ReflectionEffect::tail` or `ReflectionEffect::tail_into_mixer` with an output buffer that has a number of channels other than that of the impulse response specified when creating the effect.
+- Fixed a segmentation fault where `ReflectionEffect::apply_into_mixer` was missing the output buffer.
 
 ### Changed
 
@@ -30,6 +33,9 @@
 - `DirectEffect::apply` now returns an `EffectError` when the input of output buffers have a number of channels different from that specified when creating the effect.
 - `PathEffect::apply` now returns an `EffectError` when the input buffer is not mono or the output buffer has a number of channels different from that needed for the ambisonics order specified when creating the effect.
 - `PathEffect::tail` now returns an `EffectError` when the output buffer has a number of channels different from that needed for the ambisonics order specified when creating the effect.
+- `ReflectionEffect::apply_into_mixer` takes an additional `output_buffer` argument.
+- `ReflectionEffect::apply` and `ReflectionEffect::apply_into_mixer` now return an `EffectError` when the input buffer is not mono or the output buffer has a number of channels other than that of the impulse response specified when creating the effect.
+- `ReflectionEffect::tail` and `ReflectionEffect::tail_into_mixer` now return an `EffectError` when the output buffer has a number of channels other than that of the impulse response specified when creating the effect.
 
 ### Added
 
@@ -44,6 +50,7 @@
 - `SpeakerLayout` now implements `Clone` and `Display`.
 - Add `EffectError` for errors that can occur when applying audio effects.
 - `SteamAudioError` implements `PartialEq`, `Copy` and `Clone`.
+- Add `ChannelRequirement` to specify the channel count requirement for an audio buffer.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect.
 - Fixed a segmentation fault when applying a virtual surround effect on an input buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect, or an output buffer that does not have two channels.
 - Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that does not have two channels.
+- Fixed a segmentation fault when applying an ambisonics encode effect on an input buffer does not have exactly one channel or an output buffer that does not have the correct number of channels for the ambisonics order.
+- Fixed a segmentation fault when calling `AmbisonicsEncodeEffect::tail` with an output buffer that does not have the correct number of channels for the ambisonics order.
 
 ### Changed
 
@@ -48,6 +50,8 @@
 - `PanningEffect::tail` now returns an `EffectError` when the output buffer has a number of channels different from that needed for the speaker layout specified when creating the effect.
 - `VirtualSurroundEfect::apply` now returns an `EffectError` when the input buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect, or the output buffer that does not have two channels.
 - `VirtualSurroundEffect::tail` now returns an `EffectError` when the output buffer does not have two channels.
+- `AmbisonicsEncodeEfect::apply` now returns an `EffectError` when the input buffer does not have exactly one channel or the output buffer that does not have the correct number of channels for the ambisonics order.
+- `AmbisonicsEncodeEffect::tail` now returns an `EffectError` when the output buffer that does not have the correct number of channels for the ambisonics order.
 
 ### Added
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -30,6 +30,8 @@
 - Fixed a segmentation fault when calling `AmbisonicsRotationEffect::tail` with an output buffer that does not have the correct number of channels for the ambisonics order.
 - Fixed a segmentation fault when applying an ambisonics panning effect on an input buffer that does not have the correct number of channels for the ambisonics order, or an output buffer that does not have the correct number of channels for the speaker layout specified when creating the effect.
 - Fixed a segmentation fault when calling `AmbisonicsPanningEffect::tail` with an output buffer that does not have the correct number of channels for the speaker layout specified when creating the effect.
+- Fixed a segmentation fault when applying an ambisonics binaural effect on an input buffer that does not have the correct number of channels for the ambisonics order, or an output buffer that does not have exactly two channels.
+- Fixed a segmentation fault when calling `AmbisonicsBinauralEffect::tail` with an output buffer that does not have exactly two channels.
 
 ### Changed
 
@@ -65,6 +67,8 @@
 - `AmbisonicsRotationEffect::tail` now returns an `EffectError` when the output buffer does not have the correct number of channels for the ambisonics order.
 - `AmbisonicsPanningEffect::apply` now returns an `EffectError` when the input buffer does not have the correct number of channels for the ambisonics order, or the output buffer does not have the correct number of channels for the speaker layout specified when creating the effect.
 - `AmbisonicsPanningEffect::tail` now returns an `EffectError` when the output buffer does not have the correct number of channels for the speaker layout specified when creating the effect.
+- `AmbisonicsBinauralEffect::apply` now returns an `EffectError` when the input buffer does not have the correct number of channels for the ambisonics order, or the output buffer does not have exactly two channels.
+- `AmbisonicsBinauralEffect::tail` now returns an `EffectError` when the output buffer does not have exactly two channels.
 
 ### Added
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -11,18 +11,18 @@
 - Fixed a segmentation fault caused by running a reflections simulation without having set a scene.
 - Fixed a segmentation fault when applying a direct effect on audio buffers that have a number of channels different from that specified when creating the effect.
 - Fixed a segmentation fault when calling `DirectEffect::tail` with an output buffer that has a number of channels different from that specified when creating the effect.
-- Fixed a segmentation fault when applying a pathing effect on an input buffer other than mono or passing an output buffer that has a number of channels different from that needed for the ambisonics order specified when creating the effect.
+- Fixed a segmentation fault when applying a pathing effect on an input buffer that is not mono or passing an output buffer that has a number of channels different from that needed for the ambisonics order specified when creating the effect.
 - Fixed a segmentation fault when calling `PathEffect::tail` with an output buffer that has a number of channels other than that needed for the ambisonics order specified when creating the effect.
-- Fixed a segmentation fault when applying a reflection effect on an input buffer other than mono or with an output buffer that has a number of channels other than that of the impulse response specified when creating the effect.
-- Fixed a segmentation fault when calling `ReflectionEffect::tail` or `ReflectionEffect::tail_into_mixer` with an output buffer that has a number of channels other than that of the impulse response specified when creating the effect.
+- Fixed a segmentation fault when applying a reflection effect on an input buffer that is not mono or with an output buffer that has a number of channels other than that of the impulse response (or at least one channel for parametric reflections) specified when creating the effect.
+- Fixed a segmentation fault when calling `ReflectionEffect::tail` or `ReflectionEffect::tail_into_mixer` with an output buffer that has a number of channels other than that of the impulse response (or at least one channel for parametric reflections) specified when creating the effect.
 - Fixed a segmentation fault where `ReflectionEffect::apply_into_mixer` was missing the output buffer.
-- Fixed a segmentation fault when applying a binaural effect on an input buffer other than mono or stereo, or passing an output buffer that has more than two channels.
+- Fixed a segmentation fault when applying a binaural effect on an input buffer that is not mono or stereo, or passing an output buffer that has more than two channels.
 - Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that has more than two channels.
-- Fixed a segmentation fault when applying a panning effect on an input buffer other than mono, or passing an output buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect.
-- Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect.
+- Fixed a segmentation fault when applying a panning effect on an input buffer that is not mono, or passing an output buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect.
+- Fixed a segmentation fault when calling `PanningEffect::tail` with an output buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect.
 - Fixed a segmentation fault when applying a virtual surround effect on an input buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect, or an output buffer that does not have two channels.
-- Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that does not have two channels.
-- Fixed a segmentation fault when applying an ambisonics encode effect on an input buffer does not have exactly one channel or an output buffer that does not have the correct number of channels for the ambisonics order.
+- Fixed a segmentation fault when calling `VirtualSurroundEffect::tail` with an output buffer that does not have two channels.
+- Fixed a segmentation fault when applying an ambisonics encode effect on an input buffer that does not have exactly one channel or an output buffer that does not have the correct number of channels for the ambisonics order.
 - Fixed a segmentation fault when calling `AmbisonicsEncodeEffect::tail` with an output buffer that does not have the correct number of channels for the ambisonics order.
 - Fixed a segmentation fault when applying an ambisonics decode effect on an input buffer that does not have the correct number of channels for the ambisonics order, or an output buffer that does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
 - Fixed a segmentation fault when calling `AmbisonicsDecodeEffect::tail` with an output buffer that does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
@@ -35,10 +35,10 @@
 
 ### Changed
 
-- Mark `air_absorption` function as `unsafe` since it calls `iplAirAbsorptionCalculate` which causes a segfault when using a callback.
+- Mark the `air_absorption` function as `unsafe` since it calls `iplAirAbsorptionCalculate` which causes a segfault when using a callback.
 - Improved documentation and added examples.
 - Make `NUM_BANDS` constant private.
-- Rename the `null` methods of `EmbreeDevice`, `OpenClDevice`, `RadeonRaysDevice` and `TrueAudioNextDevice` into `try_new` for consistency.
+- Rename the `null` methods of `EmbreeDevice`, `OpenClDevice`, `RadeonRaysDevice` and `TrueAudioNextDevice` to `try_new` for consistency.
 - `InstancedMeshSettings` now takes a reference to the sub-scene.
 - `Scene::add_static_mesh` and `Scene::add_instanced_mesh` now return handles.
 - `Scene::remove_static_mesh` and `Scene::remove_instanced_mesh` now take handles as arguments instead of references to `StaticMesh` and `InstancedMesh`.
@@ -46,20 +46,20 @@
 - `Simulator::run_pathing` now returns an error if the simulator contains no probes.
 - `ProbeBatch::commit` now takes `&mut self` instead of `&self`.
 - `Simulator::run_reflections` now returns an error if a scene has not been set and committed to the simulator.
-- `DirectEffect::apply` now returns an `EffectError` when the input of output buffers have a number of channels different from that specified when creating the effect.
+- `DirectEffect::apply` now returns an `EffectError` when the input or output buffers have a number of channels different from that specified when creating the effect.
 - `PathEffect::apply` now returns an `EffectError` when the input buffer is not mono or the output buffer has a number of channels different from that needed for the ambisonics order specified when creating the effect.
 - `PathEffect::tail` now returns an `EffectError` when the output buffer has a number of channels different from that needed for the ambisonics order specified when creating the effect.
 - `ReflectionEffect::apply_into_mixer` takes an additional `output_buffer` argument.
-- `ReflectionEffect::apply` and `ReflectionEffect::apply_into_mixer` now return an `EffectError` when the input buffer is not mono or the output buffer has a number of channels other than that of the impulse response specified when creating the effect.
-- `ReflectionEffect::tail` and `ReflectionEffect::tail_into_mixer` now return an `EffectError` when the output buffer has a number of channels other than that of the impulse response specified when creating the effect.
+- `ReflectionEffect::apply` and `ReflectionEffect::apply_into_mixer` now return an `EffectError` when the input buffer is not mono or the output buffer has a number of channels other than that of the impulse response (or at least one channel for parametric reflections) specified when creating the effect.
+- `ReflectionEffect::tail` and `ReflectionEffect::tail_into_mixer` now return an `EffectError` when the output buffer has a number of channels other than that of the impulse response (or at least one channel for parametric reflections) specified when creating the effect.
 - `BinauralEffect::apply` now returns an `EffectError` when the input buffer is not mono or stereo, or the output buffer has more than two channels.
 - `BinauralEffect::tail` now returns an `EffectError` when the output buffer has more than two channels.
 - `PanningEffect::apply` now returns an `EffectError` when the input buffer is not mono, or the output buffer has a number of channels different from that needed for the speaker layout specified when creating the effect.
 - `PanningEffect::tail` now returns an `EffectError` when the output buffer has a number of channels different from that needed for the speaker layout specified when creating the effect.
-- `VirtualSurroundEfect::apply` now returns an `EffectError` when the input buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect, or the output buffer that does not have two channels.
+- `VirtualSurroundEffect::apply` now returns an `EffectError` when the input buffer has a number of channels different from that needed for the speaker layout specified when creating the effect, or the output buffer does not have two channels.
 - `VirtualSurroundEffect::tail` now returns an `EffectError` when the output buffer does not have two channels.
-- `AmbisonicsEncodeEfect::apply` now returns an `EffectError` when the input buffer does not have exactly one channel or the output buffer that does not have the correct number of channels for the ambisonics order.
-- `AmbisonicsEncodeEffect::tail` now returns an `EffectError` when the output buffer that does not have the correct number of channels for the ambisonics order.
+- `AmbisonicsEncodeEffect::apply` now returns an `EffectError` when the input buffer does not have exactly one channel or the output buffer does not have the correct number of channels for the ambisonics order.
+- `AmbisonicsEncodeEffect::tail` now returns an `EffectError` when the output buffer does not have the correct number of channels for the ambisonics order.
 - `AmbisonicsDecodeEffect::apply` now returns an `EffectError` when the input buffer does not have the correct number of channels for the ambisonics order, or the output buffer does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
 - `AmbisonicsDecodeEffect::tail` now returns an `EffectError` when the output buffer does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
 - `AmbisonicsDecodeEffectParams::binaural` field removed and added field `AmbisonicsDecodeEffectSettings::rendering` in order to validate output buffers in `AmbisonicsDecodeEffect::tail`.

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Fixed a segmentation fault caused by running a pathing simulation without probes.
 - Fixed a segmentation fault caused by running a reflections simulation without having set a scene.
 - Fixed a segmentation fault when applying a direct effect on audio buffers that have a number of channels different from that specified when creating the effect.
+- Fixed a segmentation fault when applying a pathing effect on an input buffer other than mono.
+- Fixed a segmentation fault when applying a pathing effect with an output buffer that has a number of channels other than that needed for the ambisonics order specified when creating the effect.
 
 ### Changed
 
@@ -25,6 +27,7 @@
 - `ProbeBatch::commit` now takes `&mut self` instead of `&self`.
 - `Simulator::run_reflections` now returns an error if a scene has not been set and committed to the simulator.
 - `DirectEffect::apply` now returns an `EffectError` when the input of output buffers have a number of channels different from that specified when creating the effect.
+- `PathEffect::apply` now returns an `EffectError` when the input buffer is not mono or the output buffer has a number of channels different from that needed for the ambisonics order specified when creating the effect.
 
 ### Added
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed a segmentation fault when applying a reflection effect on an input buffer that is not mono or with an output buffer that has a number of channels other than that of the impulse response (or at least one channel for parametric reflections) specified when creating the effect.
 - Fixed a segmentation fault when calling `ReflectionEffect::tail` or `ReflectionEffect::tail_into_mixer` with an output buffer that has a number of channels other than that of the impulse response (or at least one channel for parametric reflections) specified when creating the effect.
 - Fixed a segmentation fault where `ReflectionEffect::apply_into_mixer` was missing the output buffer.
+- Fixed a segmentation fault when applying a reflection mixer with an output buffer that has a number of channels other than that of the impulse response (or at least one channel for parametric reflections) specified when creating the mixer.
 - Fixed a segmentation fault when applying a binaural effect on an input buffer that is not mono or stereo, or passing an output buffer that has more than two channels.
 - Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that has more than two channels.
 - Fixed a segmentation fault when applying a panning effect on an input buffer that is not mono, or passing an output buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect.
@@ -52,6 +53,7 @@
 - `ReflectionEffect::apply_into_mixer` takes an additional `output_buffer` argument.
 - `ReflectionEffect::apply` and `ReflectionEffect::apply_into_mixer` now return an `EffectError` when the input buffer is not mono or the output buffer has a number of channels other than that of the impulse response (or at least one channel for parametric reflections) specified when creating the effect.
 - `ReflectionEffect::tail` and `ReflectionEffect::tail_into_mixer` now return an `EffectError` when the output buffer has a number of channels other than that of the impulse response (or at least one channel for parametric reflections) specified when creating the effect.
+- `ReflectionMixer::apply` now returns an `EffectError` when the output buffer has a number of channels other than that of the impulse response (or at least one channel for parametric reflections) specified when creating the mixer.
 - `BinauralEffect::apply` now returns an `EffectError` when the input buffer is not mono or stereo, or the output buffer has more than two channels.
 - `BinauralEffect::tail` now returns an `EffectError` when the output buffer has more than two channels.
 - `PanningEffect::apply` now returns an `EffectError` when the input buffer is not mono, or the output buffer has a number of channels different from that needed for the speaker layout specified when creating the effect.

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -10,8 +10,9 @@
 - Fixed a segmentation fault caused by running a pathing simulation without probes.
 - Fixed a segmentation fault caused by running a reflections simulation without having set a scene.
 - Fixed a segmentation fault when applying a direct effect on audio buffers that have a number of channels different from that specified when creating the effect.
+- Fixed a segmentation fault when calling `DirectEffect::tail` with an output buffer that has a number of channels different from that specified when creating the effect.
 - Fixed a segmentation fault when applying a pathing effect on an input buffer other than mono.
-- Fixed a segmentation fault when applying a pathing effect with an output buffer that has a number of channels other than that needed for the ambisonics order specified when creating the effect.
+- Fixed a segmentation fault when calling `PathEffect::tail` with an output buffer that has a number of channels other than that needed for the ambisonics order specified when creating the effect.
 
 ### Changed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -26,6 +26,8 @@
 - Fixed a segmentation fault when calling `AmbisonicsEncodeEffect::tail` with an output buffer that does not have the correct number of channels for the ambisonics order.
 - Fixed a segmentation fault when applying an ambisonics decode effect on an input buffer that does not have the correct number of channels for the ambisonics order, or an output buffer that does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
 - Fixed a segmentation fault when calling `AmbisonicsDecodeEffect::tail` with an output buffer that does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
+- Fixed a segmentation fault when applying an ambisonics rotation effect on an input buffer that does not have the correct number of channels for the ambisonics order, or an output buffer that does not have the correct number of channels for the ambisonics order.
+- Fixed a segmentation fault when calling `AmbisonicsRotationEffect::tail` with an output buffer that does not have the correct number of channels for the ambisonics order.
 
 ### Changed
 
@@ -57,6 +59,8 @@
 - `AmbisonicsDecodeEffect::apply` now returns an `EffectError` when the input buffer does not have the correct number of channels for the ambisonics order, or the output buffer does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
 - `AmbisonicsDecodeEffect::tail` now returns an `EffectError` when the output buffer does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
 - `AmbisonicsDecodeEffectParams::binaural` field removed and added field `AmbisonicsDecodeEffectSettings::rendering` in order to validate output buffers in `AmbisonicsDecodeEffect::tail`.
+- `AmbisonicsRotationEffect::apply` now returns an `EffectError` when the input buffer does not have the correct number of channels for the ambisonics order, or the output buffer does not have the correct number of channels for the ambisonics order.
+- `AmbisonicsRotationEffect::tail` now returns an `EffectError` when the output buffer does not have the correct number of channels for the ambisonics order.
 
 ### Added
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that has more than two channels.
 - Fixed a segmentation fault when applying a panning effect on an input buffer other than mono, or passing an output buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect.
 - Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect.
+- Fixed a segmentation fault when applying a virtual surround effect on an input buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect, or an output buffer that does not have two channels.
+- Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that does not have two channels.
 
 ### Changed
 
@@ -44,6 +46,8 @@
 - `BinauralEffect::tail` now returns an `EffectError` when the output buffer has more than two channels.
 - `PanningEffect::apply` now returns an `EffectError` when the input buffer is not mono, or the output buffer has a number of channels different from that needed for the speaker layout specified when creating the effect.
 - `PanningEffect::tail` now returns an `EffectError` when the output buffer has a number of channels different from that needed for the speaker layout specified when creating the effect.
+- `VirtualSurroundEfect::apply` now returns an `EffectError` when the input buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect, or the output buffer that does not have two channels.
+- `VirtualSurroundEffect::tail` now returns an `EffectError` when the output buffer does not have two channels.
 
 ### Added
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -24,6 +24,8 @@
 - Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that does not have two channels.
 - Fixed a segmentation fault when applying an ambisonics encode effect on an input buffer does not have exactly one channel or an output buffer that does not have the correct number of channels for the ambisonics order.
 - Fixed a segmentation fault when calling `AmbisonicsEncodeEffect::tail` with an output buffer that does not have the correct number of channels for the ambisonics order.
+- Fixed a segmentation fault when applying an ambisonics decode effect on an input buffer that does not have the correct number of channels for the ambisonics order, or an output buffer that does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
+- Fixed a segmentation fault when calling `AmbisonicsDecodeEffect::tail` with an output buffer that does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
 
 ### Changed
 
@@ -52,6 +54,9 @@
 - `VirtualSurroundEffect::tail` now returns an `EffectError` when the output buffer does not have two channels.
 - `AmbisonicsEncodeEfect::apply` now returns an `EffectError` when the input buffer does not have exactly one channel or the output buffer that does not have the correct number of channels for the ambisonics order.
 - `AmbisonicsEncodeEffect::tail` now returns an `EffectError` when the output buffer that does not have the correct number of channels for the ambisonics order.
+- `AmbisonicsDecodeEffect::apply` now returns an `EffectError` when the input buffer does not have the correct number of channels for the ambisonics order, or the output buffer does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
+- `AmbisonicsDecodeEffect::tail` now returns an `EffectError` when the output buffer does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
+- `AmbisonicsDecodeEffectParams::binaural` field removed and added field `AmbisonicsDecodeEffectSettings::rendering` in order to validate output buffers in `AmbisonicsDecodeEffect::tail`.
 
 ### Added
 
@@ -67,6 +72,7 @@
 - Add `EffectError` for errors that can occur when applying audio effects.
 - `SteamAudioError` implements `PartialEq`, `Copy` and `Clone`.
 - Add `ChannelRequirement` to specify the channel count requirement for an audio buffer.
+- Add `Rendering` enum to choose between decoding ambisonics using binaural rendering or panning.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Fixed a segmentation fault where `ReflectionEffect::apply_into_mixer` was missing the output buffer.
 - Fixed a segmentation fault when applying a binaural effect on an input buffer other than mono or stereo, or passing an output buffer that has more than two channels.
 - Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that has more than two channels.
+- Fixed a segmentation fault when applying a panning effect on an input buffer other than mono, or passing an output buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect.
+- Fixed a segmentation fault when calling `BinauralEffect::tail` with an output buffer that has a number of channels different from that needed for the speaker layout specified when creating the effect.
 
 ### Changed
 
@@ -39,7 +41,9 @@
 - `ReflectionEffect::apply` and `ReflectionEffect::apply_into_mixer` now return an `EffectError` when the input buffer is not mono or the output buffer has a number of channels other than that of the impulse response specified when creating the effect.
 - `ReflectionEffect::tail` and `ReflectionEffect::tail_into_mixer` now return an `EffectError` when the output buffer has a number of channels other than that of the impulse response specified when creating the effect.
 - `BinauralEffect::apply` now returns an `EffectError` when the input buffer is not mono or stereo, or the output buffer has more than two channels.
-- `BinauralEffect::tail` now returns an `EffectError` when the output buffer has more than two channels
+- `BinauralEffect::tail` now returns an `EffectError` when the output buffer has more than two channels.
+- `PanningEffect::apply` now returns an `EffectError` when the input buffer is not mono, or the output buffer has a number of channels different from that needed for the speaker layout specified when creating the effect.
+- `PanningEffect::tail` now returns an `EffectError` when the output buffer has a number of channels different from that needed for the speaker layout specified when creating the effect.
 
 ### Added
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Fixed a segmentation fault when calling `AmbisonicsDecodeEffect::tail` with an output buffer that does not have the correct number of channels for the speaker layout (or two channels for binaural) specified when creating the effect.
 - Fixed a segmentation fault when applying an ambisonics rotation effect on an input buffer that does not have the correct number of channels for the ambisonics order, or an output buffer that does not have the correct number of channels for the ambisonics order.
 - Fixed a segmentation fault when calling `AmbisonicsRotationEffect::tail` with an output buffer that does not have the correct number of channels for the ambisonics order.
+- Fixed a segmentation fault when applying an ambisonics panning effect on an input buffer that does not have the correct number of channels for the ambisonics order, or an output buffer that does not have the correct number of channels for the speaker layout specified when creating the effect.
+- Fixed a segmentation fault when calling `AmbisonicsPanningEffect::tail` with an output buffer that does not have the correct number of channels for the speaker layout specified when creating the effect.
 
 ### Changed
 
@@ -61,6 +63,8 @@
 - `AmbisonicsDecodeEffectParams::binaural` field removed and added field `AmbisonicsDecodeEffectSettings::rendering` in order to validate output buffers in `AmbisonicsDecodeEffect::tail`.
 - `AmbisonicsRotationEffect::apply` now returns an `EffectError` when the input buffer does not have the correct number of channels for the ambisonics order, or the output buffer does not have the correct number of channels for the ambisonics order.
 - `AmbisonicsRotationEffect::tail` now returns an `EffectError` when the output buffer does not have the correct number of channels for the ambisonics order.
+- `AmbisonicsPanningEffect::apply` now returns an `EffectError` when the input buffer does not have the correct number of channels for the ambisonics order, or the output buffer does not have the correct number of channels for the speaker layout specified when creating the effect.
+- `AmbisonicsPanningEffect::tail` now returns an `EffectError` when the output buffer does not have the correct number of channels for the speaker layout specified when creating the effect.
 
 ### Added
 

--- a/audionimbus/src/audio_buffer.rs
+++ b/audionimbus/src/audio_buffer.rs
@@ -648,6 +648,36 @@ pub const fn num_ambisonics_channels(order: u32) -> u32 {
     (order + 1) * (order + 1)
 }
 
+/// Describes the channel count requirement for an audio buffer.
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum ChannelRequirement {
+    Exactly(u32),
+    AtLeast(u32),
+}
+
+impl ChannelRequirement {
+    /// Returns whether a number satisfies this requirement.
+    pub fn is_satisfied_by(&self, actual: u32) -> bool {
+        match *self {
+            ChannelRequirement::Exactly(num_channels) => actual == num_channels,
+            ChannelRequirement::AtLeast(num_channels) => actual >= num_channels,
+        }
+    }
+}
+
+impl std::fmt::Display for ChannelRequirement {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Exactly(num_channels) => {
+                write!(f, "exactly {}", num_channels,)
+            }
+            Self::AtLeast(num_channels) => {
+                write!(f, "at least {}", num_channels,)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1088,6 +1118,18 @@ mod tests {
 
             let result = allocate_channel_ptrs(&data, settings);
             assert!(result.is_err());
+        }
+    }
+
+    mod channel_requirement {
+        use super::*;
+
+        #[test]
+        fn test_is_satisfied_by() {
+            assert!(ChannelRequirement::Exactly(2).is_satisfied_by(2));
+            assert!(!ChannelRequirement::Exactly(2).is_satisfied_by(1));
+            assert!(ChannelRequirement::AtLeast(2).is_satisfied_by(3));
+            assert!(!ChannelRequirement::AtLeast(2).is_satisfied_by(1));
         }
     }
 }

--- a/audionimbus/src/audio_buffer.rs
+++ b/audionimbus/src/audio_buffer.rs
@@ -651,16 +651,23 @@ pub const fn num_ambisonics_channels(order: u32) -> u32 {
 /// Describes the channel count requirement for an audio buffer.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum ChannelRequirement {
+    /// The buffer must have exactly this many channels.
     Exactly(u32),
+
+    /// The buffer must have at least this many channels.
     AtLeast(u32),
+
+    /// The buffer must have a channel count within the given inclusive range.
+    Range { min: u32, max: u32 },
 }
 
 impl ChannelRequirement {
-    /// Returns whether a number satisfies this requirement.
+    /// Returns whether a number of channels satisfies this requirement.
     pub fn is_satisfied_by(&self, actual: u32) -> bool {
         match *self {
             ChannelRequirement::Exactly(num_channels) => actual == num_channels,
             ChannelRequirement::AtLeast(num_channels) => actual >= num_channels,
+            ChannelRequirement::Range { min, max } => (min..=max).contains(&actual),
         }
     }
 }
@@ -669,10 +676,13 @@ impl std::fmt::Display for ChannelRequirement {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::Exactly(num_channels) => {
-                write!(f, "exactly {}", num_channels,)
+                write!(f, "exactly {}", num_channels)
             }
             Self::AtLeast(num_channels) => {
-                write!(f, "at least {}", num_channels,)
+                write!(f, "at least {}", num_channels)
+            }
+            Self::Range { min, max } => {
+                write!(f, "between {} and {} (inclusive)", min, max)
             }
         }
     }
@@ -1130,6 +1140,8 @@ mod tests {
             assert!(!ChannelRequirement::Exactly(2).is_satisfied_by(1));
             assert!(ChannelRequirement::AtLeast(2).is_satisfied_by(3));
             assert!(!ChannelRequirement::AtLeast(2).is_satisfied_by(1));
+            assert!(ChannelRequirement::Range { min: 1, max: 4 }.is_satisfied_by(3));
+            assert!(!ChannelRequirement::Range { min: 1, max: 4 }.is_satisfied_by(5));
         }
     }
 }

--- a/audionimbus/src/effect/ambisonics/decode.rs
+++ b/audionimbus/src/effect/ambisonics/decode.rs
@@ -1,6 +1,4 @@
-use super::super::AudioEffectState;
-use super::super::EffectError;
-use super::SpeakerLayout;
+use super::super::{AudioEffectState, EffectError, SpeakerLayout};
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::context::Context;

--- a/audionimbus/src/effect/ambisonics/decode.rs
+++ b/audionimbus/src/effect/ambisonics/decode.rs
@@ -1,13 +1,14 @@
 use super::super::AudioEffectState;
+use super::super::EffectError;
 use super::SpeakerLayout;
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::context::Context;
 use crate::error::{to_option_error, SteamAudioError};
-use crate::ffi_wrapper::FFIWrapper;
 use crate::geometry::CoordinateSystem;
 use crate::hrtf::Hrtf;
-use crate::ChannelPointers;
+use crate::num_ambisonics_channels;
+use crate::{ChannelPointers, ChannelRequirement};
 
 /// Applies a rotation to an ambisonics audio buffer, then decodes it using panning or binaural rendering.
 ///
@@ -29,6 +30,7 @@ use crate::ChannelPointers;
 ///         speaker_layout: SpeakerLayout::Stereo,
 ///         hrtf: &hrtf,
 ///         max_order: 1,
+///         rendering: Rendering::Binaural,
 ///     }
 /// )?;
 ///
@@ -36,7 +38,6 @@ use crate::ChannelPointers;
 ///     order: 1,
 ///     hrtf: &hrtf,
 ///     orientation: CoordinateSystem::default(),
-///     binaural: true,
 /// };
 ///
 /// const FRAME_SIZE: usize = 1024;
@@ -55,7 +56,18 @@ use crate::ChannelPointers;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug)]
-pub struct AmbisonicsDecodeEffect(audionimbus_sys::IPLAmbisonicsDecodeEffect);
+pub struct AmbisonicsDecodeEffect {
+    inner: audionimbus_sys::IPLAmbisonicsDecodeEffect,
+
+    /// Ambisonics order specified when creating the effect.
+    max_order: u32,
+
+    /// Number of output channels required.
+    num_output_channels: u32,
+
+    /// Whether the effect uses binaural rendering or panning.
+    rendering: Rendering,
+}
 
 impl AmbisonicsDecodeEffect {
     /// Creates a new ambisonics decode effect.
@@ -68,7 +80,7 @@ impl AmbisonicsDecodeEffect {
         audio_settings: &AudioSettings,
         ambisonics_decode_effect_settings: &AmbisonicsDecodeEffectSettings,
     ) -> Result<Self, SteamAudioError> {
-        let mut ambisonics_decode_effect = Self(std::ptr::null_mut());
+        let mut inner = std::ptr::null_mut();
 
         let status = unsafe {
             audionimbus_sys::iplAmbisonicsDecodeEffectCreate(
@@ -77,7 +89,7 @@ impl AmbisonicsDecodeEffect {
                 &mut audionimbus_sys::IPLAmbisonicsDecodeEffectSettings::from(
                     ambisonics_decode_effect_settings,
                 ),
-                ambisonics_decode_effect.raw_ptr_mut(),
+                &mut inner,
             )
         };
 
@@ -85,40 +97,95 @@ impl AmbisonicsDecodeEffect {
             return Err(error);
         }
 
+        let num_output_channels = match ambisonics_decode_effect_settings.rendering {
+            Rendering::Binaural => 2,
+            Rendering::Panning => match &ambisonics_decode_effect_settings.speaker_layout {
+                SpeakerLayout::Mono => 1,
+                SpeakerLayout::Stereo => 2,
+                SpeakerLayout::Quadraphonic => 4,
+                SpeakerLayout::Surround5_1 => 6,
+                SpeakerLayout::Surround7_1 => 8,
+                SpeakerLayout::Custom { speaker_directions } => speaker_directions.len() as u32,
+            },
+        };
+
+        let ambisonics_decode_effect = Self {
+            inner,
+            max_order: ambisonics_decode_effect_settings.max_order,
+            num_output_channels,
+            rendering: ambisonics_decode_effect_settings.rendering,
+        };
+
         Ok(ambisonics_decode_effect)
     }
 
     /// Applies an ambisonics decode effect to an audio buffer.
     ///
     /// This effect CANNOT be applied in-place.
+    ///
+    /// The input audio buffer must have as many channels as needed for the Ambisonics order used
+    /// (see [`num_ambisonics_channels`]).
+    /// The output audio buffer must have:
+    /// - 2 channels if using binaural rendering
+    /// - As many channels as needed for the speaker layout if using panning
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EffectError`] if:
+    /// - The input buffer does not have the correct number of channels for the Ambisonics order
+    /// - The output buffer does not have the correct number of channels (i.e., two channels if
+    ///   using binaural rendering, or as many channels as needed for the speaker layout if using
+    ///   panning).
     pub fn apply<I, O, PI: ChannelPointers, PO: ChannelPointers>(
         &mut self,
         ambisonics_decode_effect_params: &AmbisonicsDecodeEffectParams,
         input_buffer: &AudioBuffer<I, PI>,
         output_buffer: &AudioBuffer<O, PO>,
-    ) -> AudioEffectState
+    ) -> Result<AudioEffectState, EffectError>
     where
         I: AsRef<[Sample]>,
         O: AsRef<[Sample]> + AsMut<[Sample]>,
     {
-        let required_num_channels = (ambisonics_decode_effect_params.order + 1).pow(2);
-        assert_eq!(
-            input_buffer.num_channels(),
-            required_num_channels,
-            "ambisonic order N = {} requires (N + 1)^2 = {} input channels",
-            ambisonics_decode_effect_params.order,
-            required_num_channels
-        );
+        let required_input_channels = num_ambisonics_channels(self.max_order);
+        let num_input_channels = input_buffer.num_channels();
+        if num_input_channels != required_input_channels {
+            return Err(EffectError::InvalidAmbisonicOrder {
+                order: ambisonics_decode_effect_params.order,
+                buffer_channels: num_input_channels,
+                required_channels: required_input_channels,
+            });
+        }
 
-        unsafe {
+        let num_output_channels = output_buffer.num_channels();
+        if num_output_channels != self.num_output_channels {
+            return Err(EffectError::InvalidOutputChannels {
+                expected: ChannelRequirement::Exactly(self.num_output_channels),
+                actual: num_output_channels,
+            });
+        }
+
+        let mut ambisonics_decode_effect_params_ffi =
+            audionimbus_sys::IPLAmbisonicsDecodeEffectParams {
+                order: ambisonics_decode_effect_params.order as i32,
+                hrtf: ambisonics_decode_effect_params.hrtf.raw_ptr(),
+                orientation: ambisonics_decode_effect_params.orientation.into(),
+                binaural: match self.rendering {
+                    Rendering::Binaural => audionimbus_sys::IPLbool::IPL_TRUE,
+                    Rendering::Panning => audionimbus_sys::IPLbool::IPL_FALSE,
+                },
+            };
+
+        let state = unsafe {
             audionimbus_sys::iplAmbisonicsDecodeEffectApply(
                 self.raw_ptr(),
-                &mut *ambisonics_decode_effect_params.as_ffi(),
+                &mut ambisonics_decode_effect_params_ffi,
                 &mut *input_buffer.as_ffi(),
                 &mut *output_buffer.as_ffi(),
             )
         }
-        .into()
+        .into();
+
+        Ok(state)
     }
 
     /// Retrieves a single frame of tail samples from an Ambisonics decode effect’s internal buffers.
@@ -126,17 +193,32 @@ impl AmbisonicsDecodeEffect {
     /// After the input to the Ambisonics decode effect has stopped, this function must be called instead of [`Self::apply`] until the return value indicates that no more tail samples remain.
     ///
     /// The output audio buffer must have as many channels as needed for the speaker layout specified when creating the effect (if using panning) or 2 channels (if using binaural rendering).
-    pub fn tail<O>(&self, output_buffer: &AudioBuffer<O>) -> AudioEffectState
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EffectError`] if the output buffer does not have the correct number of channels (i.e., two channels if
+    /// using binaural rendering, or as many channels as needed for the speaker layout if using panning).
+    pub fn tail<O>(&self, output_buffer: &AudioBuffer<O>) -> Result<AudioEffectState, EffectError>
     where
         O: AsRef<[Sample]> + AsMut<[Sample]>,
     {
-        unsafe {
+        let num_output_channels = output_buffer.num_channels();
+        if num_output_channels != self.num_output_channels {
+            return Err(EffectError::InvalidOutputChannels {
+                expected: ChannelRequirement::Exactly(self.num_output_channels),
+                actual: num_output_channels,
+            });
+        }
+
+        let state = unsafe {
             audionimbus_sys::iplAmbisonicsDecodeEffectGetTail(
                 self.raw_ptr(),
                 &mut *output_buffer.as_ffi(),
             )
         }
-        .into()
+        .into();
+
+        Ok(state)
     }
 
     /// Returns the number of tail samples remaining in an Ambisonics decode effect’s internal buffers.
@@ -155,35 +237,35 @@ impl AmbisonicsDecodeEffect {
     ///
     /// This is intended for internal use and advanced scenarios.
     pub fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsDecodeEffect {
-        self.0
+        self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
     pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsDecodeEffect {
-        &mut self.0
-    }
-}
-
-impl From<audionimbus_sys::IPLAmbisonicsDecodeEffect> for AmbisonicsDecodeEffect {
-    fn from(ptr: audionimbus_sys::IPLAmbisonicsDecodeEffect) -> Self {
-        Self(ptr)
+        &mut self.inner
     }
 }
 
 impl Clone for AmbisonicsDecodeEffect {
     fn clone(&self) -> Self {
         unsafe {
-            audionimbus_sys::iplAmbisonicsDecodeEffectRetain(self.0);
+            audionimbus_sys::iplAmbisonicsDecodeEffectRetain(self.inner);
         }
-        Self(self.0)
+
+        Self {
+            inner: self.inner,
+            max_order: self.max_order,
+            num_output_channels: self.num_output_channels,
+            rendering: self.rendering,
+        }
     }
 }
 
 impl Drop for AmbisonicsDecodeEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplAmbisonicsDecodeEffectRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplAmbisonicsDecodeEffectRelease(&mut self.inner) }
     }
 }
 
@@ -201,6 +283,9 @@ pub struct AmbisonicsDecodeEffectSettings<'a> {
 
     /// The maximum ambisonics order that will be used by input audio buffers.
     pub max_order: u32,
+
+    /// Whether to use binaural rendering or panning.
+    pub rendering: Rendering,
 }
 
 impl From<&AmbisonicsDecodeEffectSettings<'_>>
@@ -228,26 +313,273 @@ pub struct AmbisonicsDecodeEffectParams<'a> {
 
     /// The orientation of the listener.
     pub orientation: CoordinateSystem,
-
-    /// Whether to use binaural rendering or panning.
-    pub binaural: bool,
 }
 
-impl AmbisonicsDecodeEffectParams<'_> {
-    pub(crate) fn as_ffi(
-        &self,
-    ) -> FFIWrapper<'_, audionimbus_sys::IPLAmbisonicsDecodeEffectParams, Self> {
-        let ambisonics_decode_effect_params = audionimbus_sys::IPLAmbisonicsDecodeEffectParams {
-            order: self.order as i32,
-            hrtf: self.hrtf.raw_ptr(),
-            orientation: self.orientation.into(),
-            binaural: if self.binaural {
-                audionimbus_sys::IPLbool::IPL_TRUE
-            } else {
-                audionimbus_sys::IPLbool::IPL_FALSE
-            },
-        };
+/// Rendering for the ambisonics decode effect.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Rendering {
+    /// Binaural rendering
+    Binaural,
 
-        FFIWrapper::new(ambisonics_decode_effect_params)
+    /// Panning
+    Panning,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::*;
+
+    mod apply {
+        use super::*;
+
+        #[test]
+        fn test_valid_first_order_binaural() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+            let hrtf_settings = HrtfSettings::default();
+            let hrtf = Hrtf::try_new(&context, &audio_settings, &hrtf_settings).unwrap();
+
+            let mut effect = AmbisonicsDecodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsDecodeEffectSettings {
+                    speaker_layout: SpeakerLayout::Stereo,
+                    hrtf: &hrtf,
+                    max_order: 1,
+                    rendering: Rendering::Binaural,
+                },
+            )
+            .unwrap();
+
+            let params = AmbisonicsDecodeEffectParams {
+                order: 1,
+                hrtf: &hrtf,
+                orientation: CoordinateSystem::default(),
+            };
+
+            let input = vec![0.5; 4 * 1024];
+            let input_buffer = AudioBuffer::try_with_data_and_settings(
+                &input,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 2 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(2),
+            )
+            .unwrap();
+
+            assert!(effect.apply(&params, &input_buffer, &output_buffer).is_ok());
+        }
+
+        #[test]
+        fn test_valid_first_order_panning() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+            let hrtf_settings = HrtfSettings::default();
+            let hrtf = Hrtf::try_new(&context, &audio_settings, &hrtf_settings).unwrap();
+
+            let mut effect = AmbisonicsDecodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsDecodeEffectSettings {
+                    speaker_layout: SpeakerLayout::Surround7_1,
+                    hrtf: &hrtf,
+                    max_order: 1,
+                    rendering: Rendering::Panning,
+                },
+            )
+            .unwrap();
+
+            let params = AmbisonicsDecodeEffectParams {
+                order: 1,
+                hrtf: &hrtf,
+                orientation: CoordinateSystem::default(),
+            };
+
+            let input = vec![0.5; 4 * 1024];
+            let input_buffer = AudioBuffer::try_with_data_and_settings(
+                &input,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 8 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(8),
+            )
+            .unwrap();
+
+            assert!(effect.apply(&params, &input_buffer, &output_buffer).is_ok());
+        }
+
+        #[test]
+        fn test_valid_invalid_input_channels() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+            let hrtf_settings = HrtfSettings::default();
+            let hrtf = Hrtf::try_new(&context, &audio_settings, &hrtf_settings).unwrap();
+
+            let mut effect = AmbisonicsDecodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsDecodeEffectSettings {
+                    speaker_layout: SpeakerLayout::Stereo,
+                    hrtf: &hrtf,
+                    max_order: 1,
+                    rendering: Rendering::Binaural,
+                },
+            )
+            .unwrap();
+
+            let params = AmbisonicsDecodeEffectParams {
+                order: 1,
+                hrtf: &hrtf,
+                orientation: CoordinateSystem::default(),
+            };
+
+            let input = vec![0.5; 2 * 1024];
+            let input_buffer = AudioBuffer::try_with_data_and_settings(
+                &input,
+                AudioBufferSettings::with_num_channels(2),
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 2 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(2),
+            )
+            .unwrap();
+
+            assert_eq!(
+                effect.apply(&params, &input_buffer, &output_buffer),
+                Err(EffectError::InvalidAmbisonicOrder {
+                    order: 1,
+                    buffer_channels: 2,
+                    required_channels: 4,
+                })
+            );
+        }
+
+        #[test]
+        fn test_valid_invalid_output_channels() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+            let hrtf_settings = HrtfSettings::default();
+            let hrtf = Hrtf::try_new(&context, &audio_settings, &hrtf_settings).unwrap();
+
+            let mut effect = AmbisonicsDecodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsDecodeEffectSettings {
+                    speaker_layout: SpeakerLayout::Stereo,
+                    hrtf: &hrtf,
+                    max_order: 1,
+                    rendering: Rendering::Binaural,
+                },
+            )
+            .unwrap();
+
+            let params = AmbisonicsDecodeEffectParams {
+                order: 1,
+                hrtf: &hrtf,
+                orientation: CoordinateSystem::default(),
+            };
+
+            let input = vec![0.5; 4 * 1024];
+            let input_buffer = AudioBuffer::try_with_data_and_settings(
+                &input,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 3 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(3),
+            )
+            .unwrap();
+
+            assert_eq!(
+                effect.apply(&params, &input_buffer, &output_buffer),
+                Err(EffectError::InvalidOutputChannels {
+                    expected: ChannelRequirement::Exactly(2),
+                    actual: 3,
+                })
+            );
+        }
+    }
+
+    mod tail {
+        use super::*;
+
+        #[test]
+        fn test_valid() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+            let hrtf_settings = HrtfSettings::default();
+            let hrtf = Hrtf::try_new(&context, &audio_settings, &hrtf_settings).unwrap();
+
+            let effect = AmbisonicsDecodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsDecodeEffectSettings {
+                    speaker_layout: SpeakerLayout::Stereo,
+                    hrtf: &hrtf,
+                    max_order: 1,
+                    rendering: Rendering::Binaural,
+                },
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 2 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(2),
+            )
+            .unwrap();
+
+            assert!(effect.tail(&output_buffer).is_ok());
+        }
+
+        #[test]
+        fn test_invalid_output_channels() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+            let hrtf_settings = HrtfSettings::default();
+            let hrtf = Hrtf::try_new(&context, &audio_settings, &hrtf_settings).unwrap();
+
+            let effect = AmbisonicsDecodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsDecodeEffectSettings {
+                    speaker_layout: SpeakerLayout::Stereo,
+                    hrtf: &hrtf,
+                    max_order: 1,
+                    rendering: Rendering::Binaural,
+                },
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 4 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            assert_eq!(
+                effect.tail(&output_buffer),
+                Err(EffectError::InvalidOutputChannels {
+                    expected: ChannelRequirement::Exactly(2),
+                    actual: 4,
+                })
+            );
+        }
     }
 }

--- a/audionimbus/src/effect/ambisonics/encode.rs
+++ b/audionimbus/src/effect/ambisonics/encode.rs
@@ -1,5 +1,4 @@
-use super::super::AudioEffectState;
-use super::super::EffectError;
+use super::super::{AudioEffectState, EffectError};
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::context::Context;

--- a/audionimbus/src/effect/ambisonics/encode.rs
+++ b/audionimbus/src/effect/ambisonics/encode.rs
@@ -148,6 +148,10 @@ impl AmbisonicsEncodeEffect {
     /// After the input to the Ambisonics encode effect has stopped, this function must be called instead of [`Self::apply`] until the return value indicates that no more tail samples remain.
     ///
     /// The output audio buffer must have as many channels as needed for the Ambisonics order specified when creating the effect.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EffectError`] if the output buffer does not have the correct number of channels for the Ambisonics order.
     pub fn tail<O>(&self, output_buffer: &AudioBuffer<O>) -> Result<AudioEffectState, EffectError>
     where
         O: AsRef<[Sample]> + AsMut<[Sample]>,

--- a/audionimbus/src/effect/ambisonics/encode.rs
+++ b/audionimbus/src/effect/ambisonics/encode.rs
@@ -1,11 +1,13 @@
 use super::super::AudioEffectState;
+use super::super::EffectError;
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::context::Context;
 use crate::error::{to_option_error, SteamAudioError};
 use crate::ffi_wrapper::FFIWrapper;
 use crate::geometry::Direction;
-use crate::ChannelPointers;
+use crate::num_ambisonics_channels;
+use crate::{ChannelPointers, ChannelRequirement};
 
 /// Encodes a point source into ambisonics.
 ///
@@ -45,7 +47,12 @@ use crate::ChannelPointers;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug)]
-pub struct AmbisonicsEncodeEffect(audionimbus_sys::IPLAmbisonicsEncodeEffect);
+pub struct AmbisonicsEncodeEffect {
+    inner: audionimbus_sys::IPLAmbisonicsEncodeEffect,
+
+    /// Ambisonics order specified when creating the effect.
+    max_order: u32,
+}
 
 impl AmbisonicsEncodeEffect {
     /// Creates a new ambisonics encode effect.
@@ -58,7 +65,7 @@ impl AmbisonicsEncodeEffect {
         audio_settings: &AudioSettings,
         ambisonics_encode_effect_settings: &AmbisonicsEncodeEffectSettings,
     ) -> Result<Self, SteamAudioError> {
-        let mut ambisonics_encode_effect = Self(std::ptr::null_mut());
+        let mut inner = std::ptr::null_mut();
 
         let status = unsafe {
             audionimbus_sys::iplAmbisonicsEncodeEffectCreate(
@@ -67,7 +74,7 @@ impl AmbisonicsEncodeEffect {
                 &mut audionimbus_sys::IPLAmbisonicsEncodeEffectSettings::from(
                     ambisonics_encode_effect_settings,
                 ),
-                ambisonics_encode_effect.raw_ptr_mut(),
+                &mut inner,
             )
         };
 
@@ -75,38 +82,55 @@ impl AmbisonicsEncodeEffect {
             return Err(error);
         }
 
+        let ambisonics_encode_effect = Self {
+            inner,
+            max_order: ambisonics_encode_effect_settings.max_order,
+        };
+
         Ok(ambisonics_encode_effect)
     }
 
     /// Applies an ambisonics encode effect to an audio buffer.
     ///
     /// This effect CANNOT be applied in-place.
+    ///
+    /// The input audio buffer must have 1 channel, and the output audio buffer must have as many
+    /// channels as needed for the Ambisonics order used (see [`crate::num_ambisonics_channels`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EffectError`] if:
+    /// - The input buffer does not have exactly 1 channel
+    /// - The output buffer does not have the correct number of channels for the Ambisonics order
     pub fn apply<I, O, PI: ChannelPointers, PO: ChannelPointers>(
         &mut self,
         ambisonics_encode_effect_params: &AmbisonicsEncodeEffectParams,
         input_buffer: &AudioBuffer<I, PI>,
         output_buffer: &AudioBuffer<O, PO>,
-    ) -> AudioEffectState
+    ) -> Result<AudioEffectState, EffectError>
     where
         I: AsRef<[Sample]>,
         O: AsRef<[Sample]> + AsMut<[Sample]>,
     {
-        assert_eq!(
-            input_buffer.num_channels(),
-            1,
-            "input buffer must have 1 channel",
-        );
+        let num_input_channels = input_buffer.num_channels();
+        if num_input_channels != 1 {
+            return Err(EffectError::InvalidInputChannels {
+                expected: ChannelRequirement::Exactly(1),
+                actual: num_input_channels,
+            });
+        }
 
-        let required_num_channels = (ambisonics_encode_effect_params.order + 1).pow(2);
-        assert_eq!(
-            output_buffer.num_channels(),
-            required_num_channels,
-            "ambisonic order N = {} requires (N + 1)^2 = {} output channels",
-            ambisonics_encode_effect_params.order,
-            required_num_channels
-        );
+        let required_num_channels = num_ambisonics_channels(self.max_order);
+        let num_output_channels = output_buffer.num_channels();
+        if num_output_channels != required_num_channels {
+            return Err(EffectError::InvalidAmbisonicOrder {
+                order: self.max_order,
+                buffer_channels: num_output_channels,
+                required_channels: required_num_channels,
+            });
+        }
 
-        unsafe {
+        let state = unsafe {
             audionimbus_sys::iplAmbisonicsEncodeEffectApply(
                 self.raw_ptr(),
                 &mut *ambisonics_encode_effect_params.as_ffi(),
@@ -114,7 +138,9 @@ impl AmbisonicsEncodeEffect {
                 &mut *output_buffer.as_ffi(),
             )
         }
-        .into()
+        .into();
+
+        Ok(state)
     }
 
     /// Retrieves a single frame of tail samples from an Ambisonics encode effect’s internal buffers.
@@ -122,17 +148,29 @@ impl AmbisonicsEncodeEffect {
     /// After the input to the Ambisonics encode effect has stopped, this function must be called instead of [`Self::apply`] until the return value indicates that no more tail samples remain.
     ///
     /// The output audio buffer must have as many channels as needed for the Ambisonics order specified when creating the effect.
-    pub fn tail<O>(&self, output_buffer: &AudioBuffer<O>) -> AudioEffectState
+    pub fn tail<O>(&self, output_buffer: &AudioBuffer<O>) -> Result<AudioEffectState, EffectError>
     where
         O: AsRef<[Sample]> + AsMut<[Sample]>,
     {
-        unsafe {
+        let required_num_channels = num_ambisonics_channels(self.max_order);
+        let num_output_channels = output_buffer.num_channels();
+        if num_output_channels != required_num_channels {
+            return Err(EffectError::InvalidAmbisonicOrder {
+                order: self.max_order,
+                buffer_channels: num_output_channels,
+                required_channels: required_num_channels,
+            });
+        }
+
+        let state = unsafe {
             audionimbus_sys::iplAmbisonicsEncodeEffectGetTail(
                 self.raw_ptr(),
                 &mut *output_buffer.as_ffi(),
             )
         }
-        .into()
+        .into();
+
+        Ok(state)
     }
 
     /// Returns the number of tail samples remaining in an Ambisonics encode effect’s internal buffers.
@@ -151,29 +189,33 @@ impl AmbisonicsEncodeEffect {
     ///
     /// This is intended for internal use and advanced scenarios.
     pub fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsEncodeEffect {
-        self.0
+        self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
     pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsEncodeEffect {
-        &mut self.0
+        &mut self.inner
     }
 }
 
 impl Clone for AmbisonicsEncodeEffect {
     fn clone(&self) -> Self {
         unsafe {
-            audionimbus_sys::iplAmbisonicsEncodeEffectRetain(self.0);
+            audionimbus_sys::iplAmbisonicsEncodeEffectRetain(self.inner);
         }
-        Self(self.0)
+
+        Self {
+            inner: self.inner,
+            max_order: self.max_order,
+        }
     }
 }
 
 impl Drop for AmbisonicsEncodeEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplAmbisonicsEncodeEffectRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplAmbisonicsEncodeEffectRelease(&mut self.inner) }
     }
 }
 
@@ -221,5 +263,177 @@ impl AmbisonicsEncodeEffectParams {
         };
 
         FFIWrapper::new(ambisonics_encode_effect_params)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::*;
+
+    mod apply {
+        use super::*;
+
+        #[test]
+        fn test_valid_first_order() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let mut effect = AmbisonicsEncodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsEncodeEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+
+            let params = AmbisonicsEncodeEffectParams {
+                direction: Direction::new(1.0, 0.0, 0.0),
+                order: 1,
+            };
+
+            let input = vec![0.5; 1024];
+            let input_buffer = AudioBuffer::try_with_data(&input).unwrap();
+
+            let mut output = vec![0.0; 4 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            assert!(effect.apply(&params, &input_buffer, &output_buffer).is_ok());
+        }
+
+        #[test]
+        fn test_invalid_input_channels() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let mut effect = AmbisonicsEncodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsEncodeEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+
+            let params = AmbisonicsEncodeEffectParams {
+                direction: Direction::new(1.0, 0.0, 0.0),
+                order: 1,
+            };
+
+            let input = vec![0.5; 2 * 1024];
+            let input_buffer = AudioBuffer::try_with_data_and_settings(
+                &input,
+                AudioBufferSettings::with_num_channels(2),
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 4 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            assert_eq!(
+                effect.apply(&params, &input_buffer, &output_buffer),
+                Err(EffectError::InvalidInputChannels {
+                    expected: ChannelRequirement::Exactly(1),
+                    actual: 2
+                })
+            );
+        }
+
+        #[test]
+        fn test_invalid_output_channels() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let mut effect = AmbisonicsEncodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsEncodeEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+
+            let params = AmbisonicsEncodeEffectParams {
+                direction: Direction::new(1.0, 0.0, 0.0),
+                order: 1,
+            };
+
+            let input = vec![0.5; 1024];
+            let input_buffer = AudioBuffer::try_with_data(&input).unwrap();
+
+            let mut output = vec![0.0; 2 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(2),
+            )
+            .unwrap();
+
+            assert_eq!(
+                effect.apply(&params, &input_buffer, &output_buffer),
+                Err(EffectError::InvalidAmbisonicOrder {
+                    order: 1,
+                    buffer_channels: 2,
+                    required_channels: 4
+                })
+            );
+        }
+    }
+
+    mod tail {
+        use super::*;
+
+        #[test]
+        fn test_valid() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let effect = AmbisonicsEncodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsEncodeEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 4 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            assert!(effect.tail(&output_buffer).is_ok());
+        }
+
+        #[test]
+        fn test_invalid_output_channels() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let effect = AmbisonicsEncodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsEncodeEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 2 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(2),
+            )
+            .unwrap();
+
+            assert_eq!(
+                effect.tail(&output_buffer),
+                Err(EffectError::InvalidAmbisonicOrder {
+                    order: 1,
+                    buffer_channels: 2,
+                    required_channels: 4
+                })
+            );
+        }
     }
 }

--- a/audionimbus/src/effect/ambisonics/panning.rs
+++ b/audionimbus/src/effect/ambisonics/panning.rs
@@ -1,6 +1,4 @@
-use super::super::AudioEffectState;
-use super::super::EffectError;
-use super::super::SpeakerLayout;
+use super::super::{AudioEffectState, EffectError, SpeakerLayout};
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::context::Context;

--- a/audionimbus/src/effect/ambisonics/rotation.rs
+++ b/audionimbus/src/effect/ambisonics/rotation.rs
@@ -1,5 +1,4 @@
-use super::super::AudioEffectState;
-use super::super::EffectError;
+use super::super::{AudioEffectState, EffectError};
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::context::Context;

--- a/audionimbus/src/effect/ambisonics/rotation.rs
+++ b/audionimbus/src/effect/ambisonics/rotation.rs
@@ -1,11 +1,13 @@
 use super::super::AudioEffectState;
+use super::super::EffectError;
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::context::Context;
 use crate::error::{to_option_error, SteamAudioError};
 use crate::ffi_wrapper::FFIWrapper;
 use crate::geometry::CoordinateSystem;
-use crate::ChannelPointers;
+use crate::num_ambisonics_channels;
+use crate::{ChannelPointers, ChannelRequirement};
 
 /// Applies a rotation to an ambisonics audio buffer.
 ///
@@ -50,7 +52,13 @@ use crate::ChannelPointers;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug)]
-pub struct AmbisonicsRotationEffect(audionimbus_sys::IPLAmbisonicsRotationEffect);
+pub struct AmbisonicsRotationEffect {
+    inner: audionimbus_sys::IPLAmbisonicsRotationEffect,
+
+    /// The number of input and output channels needed for the ambisonics order used when creating
+    /// the effect.
+    num_channels: u32,
+}
 
 impl AmbisonicsRotationEffect {
     /// Creates a new ambisonics rotation effect.
@@ -63,7 +71,7 @@ impl AmbisonicsRotationEffect {
         audio_settings: &AudioSettings,
         ambisonics_rotation_effect_settings: &AmbisonicsRotationEffectSettings,
     ) -> Result<Self, SteamAudioError> {
-        let mut ambisonics_rotation_effect = Self(std::ptr::null_mut());
+        let mut inner = std::ptr::null_mut();
 
         let status = unsafe {
             audionimbus_sys::iplAmbisonicsRotationEffectCreate(
@@ -72,7 +80,7 @@ impl AmbisonicsRotationEffect {
                 &mut audionimbus_sys::IPLAmbisonicsRotationEffectSettings::from(
                     ambisonics_rotation_effect_settings,
                 ),
-                ambisonics_rotation_effect.raw_ptr_mut(),
+                &mut inner,
             )
         };
 
@@ -80,39 +88,54 @@ impl AmbisonicsRotationEffect {
             return Err(error);
         }
 
+        let num_channels = num_ambisonics_channels(ambisonics_rotation_effect_settings.max_order);
+        let ambisonics_rotation_effect = Self {
+            inner,
+            num_channels,
+        };
+
         Ok(ambisonics_rotation_effect)
     }
 
     /// Applies an ambisonics rotation effect to an audio buffer.
     ///
     /// This effect CANNOT be applied in-place.
+    ///
+    /// Both input and output audio buffers must have as many channels as needed for the
+    /// Ambisonics order used (see [`crate::num_ambisonics_channels`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EffectError`] if:
+    /// - The input buffer does not have the correct number of channels for the Ambisonics order
+    /// - The output buffer does not have the correct number of channels for the Ambisonics order
     pub fn apply<I, O, PI: ChannelPointers, PO: ChannelPointers>(
         &mut self,
         ambisonics_rotation_effect_params: &AmbisonicsRotationEffectParams,
         input_buffer: &AudioBuffer<I, PI>,
         output_buffer: &AudioBuffer<O, PO>,
-    ) -> AudioEffectState
+    ) -> Result<AudioEffectState, EffectError>
     where
         I: AsRef<[Sample]>,
         O: AsRef<[Sample]> + AsMut<[Sample]>,
     {
-        let required_num_channels = (ambisonics_rotation_effect_params.order + 1).pow(2);
-        assert_eq!(
-            input_buffer.num_channels(),
-            required_num_channels,
-            "ambisonic order N = {} requires (N + 1)^2 = {} input channels",
-            ambisonics_rotation_effect_params.order,
-            required_num_channels
-        );
-        assert_eq!(
-            output_buffer.num_channels(),
-            required_num_channels,
-            "ambisonic order N = {} requires (N + 1)^2 = {} output channels",
-            ambisonics_rotation_effect_params.order,
-            required_num_channels
-        );
+        let num_input_channels = input_buffer.num_channels();
+        if num_input_channels != self.num_channels {
+            return Err(EffectError::InvalidInputChannels {
+                expected: ChannelRequirement::Exactly(self.num_channels),
+                actual: num_input_channels,
+            });
+        }
 
-        unsafe {
+        let num_output_channels = output_buffer.num_channels();
+        if num_output_channels != self.num_channels {
+            return Err(EffectError::InvalidOutputChannels {
+                expected: ChannelRequirement::Exactly(self.num_channels),
+                actual: num_output_channels,
+            });
+        }
+
+        let state = unsafe {
             audionimbus_sys::iplAmbisonicsRotationEffectApply(
                 self.raw_ptr(),
                 &mut *ambisonics_rotation_effect_params.as_ffi(),
@@ -120,7 +143,9 @@ impl AmbisonicsRotationEffect {
                 &mut *output_buffer.as_ffi(),
             )
         }
-        .into()
+        .into();
+
+        Ok(state)
     }
 
     /// Retrieves a single frame of tail samples from an Ambisonics rotation effect’s internal buffers.
@@ -128,17 +153,32 @@ impl AmbisonicsRotationEffect {
     /// After the input to the Ambisonics rotation effect has stopped, this function must be called instead of [`Self::apply`] until the return value indicates that no more tail samples remain.
     ///
     /// The output audio buffer must have as many channels as needed for the Ambisonics order specified when creating the effect.
-    pub fn tail<O>(&self, output_buffer: &AudioBuffer<O>) -> AudioEffectState
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EffectError`] if the output buffer does not have the correct number of channels
+    /// for the Ambisonics order.
+    pub fn tail<O>(&self, output_buffer: &AudioBuffer<O>) -> Result<AudioEffectState, EffectError>
     where
         O: AsRef<[Sample]> + AsMut<[Sample]>,
     {
-        unsafe {
+        let num_output_channels = output_buffer.num_channels();
+        if num_output_channels != self.num_channels {
+            return Err(EffectError::InvalidOutputChannels {
+                expected: ChannelRequirement::Exactly(self.num_channels),
+                actual: num_output_channels,
+            });
+        }
+
+        let state = unsafe {
             audionimbus_sys::iplAmbisonicsRotationEffectGetTail(
                 self.raw_ptr(),
                 &mut *output_buffer.as_ffi(),
             )
         }
-        .into()
+        .into();
+
+        Ok(state)
     }
 
     /// Returns the number of tail samples remaining in an Ambisonics rotation effect’s internal buffers.
@@ -157,29 +197,33 @@ impl AmbisonicsRotationEffect {
     ///
     /// This is intended for internal use and advanced scenarios.
     pub fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsRotationEffect {
-        self.0
+        self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
     pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsRotationEffect {
-        &mut self.0
+        &mut self.inner
     }
 }
 
 impl Clone for AmbisonicsRotationEffect {
     fn clone(&self) -> Self {
         unsafe {
-            audionimbus_sys::iplAmbisonicsRotationEffectRetain(self.0);
+            audionimbus_sys::iplAmbisonicsRotationEffectRetain(self.inner);
         }
-        Self(self.0)
+
+        Self {
+            inner: self.inner,
+            num_channels: self.num_channels,
+        }
     }
 }
 
 impl Drop for AmbisonicsRotationEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplAmbisonicsRotationEffectRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplAmbisonicsRotationEffectRelease(&mut self.inner) }
     }
 }
 
@@ -226,5 +270,183 @@ impl AmbisonicsRotationEffectParams {
             };
 
         FFIWrapper::new(ambisonics_rotation_effect_params)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::*;
+
+    mod apply {
+        use super::*;
+
+        #[test]
+        fn test_valid_first_order() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let mut effect = AmbisonicsRotationEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsRotationEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+
+            let params = AmbisonicsRotationEffectParams {
+                orientation: CoordinateSystem::default(),
+                order: 1,
+            };
+
+            let input = vec![0.5; 4 * 1024];
+            let input_buffer = AudioBuffer::try_with_data_and_settings(
+                &input,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 4 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            assert!(effect.apply(&params, &input_buffer, &output_buffer).is_ok());
+        }
+
+        #[test]
+        fn test_invalid_input_channels() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let mut effect = AmbisonicsRotationEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsRotationEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+
+            let params = AmbisonicsRotationEffectParams {
+                orientation: CoordinateSystem::default(),
+                order: 1,
+            };
+
+            let input = vec![0.5; 2 * 1024];
+            let input_buffer = AudioBuffer::try_with_data_and_settings(
+                &input,
+                AudioBufferSettings::with_num_channels(2),
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 4 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            assert_eq!(
+                effect.apply(&params, &input_buffer, &output_buffer),
+                Err(EffectError::InvalidInputChannels {
+                    expected: ChannelRequirement::Exactly(4),
+                    actual: 2
+                })
+            );
+        }
+
+        #[test]
+        fn test_invalid_output_channels() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let mut effect = AmbisonicsRotationEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsRotationEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+
+            let params = AmbisonicsRotationEffectParams {
+                orientation: CoordinateSystem::default(),
+                order: 1,
+            };
+
+            let input = vec![0.5; 4 * 1024];
+            let input_buffer = AudioBuffer::try_with_data_and_settings(
+                &input,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 3 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(3),
+            )
+            .unwrap();
+
+            assert_eq!(
+                effect.apply(&params, &input_buffer, &output_buffer),
+                Err(EffectError::InvalidOutputChannels {
+                    expected: ChannelRequirement::Exactly(4),
+                    actual: 3,
+                })
+            );
+        }
+    }
+
+    mod tail {
+        use super::*;
+
+        #[test]
+        fn test_valid() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let effect = AmbisonicsRotationEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsRotationEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 4 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(4),
+            )
+            .unwrap();
+
+            assert!(effect.tail(&output_buffer).is_ok());
+        }
+
+        #[test]
+        fn test_invalid_output_channels() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let effect = AmbisonicsRotationEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsRotationEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+
+            let mut output = vec![0.0; 2 * 1024];
+            let output_buffer = AudioBuffer::try_with_data_and_settings(
+                &mut output,
+                AudioBufferSettings::with_num_channels(2),
+            )
+            .unwrap();
+
+            assert_eq!(
+                effect.tail(&output_buffer),
+                Err(EffectError::InvalidOutputChannels {
+                    expected: ChannelRequirement::Exactly(4),
+                    actual: 2,
+                })
+            );
+        }
     }
 }

--- a/audionimbus/src/effect/ambisonics/speaker_layout.rs
+++ b/audionimbus/src/effect/ambisonics/speaker_layout.rs
@@ -1,4 +1,5 @@
 use crate::geometry::Direction;
+use std::fmt;
 
 /// Describes a standard or custom speaker layout.
 #[derive(Debug, Clone)]
@@ -23,6 +24,31 @@ pub enum SpeakerLayout {
         /// Unit-length direction for each speaker.
         speaker_directions: Vec<Direction>,
     },
+}
+
+impl SpeakerLayout {
+    /// Returns the name of this speaker layout.
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Mono => "mono",
+            Self::Stereo => "stereo",
+            Self::Quadraphonic => "quadraphonic",
+            Self::Surround5_1 => "5.1",
+            Self::Surround7_1 => "7.1",
+            Self::Custom { .. } => "custom",
+        }
+    }
+}
+
+impl fmt::Display for SpeakerLayout {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Custom { speaker_directions } => {
+                write!(f, "{} ({} channels)", self.name(), speaker_directions.len())
+            }
+            _ => f.write_str(self.name()),
+        }
+    }
 }
 
 impl From<&SpeakerLayout> for audionimbus_sys::IPLSpeakerLayout {

--- a/audionimbus/src/effect/ambisonics/speaker_layout.rs
+++ b/audionimbus/src/effect/ambisonics/speaker_layout.rs
@@ -2,7 +2,7 @@ use crate::geometry::Direction;
 use std::fmt;
 
 /// Describes a standard or custom speaker layout.
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum SpeakerLayout {
     /// Mono.
     Mono,

--- a/audionimbus/src/effect/direct.rs
+++ b/audionimbus/src/effect/direct.rs
@@ -87,6 +87,9 @@ impl DirectEffect {
     ///
     /// This effect CAN be applied in-place.
     ///
+    /// The input and output audio buffers must have as many channels as specified when creating
+    /// the effect.
+    ///
     /// # Errors
     ///
     /// Returns [`EffectError`] if the input or output buffers have a number of channels different

--- a/audionimbus/src/effect/direct.rs
+++ b/audionimbus/src/effect/direct.rs
@@ -1,6 +1,5 @@
 use super::audio_effect_state::AudioEffectState;
-use super::EffectError;
-use super::Equalizer;
+use super::{EffectError, Equalizer};
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::context::Context;

--- a/audionimbus/src/effect/direct.rs
+++ b/audionimbus/src/effect/direct.rs
@@ -6,7 +6,7 @@ use crate::audio_settings::AudioSettings;
 use crate::context::Context;
 use crate::error::{to_option_error, SteamAudioError};
 use crate::ffi_wrapper::FFIWrapper;
-use crate::ChannelPointers;
+use crate::{ChannelPointers, ChannelRequirement};
 
 /// Filters and attenuates an audio signal based on various properties of the direct path between a point source and the listener.
 ///
@@ -115,7 +115,7 @@ impl DirectEffect {
         let num_output_channels = output_buffer.num_channels();
         if num_output_channels != self.num_channels {
             return Err(EffectError::InvalidOutputChannels {
-                expected: self.num_channels,
+                expected: ChannelRequirement::Exactly(self.num_channels),
                 actual: num_output_channels,
             });
         }
@@ -150,7 +150,7 @@ impl DirectEffect {
         let num_output_channels = output_buffer.num_channels();
         if num_output_channels != self.num_channels {
             return Err(EffectError::InvalidOutputChannels {
-                expected: self.num_channels,
+                expected: ChannelRequirement::Exactly(self.num_channels),
                 actual: num_output_channels,
             });
         }
@@ -474,7 +474,7 @@ mod tests {
             assert_eq!(
                 direct_effect.apply(&direct_effect_params, &input_buffer, &output_buffer),
                 Err(EffectError::InvalidOutputChannels {
-                    expected: 1,
+                    expected: ChannelRequirement::Exactly(1),
                     actual: 4
                 })
             );
@@ -526,7 +526,7 @@ mod tests {
             assert_eq!(
                 direct_effect.tail(&output_buffer),
                 Err(EffectError::InvalidOutputChannels {
-                    expected: 1,
+                    expected: ChannelRequirement::Exactly(1),
                     actual: 2,
                 })
             );

--- a/audionimbus/src/effect/direct.rs
+++ b/audionimbus/src/effect/direct.rs
@@ -107,7 +107,7 @@ impl DirectEffect {
         let num_input_channels = input_buffer.num_channels();
         if num_input_channels != self.num_channels {
             return Err(EffectError::InvalidInputChannels {
-                expected: self.num_channels,
+                expected: ChannelRequirement::Exactly(self.num_channels),
                 actual: num_input_channels,
             });
         }
@@ -428,7 +428,7 @@ mod tests {
             assert_eq!(
                 direct_effect.apply(&direct_effect_params, &input_buffer, &output_buffer),
                 Err(EffectError::InvalidInputChannels {
-                    expected: 1,
+                    expected: ChannelRequirement::Exactly(1),
                     actual: 4
                 })
             );

--- a/audionimbus/src/effect/error.rs
+++ b/audionimbus/src/effect/error.rs
@@ -1,4 +1,5 @@
 use super::ambisonics::SpeakerLayout;
+use crate::ChannelRequirement;
 
 /// Errors that can occur when applying audio effects.
 #[derive(Debug, PartialEq)]
@@ -7,7 +8,10 @@ pub enum EffectError {
     InvalidInputChannels { expected: u32, actual: u32 },
 
     /// Output buffer has wrong number of channels.
-    InvalidOutputChannels { expected: u32, actual: u32 },
+    InvalidOutputChannels {
+        expected: ChannelRequirement,
+        actual: u32,
+    },
 
     /// Input and output channel counts must match but don't.
     InputOutputChannelMismatch { input: u32, output: u32 },

--- a/audionimbus/src/effect/error.rs
+++ b/audionimbus/src/effect/error.rs
@@ -19,13 +19,6 @@ pub enum EffectError {
     /// Input and output channel counts must match but don't.
     InputOutputChannelMismatch { input: u32, output: u32 },
 
-    /// Buffer doesn't have correct channels for ambisonic order.
-    InvalidAmbisonicOrder {
-        order: u32,
-        buffer_channels: u32,
-        required_channels: u32,
-    },
-
     /// Buffer has wrong channels for speaker layout.
     InvalidSpeakerLayoutChannels {
         layout: SpeakerLayout,
@@ -64,17 +57,6 @@ impl std::fmt::Display for EffectError {
                     f,
                     "input and output channel counts must match: input has {}, output has {}",
                     input, output
-                )
-            }
-            Self::InvalidAmbisonicOrder {
-                order,
-                buffer_channels,
-                required_channels,
-            } => {
-                write!(
-                    f,
-                    "ambisonic order {} requires {} channels, but buffer has {}",
-                    order, required_channels, buffer_channels
                 )
             }
             Self::InvalidSpeakerLayoutChannels {

--- a/audionimbus/src/effect/error.rs
+++ b/audionimbus/src/effect/error.rs
@@ -1,0 +1,96 @@
+use super::ambisonics::SpeakerLayout;
+
+/// Errors that can occur when applying audio effects.
+#[derive(Debug)]
+pub enum EffectError {
+    /// Input buffer has wrong number of channels.
+    InvalidInputChannels { expected: u32, actual: u32 },
+
+    /// Output buffer has wrong number of channels.
+    InvalidOutputChannels { expected: u32, actual: u32 },
+
+    /// Input and output channel counts must match but don't.
+    InputOutputChannelMismatch { input: u32, output: u32 },
+
+    /// Buffer doesn't have correct channels for ambisonic order.
+    InvalidAmbisonicOrder {
+        order: u32,
+        buffer_channels: u32,
+        required_channels: u32,
+    },
+
+    /// Buffer has wrong channels for speaker layout.
+    InvalidSpeakerLayoutChannels {
+        layout: SpeakerLayout,
+        expected: u32,
+        actual: u32,
+    },
+
+    /// Buffer is too small for the required samples.
+    InsufficientBufferSize {
+        required_samples: usize,
+        actual_samples: usize,
+    },
+}
+
+impl std::error::Error for EffectError {}
+
+impl std::fmt::Display for EffectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::InvalidInputChannels { expected, actual } => {
+                write!(
+                    f,
+                    "invalid number of input channels: expected {}, got {}",
+                    expected, actual
+                )
+            }
+            Self::InvalidOutputChannels { expected, actual } => {
+                write!(
+                    f,
+                    "invalid number of output channels: expected {}, got {}",
+                    expected, actual
+                )
+            }
+            Self::InputOutputChannelMismatch { input, output } => {
+                write!(
+                    f,
+                    "input and output channel counts must match: input has {}, output has {}",
+                    input, output
+                )
+            }
+            Self::InvalidAmbisonicOrder {
+                order,
+                buffer_channels,
+                required_channels,
+            } => {
+                write!(
+                    f,
+                    "ambisonic order {} requires {} channels, but buffer has {}",
+                    order, required_channels, buffer_channels
+                )
+            }
+            Self::InvalidSpeakerLayoutChannels {
+                layout,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "speaker layout '{}' requires {} channels, but buffer has {}",
+                    layout, expected, actual
+                )
+            }
+            Self::InsufficientBufferSize {
+                required_samples,
+                actual_samples,
+            } => {
+                write!(
+                    f,
+                    "buffer too small: needs {} samples, has {}",
+                    required_samples, actual_samples
+                )
+            }
+        }
+    }
+}

--- a/audionimbus/src/effect/error.rs
+++ b/audionimbus/src/effect/error.rs
@@ -1,7 +1,7 @@
 use super::ambisonics::SpeakerLayout;
 
 /// Errors that can occur when applying audio effects.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum EffectError {
     /// Input buffer has wrong number of channels.
     InvalidInputChannels { expected: u32, actual: u32 },

--- a/audionimbus/src/effect/error.rs
+++ b/audionimbus/src/effect/error.rs
@@ -5,7 +5,10 @@ use crate::ChannelRequirement;
 #[derive(Debug, PartialEq)]
 pub enum EffectError {
     /// Input buffer has wrong number of channels.
-    InvalidInputChannels { expected: u32, actual: u32 },
+    InvalidInputChannels {
+        expected: ChannelRequirement,
+        actual: u32,
+    },
 
     /// Output buffer has wrong number of channels.
     InvalidOutputChannels {

--- a/audionimbus/src/effect/mod.rs
+++ b/audionimbus/src/effect/mod.rs
@@ -64,6 +64,9 @@ pub use binaural::*;
 pub mod direct;
 pub use direct::*;
 
+mod error;
+pub use error::EffectError;
+
 pub mod reflection;
 pub use reflection::*;
 

--- a/audionimbus/src/effect/panning.rs
+++ b/audionimbus/src/effect/panning.rs
@@ -1,6 +1,5 @@
 use super::audio_effect_state::AudioEffectState;
-use super::EffectError;
-use super::SpeakerLayout;
+use super::{EffectError, SpeakerLayout};
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::context::Context;

--- a/audionimbus/src/effect/panning.rs
+++ b/audionimbus/src/effect/panning.rs
@@ -1,6 +1,6 @@
 use super::audio_effect_state::AudioEffectState;
+use super::EffectError;
 use super::SpeakerLayout;
-use super::*;
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::context::Context;

--- a/audionimbus/src/effect/path.rs
+++ b/audionimbus/src/effect/path.rs
@@ -12,7 +12,7 @@ use crate::hrtf::Hrtf;
 use crate::num_ambisonics_channels;
 use crate::probe::ProbeBatch;
 use crate::simulation::BakedDataIdentifier;
-use crate::ChannelPointers;
+use crate::{ChannelPointers, ChannelRequirement};
 
 #[cfg(doc)]
 use crate::simulation::{SimulationOutputs, Simulator, Source};
@@ -246,7 +246,7 @@ impl PathEffect {
         let num_output_channels = output_buffer.num_channels();
         if num_output_channels != self.num_output_channels {
             return Err(EffectError::InvalidOutputChannels {
-                expected: self.num_output_channels,
+                expected: ChannelRequirement::Exactly(self.num_output_channels),
                 actual: num_output_channels,
             });
         }
@@ -281,7 +281,7 @@ impl PathEffect {
         let num_output_channels = output_buffer.num_channels();
         if num_output_channels != self.num_output_channels {
             return Err(EffectError::InvalidOutputChannels {
-                expected: self.num_output_channels,
+                expected: ChannelRequirement::Exactly(self.num_output_channels),
                 actual: num_output_channels,
             });
         }
@@ -734,7 +734,7 @@ mod tests {
             assert_eq!(
                 path_effect.apply(&path_effect_params, &input_buffer, &output_buffer),
                 Err(EffectError::InvalidOutputChannels {
-                    expected: 4,
+                    expected: ChannelRequirement::Exactly(4),
                     actual: 2
                 })
             );
@@ -796,7 +796,7 @@ mod tests {
             assert_eq!(
                 path_effect.tail(&output_buffer),
                 Err(EffectError::InvalidOutputChannels {
-                    expected: 4,
+                    expected: ChannelRequirement::Exactly(4),
                     actual: 2
                 })
             );

--- a/audionimbus/src/effect/path.rs
+++ b/audionimbus/src/effect/path.rs
@@ -1,4 +1,5 @@
 use super::audio_effect_state::AudioEffectState;
+use super::EffectError;
 use super::SpeakerLayout;
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
@@ -8,6 +9,7 @@ use crate::error::{to_option_error, SteamAudioError};
 use crate::ffi_wrapper::FFIWrapper;
 use crate::geometry::{CoordinateSystem, Scene};
 use crate::hrtf::Hrtf;
+use crate::num_ambisonics_channels;
 use crate::probe::ProbeBatch;
 use crate::simulation::BakedDataIdentifier;
 use crate::ChannelPointers;
@@ -167,7 +169,13 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug)]
-pub struct PathEffect(audionimbus_sys::IPLPathEffect);
+pub struct PathEffect {
+    inner: audionimbus_sys::IPLPathEffect,
+
+    /// Number of output channels needed for the ambisonics order specified when creating the
+    /// effect.
+    num_output_channels: u32,
+}
 
 impl PathEffect {
     /// Creates a new path effect.
@@ -180,14 +188,14 @@ impl PathEffect {
         audio_settings: &AudioSettings,
         path_effect_settings: &PathEffectSettings,
     ) -> Result<Self, SteamAudioError> {
-        let mut path_effect = Self(std::ptr::null_mut());
+        let mut inner = std::ptr::null_mut();
 
         let status = unsafe {
             audionimbus_sys::iplPathEffectCreate(
                 context.raw_ptr(),
                 &mut audionimbus_sys::IPLAudioSettings::from(audio_settings),
                 &mut audionimbus_sys::IPLPathEffectSettings::from(path_effect_settings),
-                path_effect.raw_ptr_mut(),
+                &mut inner,
             )
         };
 
@@ -195,23 +203,48 @@ impl PathEffect {
             return Err(error);
         }
 
+        let path_effect = Self {
+            inner,
+            num_output_channels: num_ambisonics_channels(path_effect_settings.max_order),
+        };
+
         Ok(path_effect)
     }
 
     /// Applies a path effect to an audio buffer.
     ///
     /// This effect CANNOT be applied in-place.
+    ///
+    /// The input audio buffer must have one channel, and the output audio buffer must have as many
+    /// channels as needed for the ambisonics order specified when creating the effect (see
+    /// [`num_ambisonics_channels`]).
     pub fn apply<I, O, PI: ChannelPointers, PO: ChannelPointers>(
         &mut self,
         path_effect_params: &PathEffectParams,
         input_buffer: &AudioBuffer<I, PI>,
         output_buffer: &AudioBuffer<O, PO>,
-    ) -> AudioEffectState
+    ) -> Result<AudioEffectState, EffectError>
     where
         I: AsRef<[Sample]>,
         O: AsRef<[Sample]> + AsMut<[Sample]>,
     {
-        unsafe {
+        let num_input_channels = input_buffer.num_channels();
+        if num_input_channels != 1 {
+            return Err(EffectError::InvalidInputChannels {
+                expected: 1,
+                actual: num_input_channels,
+            });
+        }
+
+        let num_output_channels = output_buffer.num_channels();
+        if num_output_channels != self.num_output_channels {
+            return Err(EffectError::InvalidOutputChannels {
+                expected: self.num_output_channels,
+                actual: num_output_channels,
+            });
+        }
+
+        let state = unsafe {
             audionimbus_sys::iplPathEffectApply(
                 self.raw_ptr(),
                 &mut *path_effect_params.as_ffi(),
@@ -219,7 +252,9 @@ impl PathEffect {
                 &mut *output_buffer.as_ffi(),
             )
         }
-        .into()
+        .into();
+
+        Ok(state)
     }
 
     /// Retrieves a single frame of tail samples from a path effect’s internal buffers.
@@ -253,29 +288,33 @@ impl PathEffect {
     ///
     /// This is intended for internal use and advanced scenarios.
     pub fn raw_ptr(&self) -> audionimbus_sys::IPLPathEffect {
-        self.0
+        self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
     pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLPathEffect {
-        &mut self.0
+        &mut self.inner
     }
 }
 
 impl Clone for PathEffect {
     fn clone(&self) -> Self {
         unsafe {
-            audionimbus_sys::iplPathEffectRetain(self.0);
+            audionimbus_sys::iplPathEffectRetain(self.inner);
         }
-        Self(self.0)
+
+        Self {
+            inner: self.inner,
+            num_output_channels: self.num_output_channels,
+        }
     }
 }
 
 impl Drop for PathEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplPathEffectRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplPathEffectRelease(&mut self.inner) }
     }
 }
 
@@ -508,5 +547,171 @@ impl From<&PathBakeParams<'_>> for audionimbus_sys::IPLPathBakeParams {
             pathRange: params.path_range,
             numThreads: params.num_threads as i32,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+
+    #[test]
+    fn test_apply() {
+        let context = Context::default();
+
+        const FRAME_SIZE: u32 = 1024;
+        const MAX_ORDER: u32 = 1;
+        const NUM_SH_COEFFS: usize = (MAX_ORDER as usize + 1).pow(2);
+
+        let audio_settings = AudioSettings::default();
+        let path_effect_settings = PathEffectSettings {
+            max_order: MAX_ORDER,
+            spatialization: None,
+        };
+        let mut path_effect =
+            PathEffect::try_new(&context, &audio_settings, &path_effect_settings).unwrap();
+
+        let input_container = vec![0.5; FRAME_SIZE as usize];
+        let input_buffer = AudioBuffer::try_with_data(&input_container).unwrap();
+
+        // Must have 4 channels (1st order Ambisonics) for this example.
+        let mut output_container = vec![0.0; 4 * input_buffer.num_samples() as usize];
+        let output_buffer = AudioBuffer::try_with_data_and_settings(
+            &mut output_container,
+            AudioBufferSettings::with_num_channels(4),
+        )
+        .unwrap();
+
+        let hrtf_settings = HrtfSettings::default();
+        let hrtf = Hrtf::try_new(&context, &audio_settings, &hrtf_settings).unwrap();
+
+        let mut sh_storage = vec![0.0f32; NUM_SH_COEFFS];
+        sh_storage[0] = 1.0;
+
+        let sh_coeffs = ShCoeffs(sh_storage.as_mut_ptr());
+
+        let path_effect_params = PathEffectParams {
+            eq_coeffs: [1.0, 1.0, 1.0],
+            sh_coeffs,
+            order: MAX_ORDER,
+            binaural: false,
+            hrtf,
+            listener: CoordinateSystem::default(),
+            normalize_eq: false,
+        };
+
+        assert!(path_effect
+            .apply(&path_effect_params, &input_buffer, &output_buffer)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_apply_invalid_input_num_channels() {
+        let context = Context::default();
+
+        const FRAME_SIZE: u32 = 1024;
+        const MAX_ORDER: u32 = 1;
+        const NUM_SH_COEFFS: usize = (MAX_ORDER as usize + 1).pow(2);
+
+        let audio_settings = AudioSettings::default();
+        let path_effect_settings = PathEffectSettings {
+            max_order: MAX_ORDER,
+            spatialization: None,
+        };
+        let mut path_effect =
+            PathEffect::try_new(&context, &audio_settings, &path_effect_settings).unwrap();
+
+        let input_container = vec![0.5; 2 * FRAME_SIZE as usize];
+        let input_buffer = AudioBuffer::try_with_data_and_settings(
+            &input_container,
+            AudioBufferSettings::with_num_channels(2),
+        )
+        .unwrap();
+
+        // Must have 4 channels (1st order Ambisonics) for this example.
+        let mut output_container = vec![0.0; 4 * input_buffer.num_samples() as usize];
+        let output_buffer = AudioBuffer::try_with_data_and_settings(
+            &mut output_container,
+            AudioBufferSettings::with_num_channels(4),
+        )
+        .unwrap();
+
+        let hrtf_settings = HrtfSettings::default();
+        let hrtf = Hrtf::try_new(&context, &audio_settings, &hrtf_settings).unwrap();
+
+        let mut sh_storage = vec![0.0f32; NUM_SH_COEFFS];
+        sh_storage[0] = 1.0;
+
+        let sh_coeffs = ShCoeffs(sh_storage.as_mut_ptr());
+
+        let path_effect_params = PathEffectParams {
+            eq_coeffs: [1.0, 1.0, 1.0],
+            sh_coeffs,
+            order: MAX_ORDER,
+            binaural: false,
+            hrtf,
+            listener: CoordinateSystem::default(),
+            normalize_eq: false,
+        };
+
+        assert_eq!(
+            path_effect.apply(&path_effect_params, &input_buffer, &output_buffer),
+            Err(EffectError::InvalidInputChannels {
+                expected: 1,
+                actual: 2
+            })
+        );
+    }
+
+    #[test]
+    fn test_apply_invalid_output_num_channels() {
+        let context = Context::default();
+
+        const FRAME_SIZE: u32 = 1024;
+        const MAX_ORDER: u32 = 1;
+        const NUM_SH_COEFFS: usize = (MAX_ORDER as usize + 1).pow(2);
+
+        let audio_settings = AudioSettings::default();
+        let path_effect_settings = PathEffectSettings {
+            max_order: MAX_ORDER,
+            spatialization: None,
+        };
+        let mut path_effect =
+            PathEffect::try_new(&context, &audio_settings, &path_effect_settings).unwrap();
+
+        let input_container = vec![0.5; FRAME_SIZE as usize];
+        let input_buffer = AudioBuffer::try_with_data(&input_container).unwrap();
+
+        let mut output_container = vec![0.0; 2 * input_buffer.num_samples() as usize];
+        let output_buffer = AudioBuffer::try_with_data_and_settings(
+            &mut output_container,
+            AudioBufferSettings::with_num_channels(2),
+        )
+        .unwrap();
+
+        let hrtf_settings = HrtfSettings::default();
+        let hrtf = Hrtf::try_new(&context, &audio_settings, &hrtf_settings).unwrap();
+
+        let mut sh_storage = vec![0.0f32; NUM_SH_COEFFS];
+        sh_storage[0] = 1.0;
+
+        let sh_coeffs = ShCoeffs(sh_storage.as_mut_ptr());
+
+        let path_effect_params = PathEffectParams {
+            eq_coeffs: [1.0, 1.0, 1.0],
+            sh_coeffs,
+            order: MAX_ORDER,
+            binaural: false,
+            hrtf,
+            listener: CoordinateSystem::default(),
+            normalize_eq: false,
+        };
+
+        assert_eq!(
+            path_effect.apply(&path_effect_params, &input_buffer, &output_buffer),
+            Err(EffectError::InvalidOutputChannels {
+                expected: 4,
+                actual: 2
+            })
+        );
     }
 }

--- a/audionimbus/src/effect/path.rs
+++ b/audionimbus/src/effect/path.rs
@@ -1,6 +1,5 @@
 use super::audio_effect_state::AudioEffectState;
-use super::EffectError;
-use super::SpeakerLayout;
+use super::{EffectError, SpeakerLayout};
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::callback::{CallbackInformation, ProgressCallback};

--- a/audionimbus/src/effect/path.rs
+++ b/audionimbus/src/effect/path.rs
@@ -238,7 +238,7 @@ impl PathEffect {
         let num_input_channels = input_buffer.num_channels();
         if num_input_channels != 1 {
             return Err(EffectError::InvalidInputChannels {
-                expected: 1,
+                expected: ChannelRequirement::Exactly(1),
                 actual: num_input_channels,
             });
         }
@@ -681,7 +681,7 @@ mod tests {
             assert_eq!(
                 path_effect.apply(&path_effect_params, &input_buffer, &output_buffer),
                 Err(EffectError::InvalidInputChannels {
-                    expected: 1,
+                    expected: ChannelRequirement::Exactly(1),
                     actual: 2
                 })
             );

--- a/audionimbus/src/effect/reflection.rs
+++ b/audionimbus/src/effect/reflection.rs
@@ -276,7 +276,7 @@ impl ReflectionEffect {
         let num_input_channels = input_buffer.num_channels();
         if num_input_channels != 1 {
             return Err(EffectError::InvalidInputChannels {
-                expected: 1,
+                expected: ChannelRequirement::Exactly(1),
                 actual: num_input_channels,
             });
         }
@@ -338,7 +338,7 @@ impl ReflectionEffect {
         let num_input_channels = input_buffer.num_channels();
         if num_input_channels != 1 {
             return Err(EffectError::InvalidInputChannels {
-                expected: 1,
+                expected: ChannelRequirement::Exactly(1),
                 actual: num_input_channels,
             });
         }
@@ -1275,7 +1275,7 @@ mod tests {
             assert_eq!(
                 reflection_effect.apply(&reflection_effect_params, &input_buffer, &output_buffer),
                 Err(EffectError::InvalidInputChannels {
-                    expected: 1,
+                    expected: ChannelRequirement::Exactly(1),
                     actual: 2
                 })
             );
@@ -1536,7 +1536,7 @@ mod tests {
                     &mixer
                 ),
                 Err(EffectError::InvalidInputChannels {
-                    expected: 1,
+                    expected: ChannelRequirement::Exactly(1),
                     actual: 2
                 })
             );

--- a/audionimbus/src/effect/virtual_surround.rs
+++ b/audionimbus/src/effect/virtual_surround.rs
@@ -1,6 +1,5 @@
 use super::audio_effect_state::AudioEffectState;
-use super::EffectError;
-use super::SpeakerLayout;
+use super::{EffectError, SpeakerLayout};
 use crate::audio_buffer::{AudioBuffer, Sample};
 use crate::audio_settings::AudioSettings;
 use crate::context::Context;

--- a/audionimbus/src/error.rs
+++ b/audionimbus/src/error.rs
@@ -1,5 +1,5 @@
 /// A Steam Audio error.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum SteamAudioError {
     /// An unspecified error occurred.
     Unspecified,

--- a/audionimbus/tests/audio_buffer.rs
+++ b/audionimbus/tests/audio_buffer.rs
@@ -62,10 +62,7 @@ fn test_buffer_downmix() {
     input_container.extend(std::iter::repeat_n(0.3, FRAME_SIZE));
     let input_buffer = AudioBuffer::try_with_data_and_settings(
         &mut input_container,
-        AudioBufferSettings {
-            num_channels: Some(NUM_CHANNELS as u32),
-            ..Default::default()
-        },
+        AudioBufferSettings::with_num_channels(NUM_CHANNELS as u32),
     )
     .unwrap();
 

--- a/audionimbus/tests/effect.rs
+++ b/audionimbus/tests/effect.rs
@@ -132,6 +132,7 @@ fn test_ambisonics_decode_effect() {
         speaker_layout: SpeakerLayout::Mono,
         hrtf: &hrtf,
         max_order: 0,
+        rendering: Rendering::Binaural,
     };
 
     let mut ambisonics_decode_effect = effect::AmbisonicsDecodeEffect::try_new(
@@ -145,7 +146,6 @@ fn test_ambisonics_decode_effect() {
         order: 0,
         hrtf: &hrtf,
         orientation: geometry::CoordinateSystem::default(),
-        binaural: true,
     };
 
     let _ = ambisonics_decode_effect.apply(

--- a/audionimbus/tests/simulation.rs
+++ b/audionimbus/tests/simulation.rs
@@ -100,7 +100,7 @@ fn test_simulation() {
         source.get_outputs(SimulationFlags::DIRECT | SimulationFlags::REFLECTIONS);
 
     let reflection_effect_settings = ReflectionEffectSettings::Convolution {
-        impulse_response_size: 2 * sampling_rate, // 2.0f (IR duration) * 44100 (sampling rate)
+        impulse_response_size: 2 * sampling_rate, // 2.0f (IR duration) * 48000 (sampling rate)
         num_channels: 4,                          // 1st order Ambisonics
     };
     let mut reflection_effect =
@@ -117,10 +117,7 @@ fn test_simulation() {
     let mut output_container = vec![0.0; 4 * input_buffer.num_samples() as usize];
     let output_buffer = AudioBuffer::try_with_data_and_settings(
         &mut output_container,
-        AudioBufferSettings {
-            num_channels: Some(4),
-            ..Default::default()
-        },
+        AudioBufferSettings::with_num_channels(4),
     )
     .unwrap();
 


### PR DESCRIPTION
### Summary

This PR fixes segmentation faults occurring in all audio effect `apply` and `tail` methods when buffers with incorrect channel counts are passed.
The underlying Steam Audio C API does not validate buffer channel counts before accessing memory, leading to segfaults when channel requirements are not met.

### Problem

All audio effect types were vulnerable to segmentation faults when:
- Input buffers had an incorrect number of channels
- Output buffers had an incorrect number of channels

The Steam Audio C API (`iplXXXEffectApply` and `iplXXXEffectGetTail` functions) does not perform bounds checking on buffer channels, directly accessing memory based on expected channel counts.
This caused crashes that were difficult to debug for users.

### Solution

Added validation of input and output buffer channel counts before calling FFI functions. Each effect now:
- Checks that input buffers meet the required channel count
- Checks that output buffers meet the required channel count
- Returns an `EffectError` with expected vs. actual channel counts if validation fails (also replaces the `panic!`s present in some places)

#### Channel requirements overview

| Effect | Input Channels | Output Channels |
|--------|---------------|-----------------|
| `DirectEffect` | Exactly as specified in settings | Exactly as specified in settings |
| `PathEffect` | Exactly 1 (mono) | Exactly ambisonics channels for order |
| `ReflectionEffect` | Exactly 1 (mono) | Exactly IR channels (or ≥1 for parametric) |
| `ReflectionMixer` | N/A | Exactly IR channels (or ≥1 for parametric) |
| `BinauralEffect` | 1 or 2 (mono/stereo) | At most 2 |
| `PanningEffect` | Exactly 1 (mono) | Exactly speaker layout channels |
| `VirtualSurroundEffect` | Exactly speaker layout channels | Exactly 2 |
| `AmbisonicsEncodeEffect` | Exactly 1 (mono) | Exactly ambisonics channels for order |
| `AmbisonicsDecodeEffect` | Exactly ambisonics channels for order | Exactly speaker layout channels (or 2 for binaural) |
| `AmbisonicsRotationEffect` | Exactly ambisonics channels for order | Exactly ambisonics channels for order |
| `AmbisonicsPanningEffect` | Exactly ambisonics channels for order | Exactly speaker layout channels |
| `AmbisonicsBinauralEffect` | Exactly ambisonics channels for order | Exactly 2 |

I also removed the `AmbisonicsDecodeEffectParams::binaural` field used to choose between binaural rendering and panning, and added it in the form of a new `AmbisonicsDecodeEffectSettings::rendering` field instead. This field uses an enum (`AmbisonicsDecodeRendering::Binaural` or `AmbisonicsDecodeRendering::Panning`) to specify the rendering mode. This slightly differs from the original Steam Audio type, but it allows for validating the output buffer in `AmbisonicsDecodeEffect::tail`, since the function doesn't take an `AmbisonicsDecodeEffectParams` argument.

### Migration Guide

- Users need to handle the `Result` type returned by effect methods.
- For `ReflectionEffect::apply_into_mixer`, add the output buffer parameter:
  ```
  effect.apply_into_mixer(&params, &input_buffer, &output_buffer, &mixer)?;
  ```
- For `AmbisonicsDecodeEffect`, update settings creation:
  ```
    let params = AmbisonicsDecodeEffectParams {
      // binaural: true, // Removed field
      // ...
  };

  let settings = AmbisonicsDecodeEffectSettings {
      rendering: Rendering::Binaural, // Added field
      // ...
  };
  ```