### PR TITLE
Replace panics with proper error handling

### DIFF
--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -84,6 +84,7 @@
 - `ImpulseResponse::channel` now returns an `ImpulseResponseError` instead of panicking when the channel index is out of bounds.
 - Methods `interleave`, `deinterleave`, `mix`, `downmix`, `convert_ambisonics_into` of `AudioBuffer` now return an `AudioBufferOperationError` when invariants are not satisfied.
 - Renamed `OpenClDeviceList::new` to `try_new` for consistency.
+- Rename `AmbisonicsType::FUMA` variant to `AmbisonicsType::FuMa`.
 
 ### Added
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -81,6 +81,7 @@
 - `OpenClDeviceLust::device_descriptor` now returns an `OpenClDeviceListError` error if the device index is out of bounds instead of panicking.
 - `channel` and `band` methods of `EnergyField` now return an `EnergyFieldError` error if arguments are out of bounds.
 - `Reconstructor::reconstruct` now returns a `ReconstructorError` instead of panicking, if the max duration or the max order is exceeded, or if the inputs and outputs have different lengths.
+- `ImpulseResponse::channel` now returns an `ImpulseResponseError` instead of panicking when the channel index is out of bounds.
 
 ### Added
 
@@ -98,7 +99,7 @@
 - Add `ChannelRequirement` to specify the channel count requirement for an audio buffer.
 - Add `Rendering` enum to choose between decoding ambisonics using binaural rendering or panning.
 - `SceneParams` implements the `Default` trait.
-- Add `ProbeArrayError`, `ProbeBatchErrors`, `OpenClDeviceListError`, `EnergyFieldError`, `ReconstructorError` errors.
+- Add `ProbeArrayError`, `ProbeBatchErrors`, `OpenClDeviceListError`, `EnergyFieldError`, `ReconstructorError`, `ImpulseResponseError` errors.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -82,6 +82,7 @@
 - `channel` and `band` methods of `EnergyField` now return an `EnergyFieldError` error if arguments are out of bounds.
 - `Reconstructor::reconstruct` now returns a `ReconstructorError` instead of panicking, if the max duration or the max order is exceeded, or if the inputs and outputs have different lengths.
 - `ImpulseResponse::channel` now returns an `ImpulseResponseError` instead of panicking when the channel index is out of bounds.
+- Methods `interleave`, `deinterleave`, `mix`, `downmix`, `convert_ambisonics_into` of `AudioBuffer` now return an `AudioBufferOperationError` when invariants are not satisfied.
 
 ### Added
 
@@ -99,7 +100,7 @@
 - Add `ChannelRequirement` to specify the channel count requirement for an audio buffer.
 - Add `Rendering` enum to choose between decoding ambisonics using binaural rendering or panning.
 - `SceneParams` implements the `Default` trait.
-- Add `ProbeArrayError`, `ProbeBatchErrors`, `OpenClDeviceListError`, `EnergyFieldError`, `ReconstructorError`, `ImpulseResponseError` errors.
+- Add `ProbeArrayError`, `ProbeBatchErrors`, `OpenClDeviceListError`, `EnergyFieldError`, `ReconstructorError`, `ImpulseResponseError`, `AudioBufferOperationError` errors.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -80,6 +80,7 @@
 - `OpenClDeviceLust::device_descriptor` now returns an `OpenClDeviceListError` error if the device index is out of bounds instead of panicking.
 - `OpenClDeviceLust::device_descriptor` now returns an `OpenClDeviceListError` error if the device index is out of bounds instead of panicking.
 - `channel` and `band` methods of `EnergyField` now return an `EnergyFieldError` error if arguments are out of bounds.
+- `Reconstructor::reconstruct` now returns a `ReconstructorError` instead of panicking, if the max duration or the max order is exceeded, or if the inputs and outputs have different lengths.
 
 ### Added
 
@@ -97,7 +98,7 @@
 - Add `ChannelRequirement` to specify the channel count requirement for an audio buffer.
 - Add `Rendering` enum to choose between decoding ambisonics using binaural rendering or panning.
 - `SceneParams` implements the `Default` trait.
-- Add `ProbeArrayError`, `ProbeBatchErrors`, `OpenClDeviceListError`, `EnergyFieldError` errors.
+- Add `ProbeArrayError`, `ProbeBatchErrors`, `OpenClDeviceListError`, `EnergyFieldError`, `ReconstructorError` errors.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -77,14 +77,13 @@
 - `Source::get_outputs` now returns an error on failure to allocate sufficient memory for the `SimulationOutputs` (it would `panic!` before the change).
 - `ProbeArray::probe` now returns a `ProbeArrayError` error if the index argument is out of bounds instead of panicking.
 - Methods `remove_probe`, `reverb` and `energy_field` of `ProbeBatch` return a `ProbeBatchError` error if the index argument is out of bounds instead of panicking.
-- `OpenClDeviceLust::device_descriptor` now returns an `OpenClDeviceListError` error if the device index is out of bounds instead of panicking.
-- `OpenClDeviceLust::device_descriptor` now returns an `OpenClDeviceListError` error if the device index is out of bounds instead of panicking.
+- `OpenClDeviceList::device_descriptor` now returns an `OpenClDeviceListError` error if the device index is out of bounds instead of panicking.
 - `channel` and `band` methods of `EnergyField` now return an `EnergyFieldError` error if arguments are out of bounds.
 - `Reconstructor::reconstruct` now returns a `ReconstructorError` instead of panicking, if the max duration or the max order is exceeded, or if the inputs and outputs have different lengths.
 - `ImpulseResponse::channel` now returns an `ImpulseResponseError` instead of panicking when the channel index is out of bounds.
 - Methods `interleave`, `deinterleave`, `mix`, `downmix`, `convert_ambisonics_into` of `AudioBuffer` now return an `AudioBufferOperationError` when invariants are not satisfied.
 - Renamed `OpenClDeviceList::new` to `try_new` for consistency.
-- Rename `AmbisonicsType::FUMA` variant to `AmbisonicsType::FuMa`.
+- Renamed `AmbisonicsType::FUMA` variant to `AmbisonicsType::FuMa`.
 
 ### Added
 
@@ -102,7 +101,7 @@
 - Add `ChannelRequirement` to specify the channel count requirement for an audio buffer.
 - Add `Rendering` enum to choose between decoding ambisonics using binaural rendering or panning.
 - `SceneParams` implements the `Default` trait.
-- Add `ProbeArrayError`, `ProbeBatchErrors`, `OpenClDeviceListError`, `EnergyFieldError`, `ReconstructorError`, `ImpulseResponseError`, `AudioBufferOperationError` errors.
+- Add `ProbeArrayError`, `ProbeBatchError`, `OpenClDeviceListError`, `EnergyFieldError`, `ReconstructorError`, `ImpulseResponseError`, `AudioBufferOperationError` errors.
 - `OpenClDeviceType` and `OpenClDeviceDescriptor` implement `PartialEq` trait.
 
 ### Removed

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -78,6 +78,8 @@
 - `ProbeArray::probe` now returns a `ProbeArrayError` error if the index argument is out of bounds instead of panicking.
 - Methods `remove_probe`, `reverb` and `energy_field` of `ProbeBatch` return a `ProbeBatchError` error if the index argument is out of bounds instead of panicking.
 - `OpenClDeviceLust::device_descriptor` now returns an `OpenClDeviceListError` error if the device index is out of bounds instead of panicking.
+- `OpenClDeviceLust::device_descriptor` now returns an `OpenClDeviceListError` error if the device index is out of bounds instead of panicking.
+- `channel` and `band` methods of `EnergyField` now return an `EnergyFieldError` error if arguments are out of bounds.
 
 ### Added
 
@@ -95,7 +97,7 @@
 - Add `ChannelRequirement` to specify the channel count requirement for an audio buffer.
 - Add `Rendering` enum to choose between decoding ambisonics using binaural rendering or panning.
 - `SceneParams` implements the `Default` trait.
-- Add `ProbeArrayError`, `ProbeBatchErrors`, `OpenClDeviceListError` errors.
+- Add `ProbeArrayError`, `ProbeBatchErrors`, `OpenClDeviceListError`, `EnergyFieldError` errors.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -77,6 +77,7 @@
 - `Source::get_outputs` now returns an error on failure to allocate sufficient memory for the `SimulationOutputs` (it would `panic!` before the change).
 - `ProbeArray::probe` now returns a `ProbeArrayError` error if the index argument is out of bounds instead of panicking.
 - Methods `remove_probe`, `reverb` and `energy_field` of `ProbeBatch` return a `ProbeBatchError` error if the index argument is out of bounds instead of panicking.
+- `OpenClDeviceLust::device_descriptor` now returns an `OpenClDeviceListError` error if the device index is out of bounds instead of panicking.
 
 ### Added
 
@@ -94,7 +95,7 @@
 - Add `ChannelRequirement` to specify the channel count requirement for an audio buffer.
 - Add `Rendering` enum to choose between decoding ambisonics using binaural rendering or panning.
 - `SceneParams` implements the `Default` trait.
-- Add `ProbeArrayError` and `ProbeBatchErrors` errors.
+- Add `ProbeArrayError`, `ProbeBatchErrors`, `OpenClDeviceListError` errors.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -83,6 +83,7 @@
 - `Reconstructor::reconstruct` now returns a `ReconstructorError` instead of panicking, if the max duration or the max order is exceeded, or if the inputs and outputs have different lengths.
 - `ImpulseResponse::channel` now returns an `ImpulseResponseError` instead of panicking when the channel index is out of bounds.
 - Methods `interleave`, `deinterleave`, `mix`, `downmix`, `convert_ambisonics_into` of `AudioBuffer` now return an `AudioBufferOperationError` when invariants are not satisfied.
+- Renamed `OpenClDeviceList::new` to `try_new` for consistency.
 
 ### Added
 
@@ -101,6 +102,7 @@
 - Add `Rendering` enum to choose between decoding ambisonics using binaural rendering or panning.
 - `SceneParams` implements the `Default` trait.
 - Add `ProbeArrayError`, `ProbeBatchErrors`, `OpenClDeviceListError`, `EnergyFieldError`, `ReconstructorError`, `ImpulseResponseError`, `AudioBufferOperationError` errors.
+- `OpenClDeviceType` and `OpenClDeviceDescriptor` implement `PartialEq` trait.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -75,6 +75,8 @@
 - `AmbisonicsBinauralEffect::tail` now returns an `EffectError` when the output buffer does not have exactly two channels.
 - Refactored `ReflectionEffect`, `ReflectionMixer`, and `ReflectionEffectParams` to use compile-time type safety via generic parameters (`Convolution`, `Parametric`, `Hybrid`, `TrueAudioNext`). This prevents segmentation faults by ensuring TrueAudioNext effects can only use `apply_into_mixer()` (not `apply()`), and guarantees effect parameters match their corresponding effect types. `ReflectionEffectSettings` is now a simple struct, with the algorithm type specified through the generic parameter.
 - `Source::get_outputs` now returns an error on failure to allocate sufficient memory for the `SimulationOutputs` (it would `panic!` before the change).
+- `ProbeArray::probe` now returns a `ProbeArrayError` error if the index argument is out of bounds instead of panicking.
+- Methods `remove_probe`, `reverb` and `energy_field` of `ProbeBatch` return a `ProbeBatchError` error if the index argument is out of bounds instead of panicking.
 
 ### Added
 
@@ -92,6 +94,7 @@
 - Add `ChannelRequirement` to specify the channel count requirement for an audio buffer.
 - Add `Rendering` enum to choose between decoding ambisonics using binaural rendering or panning.
 - `SceneParams` implements the `Default` trait.
+- Add `ProbeArrayError` and `ProbeBatchErrors` errors.
 
 ### Removed
 

--- a/audionimbus/src/device/open_cl.rs
+++ b/audionimbus/src/device/open_cl.rs
@@ -228,7 +228,7 @@ unsafe impl Send for OpenClDeviceList {}
 unsafe impl Sync for OpenClDeviceList {}
 
 /// [`OpenClDeviceList`] errors.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum OpenClDeviceListError {
     /// Device index is out of bounds.
     DeviceIndexOutOfBounds {

--- a/audionimbus/src/device/open_cl.rs
+++ b/audionimbus/src/device/open_cl.rs
@@ -126,25 +126,24 @@ unsafe impl Sync for OpenClDevice {}
 pub struct OpenClDeviceList(audionimbus_sys::IPLOpenCLDeviceList);
 
 impl OpenClDeviceList {
-    pub fn new(
+    pub fn try_new(
         context: &Context,
         open_cl_device_settings: &OpenClDeviceSettings,
     ) -> Result<Self, SteamAudioError> {
-        let open_cl_device_list = unsafe {
-            let open_cl_device_list: *mut audionimbus_sys::IPLOpenCLDeviceList =
-                std::ptr::null_mut();
-            let status = audionimbus_sys::iplOpenCLDeviceListCreate(
+        let mut open_cl_device_list: audionimbus_sys::IPLOpenCLDeviceList = std::ptr::null_mut();
+        let mut settings = audionimbus_sys::IPLOpenCLDeviceSettings::from(open_cl_device_settings);
+
+        let status = unsafe {
+            audionimbus_sys::iplOpenCLDeviceListCreate(
                 context.raw_ptr(),
-                &mut audionimbus_sys::IPLOpenCLDeviceSettings::from(open_cl_device_settings),
-                open_cl_device_list,
-            );
-
-            if let Some(error) = to_option_error(status) {
-                return Err(error);
-            }
-
-            *open_cl_device_list
+                &mut settings,
+                &mut open_cl_device_list,
+            )
         };
+
+        if let Some(error) = to_option_error(status) {
+            return Err(error);
+        }
 
         Ok(Self(open_cl_device_list))
     }
@@ -312,7 +311,7 @@ impl From<&OpenClDeviceSettings> for audionimbus_sys::IPLOpenCLDeviceSettings {
 }
 
 /// The type of device.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum OpenClDeviceType {
     /// List both CPU and GPU devices.
     Any,
@@ -346,7 +345,7 @@ impl From<audionimbus_sys::IPLOpenCLDeviceType> for OpenClDeviceType {
 
 /// Describes the properties of an OpenCL device.
 /// This information can be used to select the most suitable device for your application.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct OpenClDeviceDescriptor {
     /// The OpenCL platform id.
     pub platform: *mut std::ffi::c_void,
@@ -426,5 +425,58 @@ impl TryFrom<&audionimbus_sys::IPLOpenCLDeviceDesc> for OpenClDeviceDescriptor {
             granularity: ipl_descriptor.granularity,
             perf_score: ipl_descriptor.perfScore,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::*;
+
+    mod open_cl_device {
+        use super::*;
+
+        mod device_descriptor {
+            use super::*;
+
+            #[test]
+            fn test_valid() {
+                let context = Context::default();
+
+                let settings = OpenClDeviceSettings::default();
+                let Ok(device_list) = OpenClDeviceList::try_new(&context, &settings) else {
+                    // OpenCL not available
+                    return;
+                };
+
+                let num_devices = device_list.num_devices();
+
+                if num_devices > 0 {
+                    assert!(device_list.device_descriptor(0).is_ok());
+                    assert!(device_list.device_descriptor(num_devices - 1).is_ok());
+                }
+            }
+
+            #[test]
+            fn test_index_out_of_bounds() {
+                let context = Context::default();
+
+                let settings = OpenClDeviceSettings::default();
+                let Ok(device_list) = OpenClDeviceList::try_new(&context, &settings) else {
+                    // OpenCL not available
+                    return;
+                };
+
+                let num_devices = device_list.num_devices();
+
+                assert_eq!(
+                    device_list.device_descriptor(num_devices + 5),
+                    Err(OpenClDeviceListError::DeviceIndexOutOfBounds {
+                        device_index: num_devices + 5,
+                        num_devices,
+                    }),
+                );
+            }
+        }
     }
 }

--- a/audionimbus/src/effect/ambisonics/type.rs
+++ b/audionimbus/src/effect/ambisonics/type.rs
@@ -9,7 +9,7 @@ pub enum AmbisonicsType {
     SN3D,
 
     /// Furse-Malham (B-format).
-    FUMA,
+    FuMa,
 }
 
 impl From<AmbisonicsType> for audionimbus_sys::IPLAmbisonicsType {
@@ -17,7 +17,7 @@ impl From<AmbisonicsType> for audionimbus_sys::IPLAmbisonicsType {
         match ambisonics_type {
             AmbisonicsType::N3D => audionimbus_sys::IPLAmbisonicsType::IPL_AMBISONICSTYPE_N3D,
             AmbisonicsType::SN3D => audionimbus_sys::IPLAmbisonicsType::IPL_AMBISONICSTYPE_SN3D,
-            AmbisonicsType::FUMA => audionimbus_sys::IPLAmbisonicsType::IPL_AMBISONICSTYPE_FUMA,
+            AmbisonicsType::FuMa => audionimbus_sys::IPLAmbisonicsType::IPL_AMBISONICSTYPE_FUMA,
         }
     }
 }

--- a/audionimbus/src/energy_field.rs
+++ b/audionimbus/src/energy_field.rs
@@ -212,7 +212,7 @@ impl From<&EnergyFieldSettings> for audionimbus_sys::IPLEnergyFieldSettings {
 }
 
 /// [`EnergyField`] errors.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum EnergyFieldError {
     /// Channel index is out of bounds.
     ChannelIndexOutOfBounds {

--- a/audionimbus/src/reconstructor.rs
+++ b/audionimbus/src/reconstructor.rs
@@ -227,7 +227,7 @@ impl From<&ReconstructorOutputs<'_>> for audionimbus_sys::IPLReconstructorOutput
 }
 
 /// [`Reconstructor`] errors.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ReconstructorError {
     /// Duration exceeds the maximum duration specified in the reconstructor's settings.
     DurationExceedsMax { duration: f32, max_duration: f32 },

--- a/audionimbus/tests/audio_buffer.rs
+++ b/audionimbus/tests/audio_buffer.rs
@@ -12,7 +12,7 @@ fn test_buffer_mix() {
     let mix_container = vec![0.2; FRAME_SIZE];
     let mut mix_buffer = AudioBuffer::try_with_data(&mix_container).unwrap();
 
-    mix_buffer.mix(&context, &source_buffer);
+    assert!(mix_buffer.mix(&context, &source_buffer).is_ok());
 
     assert_eq!(mix_container, vec![0.3; FRAME_SIZE]);
 }
@@ -42,7 +42,7 @@ fn test_buffer_mix_multichannel() {
     )
     .unwrap();
 
-    mix_buffer.mix(&context, &source_buffer);
+    assert!(mix_buffer.mix(&context, &source_buffer).is_ok());
 
     // First channel: 0.3 + 0.1 = 0.4
     assert_eq!(&mix_container[0..FRAME_SIZE], &vec![0.4; FRAME_SIZE][..]);
@@ -69,7 +69,7 @@ fn test_buffer_downmix() {
     let mut downmix_container = vec![0.0; FRAME_SIZE];
     let mut downmix_buffer = AudioBuffer::try_with_data(&mut downmix_container).unwrap();
 
-    downmix_buffer.downmix(&context, &input_buffer);
+    assert!(downmix_buffer.downmix(&context, &input_buffer).is_ok());
 
     assert_eq!(downmix_container, vec![0.2; FRAME_SIZE]);
 }
@@ -95,7 +95,7 @@ fn test_buffer_downmix_multichannel() {
     let mut downmix_container = vec![0.0; FRAME_SIZE];
     let mut downmix_buffer = AudioBuffer::try_with_data(&mut downmix_container).unwrap();
 
-    downmix_buffer.downmix(&context, &input_buffer);
+    assert!(downmix_buffer.downmix(&context, &input_buffer).is_ok());
 
     // Average of 0.1, 0.2, 0.3, 0.4 = 0.25
     assert_eq!(downmix_container, vec![0.25; FRAME_SIZE]);
@@ -120,7 +120,7 @@ fn test_buffer_interleave_deinterleave() {
 
     // Interleave
     let mut interleaved = vec![0.0; NUM_CHANNELS * FRAME_SIZE];
-    buffer.interleave(&context, &mut interleaved);
+    assert!(buffer.interleave(&context, &mut interleaved).is_ok());
 
     // Verify interleaving: [ch0[0], ch1[0], ch0[1], ch1[1], ...]
     for i in 0..FRAME_SIZE {
@@ -136,7 +136,7 @@ fn test_buffer_interleave_deinterleave() {
     )
     .unwrap();
 
-    buffer_back.deinterleave(&context, &interleaved);
+    assert!(buffer_back.deinterleave(&context, &interleaved).is_ok());
 
     assert_eq!(deinterleaved_back, deinterleaved);
 }
@@ -190,12 +190,14 @@ fn test_convert_ambisonics_into() {
     )
     .unwrap();
 
-    n3d_buffer.convert_ambisonics_into(
-        &context,
-        AmbisonicsType::N3D,
-        AmbisonicsType::SN3D,
-        &mut sn3d_buffer,
-    );
+    assert!(n3d_buffer
+        .convert_ambisonics_into(
+            &context,
+            AmbisonicsType::N3D,
+            AmbisonicsType::SN3D,
+            &mut sn3d_buffer,
+        )
+        .is_ok());
 
     // Output should be written into sn3d_buffer.
     assert_ne!(sn3d_data[0], 0.0);

--- a/audionimbus/tests/effect.rs
+++ b/audionimbus/tests/effect.rs
@@ -50,7 +50,7 @@ fn test_binaural_effect() {
 
     let mut interleaved =
         vec![0.0; (output_buffer.num_channels() * output_buffer.num_samples()) as usize];
-    output_buffer.interleave(&context, &mut interleaved);
+    assert!(output_buffer.interleave(&context, &mut interleaved).is_ok());
 }
 
 #[test]
@@ -96,7 +96,7 @@ fn test_ambisonics_encode_effect() {
 
     let mut interleaved =
         vec![0.0; (output_buffer.num_channels() * output_buffer.num_samples()) as usize];
-    output_buffer.interleave(&context, &mut interleaved);
+    assert!(output_buffer.interleave(&context, &mut interleaved).is_ok());
 }
 
 #[test]
@@ -156,7 +156,7 @@ fn test_ambisonics_decode_effect() {
 
     let mut interleaved =
         vec![0.0; (output_buffer.num_channels() * output_buffer.num_samples()) as usize];
-    output_buffer.interleave(&context, &mut interleaved);
+    assert!(output_buffer.interleave(&context, &mut interleaved).is_ok());
 }
 
 #[test]
@@ -203,7 +203,7 @@ fn test_direct_effect() {
 
     let mut interleaved =
         vec![0.0; (output_buffer.num_channels() * output_buffer.num_samples()) as usize];
-    output_buffer.interleave(&context, &mut interleaved);
+    assert!(output_buffer.interleave(&context, &mut interleaved).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Replaces all `panic!` and `assert!` calls with proper `Result`-based error handling across the library.

## Changed

### Error Handling Improvements
- `ImpulseResponse::channel` now returns `ImpulseResponseError` if the channel index is out of bounds instead of panicking.
- `Reconstructor::reconstruct` now returns `ReconstructorError` instead of panicking if:
  - The duration exceeds max duration
  - The order exceeds max order  
  - The inputs and outputs arrays have different lengths
- `ProbeArray::probe` now returns `ProbeArrayError` if the index is out of bounds instead of panicking.
- `ProbeBatch` methods `remove_probe`, `reverb`, and `energy_field` now return `ProbeBatchError` if the probe index is out of bounds instead of panicking.
- `Scene::save` now returns `SceneError` if the scene was not created with the default ray tracer instead of panicking.
- `AudioBuffer` methods `interleave`, `deinterleave`, `mix`, `downmix`, and `convert_ambisonics_into` now return `AudioBufferOperationError` when validation fails instead of panicking.
- `EnergyField` methods `channel` and `band` now return `EnergyFieldError` if indices are out of bounds instead of panicking.
- `OpenClDeviceList::device_descriptor` now returns `OpenClDeviceListError` if the device index is out of bounds instead of panicking.

### API Consistency
- Renamed `OpenClDeviceList::new` to `try_new` for consistency with other constructors.
- Renamed `AmbisonicsType::FUMA` variant to `AmbisonicsType::FuMa` for correct capitalization.

## Added

- `ImpulseResponseError` - Error type for impulse response channel access
- `ReconstructorError` - Error type for reconstructor validation failures
- `ProbeArrayError` - Error type for probe array index validation
- `ProbeBatchError` - Error type for probe batch operations
- `SceneError` - Error type for scene save operations
- `AudioBufferOperationError` - Error type for audio buffer operations (distinct from existing `AudioBufferError`)
- `EnergyFieldError` - Error type for energy field channel/band access
- `OpenClDeviceListError` - Error type for OpenCL device list operations
- `PartialEq` implementation for `OpenClDeviceType` and `OpenClDeviceDescriptor`