### PR TITLE
Apply clippy pedantic and nursery lints

### DIFF
--- a/audionimbus-sys/build.rs
+++ b/audionimbus-sys/build.rs
@@ -18,7 +18,7 @@ fn main() {
     #[cfg(feature = "auto-install")]
     {
         if let Err(e) = handle_auto_install() {
-            panic!("auto-install failed: {}", e);
+            panic!("auto-install failed: {e}");
         }
     }
 
@@ -71,7 +71,7 @@ struct TargetInfo {
 fn get_target_info() -> Result<TargetInfo, Box<dyn std::error::Error>> {
     let target = std::env::var("TARGET")?;
 
-    let (platform, arch, lib_dir, lib_names, _is_static) = match target.as_str() {
+    let (platform, arch, lib_dir, lib_names, is_static) = match target.as_str() {
         t if t.contains("windows") && t.contains("i686") => (
             "windows".to_string(),
             "x86".to_string(),
@@ -142,7 +142,7 @@ fn get_target_info() -> Result<TargetInfo, Box<dyn std::error::Error>> {
             vec!["libphonon.a".to_string()],
             true,
         ),
-        _ => return Err(format!("Unsupported target: {}", target).into()),
+        _ => return Err(format!("Unsupported target: {target}").into()),
     };
 
     Ok(TargetInfo {
@@ -150,7 +150,7 @@ fn get_target_info() -> Result<TargetInfo, Box<dyn std::error::Error>> {
         arch,
         lib_dir,
         lib_names,
-        _is_static,
+        _is_static: is_static,
     })
 }
 
@@ -168,7 +168,7 @@ fn install_steam_audio(
     target_info: &TargetInfo,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let version = version().to_string();
-    let zip_name = format!("steamaudio_{}.zip", version);
+    let zip_name = format!("steamaudio_{version}.zip");
     let zip_path = cache_dir.join(&zip_name);
     let extract_dir = cache_dir.join("steamaudio_core");
 
@@ -180,17 +180,13 @@ fn install_steam_audio(
             .trim()
             == version
     {
-        println!(
-            "cargo:warning=Steam Audio {} already installed, skipping download",
-            version
-        );
+        println!("cargo:warning=Steam Audio {version} already installed, skipping download");
     } else {
         // Download if not cached
         if !zip_path.exists() {
-            println!("cargo:warning=Downloading Steam Audio {}...", version);
+            println!("cargo:warning=Downloading Steam Audio {version}...");
             download_file(
-                &format!("https://github.com/ValveSoftware/steam-audio/releases/download/v{}/steamaudio_{}.zip",
-                         version, version),
+                &format!("https://github.com/ValveSoftware/steam-audio/releases/download/v{version}/steamaudio_{version}.zip"),
                 &zip_path
             )?;
         }
@@ -219,7 +215,7 @@ fn install_fmod_integration(
     target_info: &TargetInfo,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let version = version().to_string();
-    let zip_name = format!("steamaudio_fmod_{}.zip", version);
+    let zip_name = format!("steamaudio_fmod_{version}.zip");
     let zip_path = cache_dir.join(&zip_name);
     let extract_dir = cache_dir.join("steamaudio_fmod");
 
@@ -231,20 +227,13 @@ fn install_fmod_integration(
             .trim()
             == version
     {
-        println!(
-            "cargo:warning=Steam Audio FMOD {} already installed, skipping download",
-            version
-        );
+        println!("cargo:warning=Steam Audio FMOD {version} already installed, skipping download");
     } else {
         // Download if not cached
         if !zip_path.exists() {
-            println!(
-                "cargo:warning=Downloading Steam Audio FMOD integration {}...",
-                version
-            );
+            println!("cargo:warning=Downloading Steam Audio FMOD integration {version}...");
             download_file(
-                &format!("https://github.com/ValveSoftware/steam-audio/releases/download/v{}/steamaudio_fmod_{}.zip",
-                         version, version),
+                &format!("https://github.com/ValveSoftware/steam-audio/releases/download/v{version}/steamaudio_fmod_{version}.zip"),
                 &zip_path
             )?;
         }
@@ -281,7 +270,7 @@ fn install_wwise_integration(
     target_info: &TargetInfo,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let version = version().to_string();
-    let zip_name = format!("steamaudio_wwise_{}.zip", version);
+    let zip_name = format!("steamaudio_wwise_{version}.zip");
     let zip_path = cache_dir.join(&zip_name);
     let extract_dir = cache_dir.join("steamaudio_wwise");
 
@@ -293,20 +282,13 @@ fn install_wwise_integration(
             .trim()
             == version
     {
-        println!(
-            "cargo:warning=Steam Audio Wwise {} already installed, skipping download",
-            version
-        );
+        println!("cargo:warning=Steam Audio Wwise {version} already installed, skipping download");
     } else {
         // Download if not cached
         if !zip_path.exists() {
-            println!(
-                "cargo:warning=Downloading Steam Audio Wwise integration {}...",
-                version
-            );
+            println!("cargo:warning=Downloading Steam Audio Wwise integration {version}...");
             download_file(
-                &format!("https://github.com/ValveSoftware/steam-audio/releases/download/v{}/steamaudio_wwise_{}.zip",
-                         version, version),
+                &format!("https://github.com/ValveSoftware/steam-audio/releases/download/v{version}/steamaudio_wwise_{version}.zip"),
                 &zip_path
             )?;
         }
@@ -358,7 +340,7 @@ fn download_file(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Error
 
     // Try to use curl first with progress bar
     let curl_result = Command::new("curl")
-        .args(&[
+        .args([
             "-L",             // Follow redirects
             "--progress-bar", // Show progress bar
             "-f",             // Fail on HTTP errors
@@ -385,7 +367,7 @@ fn download_file(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Error
             // Try wget as fallback with progress
             println!("cargo:warning=curl failed, trying wget...");
             let wget_result = Command::new("wget")
-                .args(&[
+                .args([
                     "--tries=3",     // Retry on failure
                     "--waitretry=1", // Wait between retries
                     "-O",
@@ -400,7 +382,7 @@ fn download_file(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Error
                     Ok(())
                 }
                 Ok(_) => Err("wget failed to download file".into()),
-                Err(e) => Err(format!("Neither curl nor wget available: {}", e).into()),
+                Err(e) => Err(format!("Neither curl nor wget available: {e}").into()),
             }
         }
     }
@@ -447,7 +429,7 @@ fn extract_zip(zip_path: &Path, dest_dir: &Path) -> Result<(), Box<dyn std::erro
 
     // Full CRC test before extracting
     if let Err(e) = test_zip(zip_path) {
-        return Err(format!("Zip file is corrupted: {}", e).into());
+        return Err(format!("Zip file is corrupted: {e}").into());
     }
 
     // Remove existing directory if it exists

--- a/audionimbus-sys/build.rs
+++ b/audionimbus-sys/build.rs
@@ -1,3 +1,5 @@
+use std::string::ToString;
+
 #[cfg(feature = "auto-install")]
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -676,7 +678,7 @@ fn version() -> Version {
 fn temporary_version_header(path: &Path, version: &Version, prefix: &str) -> TemporaryFileGuard {
     let packed_version = (version.major << 16) | (version.minor << 8) | version.patch;
     let version_header = format!(
-        r#"
+        r"
 #ifndef IPL_PHONON_VERSION_H
 #define IPL_PHONON_VERSION_H
 
@@ -686,7 +688,7 @@ fn temporary_version_header(path: &Path, version: &Version, prefix: &str) -> Tem
 #define {prefix}_VERSION       {packed_version}
 
 #endif
-"#,
+",
         version.major, version.minor, version.patch,
     );
     std::fs::write(path, version_header).unwrap();
@@ -743,5 +745,5 @@ fn system_flags() -> Vec<String> {
         flags.push("-DIPL_CPU_ARMV7");
     }
 
-    flags.into_iter().map(|s| s.to_string()).collect()
+    flags.into_iter().map(ToString::to_string).collect()
 }

--- a/audionimbus/src/baking/baked_data.rs
+++ b/audionimbus/src/baking/baked_data.rs
@@ -3,18 +3,21 @@
 use crate::geometry::Sphere;
 
 /// Identifies a “layer” of data stored in a probe batch.
+///
 /// Each probe batch may store multiple layers of data, such as reverb, static source reflections, or pathing.
 /// Each layer can be accessed using an identifier.
 #[derive(Copy, Clone, Debug)]
 pub enum BakedDataIdentifier {
     /// Reflections.
-    /// The source and listener positions used to compute the reflections data stored at each probe depends on the \c IPLBakedDataVariation selected.
+    ///
+    /// The source and listener positions used to compute the reflections data stored at each probe depends on the [`BakedDataVariation`] selected.
     Reflections {
         /// The way in which source and listener positions depend on probe position.
         variation: BakedDataVariation,
     },
 
     /// Pathing.
+    ///
     /// The probe batch stores data about the shortest paths between any pair of probes in the batch.
     Pathing {
         /// The way in which source and listener positions depend on probe position.

--- a/audionimbus/src/baking/error.rs
+++ b/audionimbus/src/baking/error.rs
@@ -1,5 +1,5 @@
 /// Errors that can occur during baking operations.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum BakeError {
     /// Another bake operation is already in progress.
     BakeInProgress,

--- a/audionimbus/src/context.rs
+++ b/audionimbus/src/context.rs
@@ -58,7 +58,7 @@ impl Context {
     ///
     /// This is intended for internal use and advanced scenarios. The returned pointer
     /// must not outlive the `Context` object.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLContext {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLContext {
         self.0
     }
 
@@ -68,7 +68,7 @@ impl Context {
     ///
     /// This is intended for internal use and advanced scenarios. The returned pointer
     /// must not outlive the `Context` object.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLContext {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLContext {
         &mut self.0
     }
 }
@@ -91,7 +91,7 @@ impl Clone for Context {
 
 impl Drop for Context {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplContextRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplContextRelease(&raw mut self.0) }
     }
 }
 
@@ -125,7 +125,7 @@ pub struct ContextSettings {
     ///
     /// Steam Audio automatically chooses the best instruction set to use based on the user’s CPU, but you can prevent it from using certain newer instruction sets using this parameter.
     /// For example, with some workloads, AVX512 instructions consume enough power that the CPU clock speed will be throttled, resulting in lower performance than expected.
-    /// If you observe this in your application, set this parameter to IPL_SIMDLEVEL_AVX2 or lower.
+    /// If you observe this in your application, set this parameter to [`SimdLevel::AVX2`] or lower.
     pub simd_level: SimdLevel,
 
     /// Additional flags for modifying the behavior of the created context.

--- a/audionimbus/src/device/embree.rs
+++ b/audionimbus/src/device/embree.rs
@@ -39,14 +39,14 @@ impl EmbreeDevice {
     /// Returns the raw FFI pointer to the underlying Embree device.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLEmbreeDevice {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLEmbreeDevice {
         self.0
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLEmbreeDevice {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLEmbreeDevice {
         &mut self.0
     }
 }
@@ -62,7 +62,7 @@ impl Clone for EmbreeDevice {
 
 impl Drop for EmbreeDevice {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplEmbreeDeviceRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplEmbreeDeviceRelease(&raw mut self.0) }
     }
 }
 

--- a/audionimbus/src/device/radeon_rays.rs
+++ b/audionimbus/src/device/radeon_rays.rs
@@ -39,14 +39,14 @@ impl RadeonRaysDevice {
     /// Returns the raw FFI pointer to the underlying Radeon Rays device.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLRadeonRaysDevice {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLRadeonRaysDevice {
         self.0
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLRadeonRaysDevice {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLRadeonRaysDevice {
         &mut self.0
     }
 }
@@ -62,7 +62,7 @@ impl Clone for RadeonRaysDevice {
 
 impl Drop for RadeonRaysDevice {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplRadeonRaysDeviceRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplRadeonRaysDeviceRelease(&raw mut self.0) }
     }
 }
 

--- a/audionimbus/src/device/true_audio_next.rs
+++ b/audionimbus/src/device/true_audio_next.rs
@@ -39,14 +39,14 @@ impl TrueAudioNextDevice {
     /// Returns the raw FFI pointer to the underlying TrueAudio Next device.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLTrueAudioNextDevice {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLTrueAudioNextDevice {
         self.0
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLTrueAudioNextDevice {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLTrueAudioNextDevice {
         &mut self.0
     }
 }
@@ -68,7 +68,7 @@ impl Clone for TrueAudioNextDevice {
 
 impl Drop for TrueAudioNextDevice {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplTrueAudioNextDeviceRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplTrueAudioNextDeviceRelease(&raw mut self.0) }
     }
 }
 

--- a/audionimbus/src/effect/ambisonics/binaural.rs
+++ b/audionimbus/src/effect/ambisonics/binaural.rs
@@ -129,9 +129,9 @@ impl AmbisonicsBinauralEffect {
         let state = unsafe {
             audionimbus_sys::iplAmbisonicsBinauralEffectApply(
                 self.raw_ptr(),
-                &mut *ambisonics_binaural_effect_params.as_ffi(),
-                &mut *input_buffer.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *ambisonics_binaural_effect_params.as_ffi(),
+                &raw mut *input_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -163,7 +163,7 @@ impl AmbisonicsBinauralEffect {
         let state = unsafe {
             audionimbus_sys::iplAmbisonicsBinauralEffectGetTail(
                 self.raw_ptr(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -186,14 +186,14 @@ impl AmbisonicsBinauralEffect {
     /// Returns the raw FFI pointer to the underlying ambisonics binaural effect.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsBinauralEffect {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsBinauralEffect {
         self.0
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsBinauralEffect {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsBinauralEffect {
         &mut self.0
     }
 }
@@ -209,7 +209,7 @@ impl Clone for AmbisonicsBinauralEffect {
 
 impl Drop for AmbisonicsBinauralEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplAmbisonicsBinauralEffectRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplAmbisonicsBinauralEffectRelease(&raw mut self.0) }
     }
 }
 

--- a/audionimbus/src/effect/ambisonics/decode.rs
+++ b/audionimbus/src/effect/ambisonics/decode.rs
@@ -88,7 +88,7 @@ impl AmbisonicsDecodeEffect {
                 &mut audionimbus_sys::IPLAmbisonicsDecodeEffectSettings::from(
                     ambisonics_decode_effect_settings,
                 ),
-                &mut inner,
+                &raw mut inner,
             )
         };
 
@@ -177,9 +177,9 @@ impl AmbisonicsDecodeEffect {
         let state = unsafe {
             audionimbus_sys::iplAmbisonicsDecodeEffectApply(
                 self.raw_ptr(),
-                &mut ambisonics_decode_effect_params_ffi,
-                &mut *input_buffer.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut ambisonics_decode_effect_params_ffi,
+                &raw mut *input_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -212,7 +212,7 @@ impl AmbisonicsDecodeEffect {
         let state = unsafe {
             audionimbus_sys::iplAmbisonicsDecodeEffectGetTail(
                 self.raw_ptr(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -235,14 +235,14 @@ impl AmbisonicsDecodeEffect {
     /// Returns the raw FFI pointer to the underlying ambisonics decode effect.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsDecodeEffect {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsDecodeEffect {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsDecodeEffect {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsDecodeEffect {
         &mut self.inner
     }
 }
@@ -264,7 +264,7 @@ impl Clone for AmbisonicsDecodeEffect {
 
 impl Drop for AmbisonicsDecodeEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplAmbisonicsDecodeEffectRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplAmbisonicsDecodeEffectRelease(&raw mut self.inner) }
     }
 }
 
@@ -315,7 +315,7 @@ pub struct AmbisonicsDecodeEffectParams<'a> {
 }
 
 /// Rendering for the ambisonics decode effect.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Rendering {
     /// Binaural rendering
     Binaural,

--- a/audionimbus/src/effect/ambisonics/encode.rs
+++ b/audionimbus/src/effect/ambisonics/encode.rs
@@ -75,7 +75,7 @@ impl AmbisonicsEncodeEffect {
                 &mut audionimbus_sys::IPLAmbisonicsEncodeEffectSettings::from(
                     ambisonics_encode_effect_settings,
                 ),
-                &mut inner,
+                &raw mut inner,
             )
         };
 
@@ -134,9 +134,9 @@ impl AmbisonicsEncodeEffect {
         let state = unsafe {
             audionimbus_sys::iplAmbisonicsEncodeEffectApply(
                 self.raw_ptr(),
-                &mut *ambisonics_encode_effect_params.as_ffi(),
-                &mut *input_buffer.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *ambisonics_encode_effect_params.as_ffi(),
+                &raw mut *input_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -168,7 +168,7 @@ impl AmbisonicsEncodeEffect {
         let state = unsafe {
             audionimbus_sys::iplAmbisonicsEncodeEffectGetTail(
                 self.raw_ptr(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -191,14 +191,14 @@ impl AmbisonicsEncodeEffect {
     /// Returns the raw FFI pointer to the underlying ambisonics encode effect.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsEncodeEffect {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsEncodeEffect {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsEncodeEffect {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsEncodeEffect {
         &mut self.inner
     }
 }
@@ -218,7 +218,7 @@ impl Clone for AmbisonicsEncodeEffect {
 
 impl Drop for AmbisonicsEncodeEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplAmbisonicsEncodeEffectRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplAmbisonicsEncodeEffectRelease(&raw mut self.inner) }
     }
 }
 

--- a/audionimbus/src/effect/ambisonics/panning.rs
+++ b/audionimbus/src/effect/ambisonics/panning.rs
@@ -73,7 +73,7 @@ impl AmbisonicsPanningEffect {
                 &mut audionimbus_sys::IPLAmbisonicsPanningEffectSettings::from(
                     ambisonics_panning_effect_settings,
                 ),
-                &mut inner,
+                &raw mut inner,
             )
         };
 
@@ -143,9 +143,9 @@ impl AmbisonicsPanningEffect {
         let state = unsafe {
             audionimbus_sys::iplAmbisonicsPanningEffectApply(
                 self.raw_ptr(),
-                &mut *ambisonics_panning_effect_params.as_ffi(),
-                &mut *input_buffer.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *ambisonics_panning_effect_params.as_ffi(),
+                &raw mut *input_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -178,7 +178,7 @@ impl AmbisonicsPanningEffect {
         let state = unsafe {
             audionimbus_sys::iplAmbisonicsPanningEffectGetTail(
                 self.raw_ptr(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -201,14 +201,14 @@ impl AmbisonicsPanningEffect {
     /// Returns the raw FFI pointer to the underlying ambisonics panning effect.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsPanningEffect {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsPanningEffect {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsPanningEffect {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsPanningEffect {
         &mut self.inner
     }
 }
@@ -228,7 +228,7 @@ impl Clone for AmbisonicsPanningEffect {
 
 impl Drop for AmbisonicsPanningEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplAmbisonicsPanningEffectRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplAmbisonicsPanningEffectRelease(&raw mut self.inner) }
     }
 }
 

--- a/audionimbus/src/effect/ambisonics/rotation.rs
+++ b/audionimbus/src/effect/ambisonics/rotation.rs
@@ -77,7 +77,7 @@ impl AmbisonicsRotationEffect {
                 &mut audionimbus_sys::IPLAmbisonicsRotationEffectSettings::from(
                     ambisonics_rotation_effect_settings,
                 ),
-                &mut inner,
+                &raw mut inner,
             )
         };
 
@@ -135,9 +135,9 @@ impl AmbisonicsRotationEffect {
         let state = unsafe {
             audionimbus_sys::iplAmbisonicsRotationEffectApply(
                 self.raw_ptr(),
-                &mut *ambisonics_rotation_effect_params.as_ffi(),
-                &mut *input_buffer.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *ambisonics_rotation_effect_params.as_ffi(),
+                &raw mut *input_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -193,14 +193,14 @@ impl AmbisonicsRotationEffect {
     /// Returns the raw FFI pointer to the underlying ambisonics rotation effect.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsRotationEffect {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLAmbisonicsRotationEffect {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsRotationEffect {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLAmbisonicsRotationEffect {
         &mut self.inner
     }
 }
@@ -220,7 +220,7 @@ impl Clone for AmbisonicsRotationEffect {
 
 impl Drop for AmbisonicsRotationEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplAmbisonicsRotationEffectRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplAmbisonicsRotationEffectRelease(&raw mut self.inner) }
     }
 }
 

--- a/audionimbus/src/effect/ambisonics/speaker_layout.rs
+++ b/audionimbus/src/effect/ambisonics/speaker_layout.rs
@@ -28,7 +28,7 @@ pub enum SpeakerLayout {
 
 impl SpeakerLayout {
     /// Returns the name of this speaker layout.
-    fn name(&self) -> &'static str {
+    const fn name(&self) -> &'static str {
         match self {
             Self::Mono => "mono",
             Self::Stereo => "stereo",

--- a/audionimbus/src/effect/ambisonics/type.rs
+++ b/audionimbus/src/effect/ambisonics/type.rs
@@ -15,9 +15,9 @@ pub enum AmbisonicsType {
 impl From<AmbisonicsType> for audionimbus_sys::IPLAmbisonicsType {
     fn from(ambisonics_type: AmbisonicsType) -> Self {
         match ambisonics_type {
-            AmbisonicsType::N3D => audionimbus_sys::IPLAmbisonicsType::IPL_AMBISONICSTYPE_N3D,
-            AmbisonicsType::SN3D => audionimbus_sys::IPLAmbisonicsType::IPL_AMBISONICSTYPE_SN3D,
-            AmbisonicsType::FuMa => audionimbus_sys::IPLAmbisonicsType::IPL_AMBISONICSTYPE_FUMA,
+            AmbisonicsType::N3D => Self::IPL_AMBISONICSTYPE_N3D,
+            AmbisonicsType::SN3D => Self::IPL_AMBISONICSTYPE_SN3D,
+            AmbisonicsType::FuMa => Self::IPL_AMBISONICSTYPE_FUMA,
         }
     }
 }

--- a/audionimbus/src/effect/binaural.rs
+++ b/audionimbus/src/effect/binaural.rs
@@ -120,9 +120,9 @@ impl BinauralEffect {
         let state = unsafe {
             audionimbus_sys::iplBinauralEffectApply(
                 self.raw_ptr(),
-                &mut *binaural_effect_params.as_ffi(),
-                &mut *input_buffer.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *binaural_effect_params.as_ffi(),
+                &raw mut *input_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -152,7 +152,10 @@ impl BinauralEffect {
         }
 
         let state = unsafe {
-            audionimbus_sys::iplBinauralEffectGetTail(self.raw_ptr(), &mut *output_buffer.as_ffi())
+            audionimbus_sys::iplBinauralEffectGetTail(
+                self.raw_ptr(),
+                &raw mut *output_buffer.as_ffi(),
+            )
         }
         .into();
 
@@ -174,14 +177,14 @@ impl BinauralEffect {
     /// Returns the raw FFI pointer to the underlying binaural effect.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLBinauralEffect {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLBinauralEffect {
         self.0
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLBinauralEffect {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLBinauralEffect {
         &mut self.0
     }
 }
@@ -197,7 +200,7 @@ impl Clone for BinauralEffect {
 
 impl Drop for BinauralEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplBinauralEffectRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplBinauralEffectRelease(&raw mut self.0) }
     }
 }
 
@@ -247,8 +250,9 @@ impl BinauralEffectParams<'_> {
         let peak_delays_ptr = self
             .peak_delays
             .as_ref()
-            .map(|peak_delays| peak_delays.as_ptr() as *mut f32)
-            .unwrap_or(std::ptr::null_mut());
+            .map_or(std::ptr::null_mut(), |peak_delays| {
+                peak_delays.as_ptr().cast_mut()
+            });
 
         let binaural_effect_params = audionimbus_sys::IPLBinauralEffectParams {
             direction: self.direction.into(),

--- a/audionimbus/src/effect/direct.rs
+++ b/audionimbus/src/effect/direct.rs
@@ -68,7 +68,7 @@ impl DirectEffect {
                 context.raw_ptr(),
                 &mut audionimbus_sys::IPLAudioSettings::from(audio_settings),
                 &mut audionimbus_sys::IPLDirectEffectSettings::from(direct_effect_settings),
-                &mut inner,
+                &raw mut inner,
             )
         };
 
@@ -124,9 +124,9 @@ impl DirectEffect {
         let state = unsafe {
             audionimbus_sys::iplDirectEffectApply(
                 self.raw_ptr(),
-                &mut *direct_effect_params.as_ffi(),
-                &mut *input_buffer.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *direct_effect_params.as_ffi(),
+                &raw mut *input_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -157,7 +157,10 @@ impl DirectEffect {
         }
 
         let state = unsafe {
-            audionimbus_sys::iplDirectEffectGetTail(self.raw_ptr(), &mut *output_buffer.as_ffi())
+            audionimbus_sys::iplDirectEffectGetTail(
+                self.raw_ptr(),
+                &raw mut *output_buffer.as_ffi(),
+            )
         }
         .into();
 
@@ -179,14 +182,14 @@ impl DirectEffect {
     /// Returns the raw FFI pointer to the underlying direct effect.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLDirectEffect {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLDirectEffect {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLDirectEffect {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLDirectEffect {
         &mut self.inner
     }
 }
@@ -206,7 +209,7 @@ impl Clone for DirectEffect {
 
 impl Drop for DirectEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplDirectEffectRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplDirectEffectRelease(&raw mut self.inner) }
     }
 }
 
@@ -281,7 +284,7 @@ impl DirectEffectParams {
             flags |= audionimbus_sys::IPLDirectEffectFlags::IPL_DIRECTEFFECTFLAGS_APPLYDISTANCEATTENUATION;
         }
 
-        let default_air_absorption = Default::default();
+        let default_air_absorption = Equalizer::default();
         let air_absorption = self
             .air_absorption
             .as_ref()
@@ -317,7 +320,7 @@ impl DirectEffectParams {
         } else {
             (
                 audionimbus_sys::IPLTransmissionType::IPL_TRANSMISSIONTYPE_FREQINDEPENDENT,
-                &Default::default(),
+                &Equalizer::default(),
             )
         };
 

--- a/audionimbus/src/effect/error.rs
+++ b/audionimbus/src/effect/error.rs
@@ -1,7 +1,7 @@
 use crate::ChannelRequirement;
 
 /// Errors that can occur when applying audio effects.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum EffectError {
     /// Input buffer has wrong number of channels.
     InvalidInputChannels {
@@ -24,15 +24,13 @@ impl std::fmt::Display for EffectError {
             Self::InvalidInputChannels { expected, actual } => {
                 write!(
                     f,
-                    "invalid number of input channels: expected {}, got {}",
-                    expected, actual
+                    "invalid number of input channels: expected {expected}, got {actual}",
                 )
             }
             Self::InvalidOutputChannels { expected, actual } => {
                 write!(
                     f,
-                    "invalid number of output channels: expected {}, got {}",
-                    expected, actual
+                    "invalid number of output channels: expected {expected}, got {actual}",
                 )
             }
         }

--- a/audionimbus/src/effect/panning.rs
+++ b/audionimbus/src/effect/panning.rs
@@ -69,7 +69,7 @@ impl PanningEffect {
                 context.raw_ptr(),
                 &mut audionimbus_sys::IPLAudioSettings::from(audio_settings),
                 &mut audionimbus_sys::IPLPanningEffectSettings::from(panning_effect_settings),
-                &mut inner,
+                &raw mut inner,
             )
         };
 
@@ -134,9 +134,9 @@ impl PanningEffect {
         let state = unsafe {
             audionimbus_sys::iplPanningEffectApply(
                 self.raw_ptr(),
-                &mut *panning_effect_params.as_ffi(),
-                &mut *input_buffer.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *panning_effect_params.as_ffi(),
+                &raw mut *input_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -167,7 +167,10 @@ impl PanningEffect {
         }
 
         let state = unsafe {
-            audionimbus_sys::iplPanningEffectGetTail(self.raw_ptr(), &mut *output_buffer.as_ffi())
+            audionimbus_sys::iplPanningEffectGetTail(
+                self.raw_ptr(),
+                &raw mut *output_buffer.as_ffi(),
+            )
         }
         .into();
 
@@ -189,14 +192,14 @@ impl PanningEffect {
     /// Returns the raw FFI pointer to the underlying panning effect.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLPanningEffect {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLPanningEffect {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLPanningEffect {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLPanningEffect {
         &mut self.inner
     }
 }
@@ -216,7 +219,7 @@ impl Clone for PanningEffect {
 
 impl Drop for PanningEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplPanningEffectRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplPanningEffectRelease(&raw mut self.inner) }
     }
 }
 

--- a/audionimbus/src/effect/pathing.rs
+++ b/audionimbus/src/effect/pathing.rs
@@ -197,7 +197,7 @@ impl PathEffect {
                 context.raw_ptr(),
                 &mut audionimbus_sys::IPLAudioSettings::from(audio_settings),
                 &mut audionimbus_sys::IPLPathEffectSettings::from(path_effect_settings),
-                &mut inner,
+                &raw mut inner,
             )
         };
 
@@ -256,9 +256,9 @@ impl PathEffect {
         let state = unsafe {
             audionimbus_sys::iplPathEffectApply(
                 self.raw_ptr(),
-                &mut *path_effect_params.as_ffi(),
-                &mut *input_buffer.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *path_effect_params.as_ffi(),
+                &raw mut *input_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -289,7 +289,7 @@ impl PathEffect {
         }
 
         let state = unsafe {
-            audionimbus_sys::iplPathEffectGetTail(self.raw_ptr(), &mut *output_buffer.as_ffi())
+            audionimbus_sys::iplPathEffectGetTail(self.raw_ptr(), &raw mut *output_buffer.as_ffi())
         }
         .into();
 
@@ -311,14 +311,14 @@ impl PathEffect {
     /// Returns the raw FFI pointer to the underlying path effect.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLPathEffect {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLPathEffect {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLPathEffect {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLPathEffect {
         &mut self.inner
     }
 }
@@ -338,7 +338,7 @@ impl Clone for PathEffect {
 
 impl Drop for PathEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplPathEffectRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplPathEffectRelease(&raw mut self.inner) }
     }
 }
 
@@ -438,7 +438,7 @@ pub struct ShCoeffs(pub *mut f32);
 unsafe impl Send for ShCoeffs {}
 
 impl ShCoeffs {
-    pub fn raw_ptr(&self) -> *mut f32 {
+    pub const fn raw_ptr(&self) -> *mut f32 {
         self.0
     }
 }

--- a/audionimbus/src/effect/reflections.rs
+++ b/audionimbus/src/effect/reflections.rs
@@ -64,7 +64,7 @@ impl CanApplyDirectly for Convolution {}
 impl CanApplyDirectly for Parametric {}
 impl CanApplyDirectly for Hybrid {}
 
-/// Marker trait for effects that can use `apply_into_mixer() and `tail_into_mixer()``.
+/// Marker trait for effects that can use `apply_into_mixer() and `tail_into_mixer()`.
 pub trait CanUseReflectionMixer: sealed::Sealed {}
 impl CanUseReflectionMixer for Convolution {}
 impl CanUseReflectionMixer for TrueAudioNext {}
@@ -375,7 +375,7 @@ impl<T: ReflectionEffectType> ReflectionEffect<T> {
                 context.raw_ptr(),
                 &mut audionimbus_sys::IPLAudioSettings::from(audio_settings),
                 &mut T::ffi_settings(reflection_effect_settings),
-                &mut inner,
+                &raw mut inner,
             )
         };
 
@@ -409,14 +409,14 @@ impl<T: ReflectionEffectType> ReflectionEffect<T> {
     /// Returns the raw FFI pointer to the underlying reflection effect.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLReflectionEffect {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLReflectionEffect {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLReflectionEffect {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLReflectionEffect {
         &mut self.inner
     }
 }
@@ -469,9 +469,9 @@ impl<T: ReflectionEffectType + CanApplyDirectly> ReflectionEffect<T> {
         let state = unsafe {
             audionimbus_sys::iplReflectionEffectApply(
                 self.raw_ptr(),
-                &mut *reflection_effect_params.as_ffi(),
-                &mut *input_buffer.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *reflection_effect_params.as_ffi(),
+                &raw mut *input_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
                 std::ptr::null_mut(),
             )
         }
@@ -510,7 +510,7 @@ impl<T: ReflectionEffectType + CanApplyDirectly> ReflectionEffect<T> {
         let state = unsafe {
             audionimbus_sys::iplReflectionEffectGetTail(
                 self.raw_ptr(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
                 std::ptr::null_mut(),
             )
         }
@@ -622,7 +622,7 @@ impl<T: ReflectionEffectType + CanUseReflectionMixer> ReflectionEffect<T> {
         let state = unsafe {
             audionimbus_sys::iplReflectionEffectGetTail(
                 self.raw_ptr(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
                 mixer.raw_ptr(),
             )
         }
@@ -648,7 +648,7 @@ impl<T: ReflectionEffectType> Clone for ReflectionEffect<T> {
 
 impl<T: ReflectionEffectType> Drop for ReflectionEffect<T> {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplReflectionEffectRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplReflectionEffectRelease(&raw mut self.inner) }
     }
 }
 
@@ -759,7 +759,7 @@ impl ReflectionEffectParams<Hybrid> {
     /// - `delay`: samples after which parametric part starts.
     /// - `num_channels`: number of IR channels to process. May be less than the number of channels specified when creating the effect, in which case CPU usage will be reduced.
     /// - `impulse_response_size`: number of IR samples per channel to process. May be less than the number of samples specified when creating the effect, in which case CPU usage will be reduced.
-    pub fn new(
+    pub const fn new(
         impulse_response: audionimbus_sys::IPLReflectionEffectIR,
         reverb_times: [f32; 3],
         equalizer: Equalizer<3>,
@@ -888,7 +888,7 @@ impl<T: ReflectionEffectType> ReflectionMixer<T> {
                 context.raw_ptr(),
                 &mut audionimbus_sys::IPLAudioSettings::from(audio_settings),
                 &mut T::ffi_settings(reflection_effect_settings),
-                &mut inner,
+                &raw mut inner,
             )
         };
 
@@ -940,8 +940,8 @@ impl<T: ReflectionEffectType> ReflectionMixer<T> {
         let audio_effect_state = unsafe {
             audionimbus_sys::iplReflectionMixerApply(
                 self.raw_ptr(),
-                &mut *reflection_effect_params.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *reflection_effect_params.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         };
         let state = audio_effect_state.into();
@@ -957,14 +957,14 @@ impl<T: ReflectionEffectType> ReflectionMixer<T> {
     /// Returns the raw FFI pointer to the underlying reflection mixer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLReflectionMixer {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLReflectionMixer {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLReflectionMixer {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLReflectionMixer {
         &mut self.inner
     }
 }
@@ -985,7 +985,7 @@ impl<T: ReflectionEffectType> Clone for ReflectionMixer<T> {
 
 impl<T: ReflectionEffectType> Drop for ReflectionMixer<T> {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplReflectionMixerRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplReflectionMixerRelease(&raw mut self.inner) }
     }
 }
 

--- a/audionimbus/src/effect/virtual_surround.rs
+++ b/audionimbus/src/effect/virtual_surround.rs
@@ -80,7 +80,7 @@ impl VirtualSurroundEffect {
                 &mut audionimbus_sys::IPLVirtualSurroundEffectSettings::from(
                     virtual_surround_effect_settings,
                 ),
-                &mut inner,
+                &raw mut inner,
             )
         };
 
@@ -144,9 +144,9 @@ impl VirtualSurroundEffect {
         let state = unsafe {
             audionimbus_sys::iplVirtualSurroundEffectApply(
                 self.raw_ptr(),
-                &mut *virtual_surround_effect_params.as_ffi(),
-                &mut *input_buffer.as_ffi(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *virtual_surround_effect_params.as_ffi(),
+                &raw mut *input_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -178,7 +178,7 @@ impl VirtualSurroundEffect {
         let state = unsafe {
             audionimbus_sys::iplVirtualSurroundEffectGetTail(
                 self.raw_ptr(),
-                &mut *output_buffer.as_ffi(),
+                &raw mut *output_buffer.as_ffi(),
             )
         }
         .into();
@@ -201,14 +201,14 @@ impl VirtualSurroundEffect {
     /// Returns the raw FFI pointer to the underlying virtual surround effect.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLVirtualSurroundEffect {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLVirtualSurroundEffect {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLVirtualSurroundEffect {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLVirtualSurroundEffect {
         &mut self.inner
     }
 }
@@ -228,7 +228,7 @@ impl Clone for VirtualSurroundEffect {
 
 impl Drop for VirtualSurroundEffect {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplVirtualSurroundEffectRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplVirtualSurroundEffectRelease(&raw mut self.inner) }
     }
 }
 

--- a/audionimbus/src/energy_field.rs
+++ b/audionimbus/src/energy_field.rs
@@ -128,14 +128,14 @@ impl EnergyField {
     /// If the source and destination energy fields have different numbers of channels, only the smaller of the two numbers of channels will be copied.
     ///
     /// If the source and destination energy fields have different numbers of bins, only the smaller of the two numbers of bins will be copied.
-    pub fn copy_into(&self, dst: &mut EnergyField) {
+    pub fn copy_into(&self, dst: &mut Self) {
         unsafe { audionimbus_sys::iplEnergyFieldCopy(self.raw_ptr(), dst.raw_ptr()) }
     }
 
     /// Swaps the data contained in one energy field with the data contained in another energy field.
     ///
     /// The two energy fields may contain different numbers of channels or bins.
-    pub fn swap(&mut self, other: &mut EnergyField) {
+    pub fn swap(&mut self, other: &mut Self) {
         unsafe { audionimbus_sys::iplEnergyFieldSwap(self.raw_ptr(), other.raw_ptr()) }
     }
 
@@ -144,9 +144,9 @@ impl EnergyField {
     /// If the energy fields have different numbers of channels, only the smallest of the three numbers of channels will be added.
     ///
     /// If the energy fields have different numbers of bins, only the smallest of the three numbers of bins will be added.
-    pub fn add(&mut self, other: &EnergyField) {
+    pub fn add(&mut self, other: &Self) {
         unsafe {
-            audionimbus_sys::iplEnergyFieldAdd(self.raw_ptr(), other.raw_ptr(), self.raw_ptr())
+            audionimbus_sys::iplEnergyFieldAdd(self.raw_ptr(), other.raw_ptr(), self.raw_ptr());
         }
     }
 
@@ -158,14 +158,14 @@ impl EnergyField {
     /// Returns the raw FFI pointer to the underlying energy field.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLEnergyField {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLEnergyField {
         self.0
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLEnergyField {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLEnergyField {
         &mut self.0
     }
 }
@@ -181,7 +181,7 @@ impl Clone for EnergyField {
 
 impl Drop for EnergyField {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplEnergyFieldRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplEnergyFieldRelease(&raw mut self.0) }
     }
 }
 
@@ -212,7 +212,7 @@ impl From<&EnergyFieldSettings> for audionimbus_sys::IPLEnergyFieldSettings {
 }
 
 /// [`EnergyField`] errors.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum EnergyFieldError {
     /// Channel index is out of bounds.
     ChannelIndexOutOfBounds {
@@ -271,7 +271,7 @@ pub fn scale_energy_field(energy_field: &EnergyField, scalar: f32, out: &mut Ene
 /// If the energy fields have different numbers of bins, only the smallest of the two numbers of bins will be added.
 pub fn scale_accum_energy_field(energy_field: &EnergyField, scalar: f32, out: &mut EnergyField) {
     unsafe {
-        audionimbus_sys::iplEnergyFieldScaleAccum(energy_field.raw_ptr(), scalar, out.raw_ptr())
+        audionimbus_sys::iplEnergyFieldScaleAccum(energy_field.raw_ptr(), scalar, out.raw_ptr());
     }
 }
 

--- a/audionimbus/src/error.rs
+++ b/audionimbus/src/error.rs
@@ -1,5 +1,5 @@
 /// A Steam Audio error.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum SteamAudioError {
     /// An unspecified error occurred.
     Unspecified,
@@ -23,7 +23,7 @@ impl std::fmt::Display for SteamAudioError {
     }
 }
 
-pub fn to_option_error(status: audionimbus_sys::IPLerror) -> Option<SteamAudioError> {
+pub const fn to_option_error(status: audionimbus_sys::IPLerror) -> Option<SteamAudioError> {
     match status {
         audionimbus_sys::IPLerror::IPL_STATUS_SUCCESS => None,
         audionimbus_sys::IPLerror::IPL_STATUS_FAILURE => Some(SteamAudioError::Unspecified),

--- a/audionimbus/src/ffi_wrapper.rs
+++ b/audionimbus/src/ffi_wrapper.rs
@@ -7,7 +7,7 @@ pub struct FFIWrapper<'a, T, Owner> {
 
 impl<T, Owner> FFIWrapper<'_, T, Owner> {
     /// Creates a new FFI wrapper around the given object.
-    pub fn new(ffi_object: T) -> Self {
+    pub const fn new(ffi_object: T) -> Self {
         FFIWrapper {
             ffi_object,
             _marker: std::marker::PhantomData,

--- a/audionimbus/src/fmod.rs
+++ b/audionimbus/src/fmod.rs
@@ -67,7 +67,7 @@ pub fn version() -> FmodStudioIntegrationVersion {
     let mut patch: c_uint = 0;
 
     unsafe {
-        audionimbus_sys::fmod::iplFMODGetVersion(&mut major, &mut minor, &mut patch);
+        audionimbus_sys::fmod::iplFMODGetVersion(&raw mut major, &raw mut minor, &raw mut patch);
     }
 
     FmodStudioIntegrationVersion {

--- a/audionimbus/src/geometry/instanced_mesh.rs
+++ b/audionimbus/src/geometry/instanced_mesh.rs
@@ -18,7 +18,7 @@ impl InstancedMesh {
     /// Returns [`SteamAudioError`] if creation fails.
     pub fn try_new(
         scene: &Scene,
-        settings: InstancedMeshSettings,
+        settings: &InstancedMeshSettings,
     ) -> Result<Self, SteamAudioError> {
         let mut instanced_mesh = Self(std::ptr::null_mut());
 
@@ -30,7 +30,7 @@ impl InstancedMesh {
         let status = unsafe {
             audionimbus_sys::iplInstancedMeshCreate(
                 scene.raw_ptr(),
-                &mut instanced_mesh_settings_ffi,
+                &raw mut instanced_mesh_settings_ffi,
                 instanced_mesh.raw_ptr_mut(),
             )
         };
@@ -60,14 +60,14 @@ impl InstancedMesh {
     /// Returns the raw FFI pointer to the underlying instanced mesh.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLInstancedMesh {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLInstancedMesh {
         self.0
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLInstancedMesh {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLInstancedMesh {
         &mut self.0
     }
 }
@@ -83,7 +83,7 @@ impl Clone for InstancedMesh {
 
 impl Drop for InstancedMesh {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplInstancedMeshRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplInstancedMeshRelease(&raw mut self.0) }
     }
 }
 

--- a/audionimbus/src/geometry/material.rs
+++ b/audionimbus/src/geometry/material.rs
@@ -97,7 +97,7 @@ impl Material {
 
 impl From<Material> for audionimbus_sys::IPLMaterial {
     fn from(material: Material) -> Self {
-        audionimbus_sys::IPLMaterial {
+        Self {
             absorption: material.absorption,
             scattering: material.scattering,
             transmission: material.transmission,

--- a/audionimbus/src/geometry/matrix.rs
+++ b/audionimbus/src/geometry/matrix.rs
@@ -1,5 +1,5 @@
-/// A ROWSxCOLS matrix of type T elements.
-#[derive(Debug, Copy, Clone, PartialEq)]
+/// A `ROWSxCOLS` matrix of type T elements.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Matrix<T, const ROWS: usize, const COLS: usize> {
     /// Matrix elements, in row-major order.
     pub elements: [[T; COLS]; ROWS],
@@ -36,14 +36,14 @@ impl Default for Matrix<f32, 4, 4> {
 
 impl<T, const ROWS: usize, const COLS: usize> Matrix<T, ROWS, COLS> {
     /// Creates a new matrix.
-    pub fn new(elements: [[T; COLS]; ROWS]) -> Self {
+    pub const fn new(elements: [[T; COLS]; ROWS]) -> Self {
         Self { elements }
     }
 }
 
 impl From<Matrix<f32, 4, 4>> for audionimbus_sys::IPLMatrix4x4 {
     fn from(matrix: Matrix<f32, 4, 4>) -> Self {
-        audionimbus_sys::IPLMatrix4x4 {
+        Self {
             elements: matrix.elements,
         }
     }
@@ -51,7 +51,7 @@ impl From<Matrix<f32, 4, 4>> for audionimbus_sys::IPLMatrix4x4 {
 
 impl From<&Matrix<f32, 4, 4>> for audionimbus_sys::IPLMatrix4x4 {
     fn from(matrix: &Matrix<f32, 4, 4>) -> Self {
-        audionimbus_sys::IPLMatrix4x4 {
+        Self {
             elements: matrix.elements,
         }
     }

--- a/audionimbus/src/geometry/mod.rs
+++ b/audionimbus/src/geometry/mod.rs
@@ -57,7 +57,7 @@
 //!
 //! let instanced = InstancedMesh::try_new(
 //!     &scene,
-//!     InstancedMeshSettings {
+//!     &InstancedMeshSettings {
 //!         sub_scene: &sub_scene,
 //!         transform,
 //!     },

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -76,6 +76,10 @@ impl<T: RayTracer> Scene<T> {
     }
 
     /// Loads a scene from FFI settings and serialized object.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     fn from_ffi_load(
         context: &Context,
         settings: &mut audionimbus_sys::IPLSceneSettings,
@@ -84,9 +88,9 @@ impl<T: RayTracer> Scene<T> {
     ) -> Result<Self, SteamAudioError> {
         let mut scene = Self::empty();
 
-        let (callback, user_data) = progress_callback
-            .map(|cb| (Some(cb.callback), cb.user_data))
-            .unwrap_or((None, std::ptr::null_mut()));
+        let (callback, user_data) = progress_callback.map_or((None, std::ptr::null_mut()), |cb| {
+            (Some(cb.callback), cb.user_data)
+        });
 
         let status = unsafe {
             audionimbus_sys::iplSceneLoad(
@@ -120,6 +124,10 @@ impl Scene<DefaultRayTracer> {
     /// Loads a scene from a serialized object.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     pub fn load(
         context: &Context,
         serialized_object: &SerializedObject,
@@ -130,6 +138,10 @@ impl Scene<DefaultRayTracer> {
     /// Loads a scene from a serialized object.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_with_progress(
         context: &Context,
         serialized_object: &SerializedObject,
@@ -166,7 +178,7 @@ impl Scene<Embree> {
     /// Returns [`SteamAudioError`] if creation fails.
     pub fn try_with_embree(
         context: &Context,
-        device: EmbreeDevice,
+        device: &EmbreeDevice,
     ) -> Result<Self, SteamAudioError> {
         Self::from_ffi_create(context, &mut Self::ffi_settings(device))
     }
@@ -174,9 +186,13 @@ impl Scene<Embree> {
     /// Loads a scene from a serialized object using Embree.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_embree(
         context: &Context,
-        device: EmbreeDevice,
+        device: &EmbreeDevice,
         serialized_object: &SerializedObject,
     ) -> Result<Self, SteamAudioError> {
         let mut scene = Self {
@@ -209,9 +225,13 @@ impl Scene<Embree> {
     /// Loads a scene from a serialized object using Embree with a progress callback.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_embree_with_progress(
         context: &Context,
-        device: EmbreeDevice,
+        device: &EmbreeDevice,
         serialized_object: &SerializedObject,
         progress_callback: CallbackInformation<ProgressCallback>,
     ) -> Result<Self, SteamAudioError> {
@@ -224,7 +244,7 @@ impl Scene<Embree> {
     }
 
     /// Returns FFI scene settings with the Embree ray tracer.
-    fn ffi_settings(device: EmbreeDevice) -> audionimbus_sys::IPLSceneSettings {
+    fn ffi_settings(device: &EmbreeDevice) -> audionimbus_sys::IPLSceneSettings {
         audionimbus_sys::IPLSceneSettings {
             type_: Embree::scene_type(),
             closestHitCallback: None,
@@ -246,7 +266,7 @@ impl Scene<RadeonRays> {
     /// Returns [`SteamAudioError`] if creation fails.
     pub fn try_with_radeon_rays(
         context: &Context,
-        device: RadeonRaysDevice,
+        device: &RadeonRaysDevice,
     ) -> Result<Self, SteamAudioError> {
         Self::from_ffi_create(context, &mut Self::ffi_settings(device))
     }
@@ -254,9 +274,13 @@ impl Scene<RadeonRays> {
     /// Loads a scene from a serialized object using Radeon Rays.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_radeon_rays(
         context: &Context,
-        device: RadeonRaysDevice,
+        device: &RadeonRaysDevice,
         serialized_object: &SerializedObject,
     ) -> Result<Self, SteamAudioError> {
         Self::from_ffi_load(
@@ -270,9 +294,13 @@ impl Scene<RadeonRays> {
     /// Loads a scene from a serialized object using Radeon Rays with a progerss callback.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_radeon_rays_with_progress(
         context: &Context,
-        device: RadeonRaysDevice,
+        device: &RadeonRaysDevice,
         serialized_object: &SerializedObject,
         progress_callback: CallbackInformation<ProgressCallback>,
     ) -> Result<Self, SteamAudioError> {
@@ -285,7 +313,7 @@ impl Scene<RadeonRays> {
     }
 
     /// Returns FFI scene settings with the Radeon Rays ray tracer.
-    fn ffi_settings(device: RadeonRaysDevice) -> audionimbus_sys::IPLSceneSettings {
+    fn ffi_settings(device: &RadeonRaysDevice) -> audionimbus_sys::IPLSceneSettings {
         audionimbus_sys::IPLSceneSettings {
             type_: RadeonRays::scene_type(),
             closestHitCallback: None,
@@ -315,6 +343,10 @@ impl Scene<CustomRayTracer> {
     /// Loads a scene from a serialized object using a custom ray tracer.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_custom(
         context: &Context,
         callbacks: &CustomCallbacks,
@@ -331,6 +363,10 @@ impl Scene<CustomRayTracer> {
     /// Loads a scene from a serialized object using a custom ray tracer with a progress callback.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_custom_with_progress(
         context: &Context,
         callbacks: &CustomCallbacks,
@@ -484,7 +520,7 @@ impl<T: RayTracer> Scene<T> {
     /// # let transform = Matrix4::IDENTITY;
     /// let instanced_mesh = InstancedMesh::try_new(
     ///     &scene,
-    ///     InstancedMeshSettings {
+    ///     &InstancedMeshSettings {
     ///         sub_scene: &sub_scene,
     ///         transform: Matrix4::IDENTITY,
     ///     },
@@ -536,7 +572,7 @@ impl<T: RayTracer> Scene<T> {
     /// # let transform = Matrix4::IDENTITY;
     /// # let instanced_mesh = InstancedMesh::try_new(
     /// #     &scene,
-    /// #     InstancedMeshSettings {
+    /// #     &InstancedMeshSettings {
     /// #        sub_scene: &sub_scene,
     /// #         transform: Matrix4::IDENTITY,
     /// #     },
@@ -599,7 +635,7 @@ impl<T: RayTracer> Scene<T> {
     /// # let transform = Matrix4::IDENTITY;
     /// # let instanced_mesh = InstancedMesh::try_new(
     /// #     &scene,
-    /// #     InstancedMeshSettings {
+    /// #     &InstancedMeshSettings {
     /// #         sub_scene: &sub_scene,
     /// #         transform: Matrix4::IDENTITY,
     /// #     },
@@ -685,14 +721,14 @@ impl<T: RayTracer> Scene<T> {
     /// Returns the raw FFI pointer to the underlying scene.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLScene {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLScene {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLScene {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLScene {
         &mut self.inner
     }
 }
@@ -750,7 +786,7 @@ impl<T: RayTracer> Clone for Scene<T> {
 
 impl<T: RayTracer> Drop for Scene<T> {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplSceneRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplSceneRelease(&raw mut self.inner) }
     }
 }
 
@@ -902,7 +938,7 @@ pub struct StaticMeshHandle(DefaultKey);
 /// # let transform = Matrix4::IDENTITY;
 /// let instanced_mesh = InstancedMesh::try_new(
 ///     &scene,
-///     InstancedMeshSettings {
+///     &InstancedMeshSettings {
 ///         sub_scene: &sub_scene,
 ///         transform: Matrix4::IDENTITY,
 ///     },

--- a/audionimbus/src/geometry/static_mesh.rs
+++ b/audionimbus/src/geometry/static_mesh.rs
@@ -64,8 +64,8 @@ impl<T: RayTracer> StaticMesh<T> {
         let status = unsafe {
             audionimbus_sys::iplStaticMeshCreate(
                 scene.raw_ptr(),
-                &mut static_mesh_settings_ffi,
-                &mut inner,
+                &raw mut static_mesh_settings_ffi,
+                &raw mut inner,
             )
         };
 
@@ -84,6 +84,10 @@ impl<T: RayTracer> StaticMesh<T> {
     /// Loads a static mesh from a serialized object.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     pub fn load(
         scene: &Scene,
         serialized_object: &mut SerializedObject,
@@ -94,6 +98,10 @@ impl<T: RayTracer> StaticMesh<T> {
     /// Loads a static mesh from a serialized object, with a progress callback.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_with_progress_callback(
         scene: &Scene,
         serialized_object: &SerializedObject,
@@ -109,6 +117,10 @@ impl<T: RayTracer> StaticMesh<T> {
     /// Loads a static mesh from a serialized object, with an optional progress callback.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     fn load_with_optional_progress_callback(
         scene: &Scene,
         serialized_object: &SerializedObject,
@@ -132,7 +144,7 @@ impl<T: RayTracer> StaticMesh<T> {
                 serialized_object.raw_ptr(),
                 progress_callback,
                 progress_callback_user_data,
-                &mut inner,
+                &raw mut inner,
             )
         };
 
@@ -151,14 +163,14 @@ impl<T: RayTracer> StaticMesh<T> {
     /// Returns the raw FFI pointer to the underlying static mesh.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLStaticMesh {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLStaticMesh {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLStaticMesh {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLStaticMesh {
         &mut self.inner
     }
 }
@@ -191,7 +203,7 @@ impl<T: RayTracer> Clone for StaticMesh<T> {
 
 impl<T> Drop for StaticMesh<T> {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplStaticMeshRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplStaticMeshRelease(&raw mut self.inner) }
     }
 }
 

--- a/audionimbus/src/geometry/triangle.rs
+++ b/audionimbus/src/geometry/triangle.rs
@@ -6,7 +6,7 @@
 /// This means that when looking at the triangle such that the normal is pointing towards you, the vertices are specified in counter-clockwise order.
 ///
 /// Each triangle must be specified using three vertices; triangle strip or fan representations are not supported.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Triangle {
     /// Indices of the three vertices of this triangle.
     pub indices: [i32; 3],
@@ -14,7 +14,7 @@ pub struct Triangle {
 
 impl Triangle {
     /// Creates a new triangle.
-    pub fn new(vertex_index_0: i32, vertex_index_1: i32, vertex_index_2: i32) -> Self {
+    pub const fn new(vertex_index_0: i32, vertex_index_1: i32, vertex_index_2: i32) -> Self {
         Self {
             indices: [vertex_index_0, vertex_index_1, vertex_index_2],
         }
@@ -23,7 +23,7 @@ impl Triangle {
 
 impl From<Triangle> for audionimbus_sys::IPLTriangle {
     fn from(triangle: Triangle) -> Self {
-        audionimbus_sys::IPLTriangle {
+        Self {
             indices: triangle.indices,
         }
     }

--- a/audionimbus/src/geometry/vector3.rs
+++ b/audionimbus/src/geometry/vector3.rs
@@ -16,7 +16,7 @@ pub struct Vector3 {
 
 impl Vector3 {
     /// Creates a new 3D vector given `x`, `y` and `z` components.
-    pub fn new(x: f32, y: f32, z: f32) -> Self {
+    pub const fn new(x: f32, y: f32, z: f32) -> Self {
         Self { x, y, z }
     }
 }

--- a/audionimbus/src/hrtf.rs
+++ b/audionimbus/src/hrtf.rs
@@ -8,7 +8,7 @@ use crate::error::{to_option_error, SteamAudioError};
 ///
 /// HRTFs describe how sound from different directions is perceived by a each of a listener’s ears, and are a crucial component of spatial audio.
 /// Steam Audio includes a built-in HRTF, while also allowing developers and users to import their own custom HRTFs.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Hrtf(pub(crate) audionimbus_sys::IPLHRTF);
 
 impl Hrtf {
@@ -36,7 +36,7 @@ impl Hrtf {
             audionimbus_sys::iplHRTFCreate(
                 context.raw_ptr(),
                 &mut audionimbus_sys::IPLAudioSettings::from(audio_settings),
-                &mut settings_ffi,
+                &raw mut settings_ffi,
                 hrtf.raw_ptr_mut(),
             )
         };
@@ -51,14 +51,14 @@ impl Hrtf {
     /// Returns the raw FFI pointer to the underlying HRTF.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLHRTF {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLHRTF {
         self.0
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLHRTF {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLHRTF {
         &mut self.0
     }
 }
@@ -80,7 +80,7 @@ impl Clone for Hrtf {
 
 impl Drop for Hrtf {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplHRTFRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplHRTFRelease(&raw mut self.0) }
     }
 }
 
@@ -140,8 +140,7 @@ impl HrtfSettings {
 
         let sofa_filename = filename_cstring
             .as_ref()
-            .map(|c| c.as_ptr())
-            .unwrap_or(std::ptr::null());
+            .map_or(std::ptr::null(), |c| c.as_ptr());
 
         let settings = audionimbus_sys::IPLHRTFSettings {
             type_,
@@ -191,10 +190,8 @@ pub enum VolumeNormalization {
 impl From<VolumeNormalization> for audionimbus_sys::IPLHRTFNormType {
     fn from(volume_normalization: VolumeNormalization) -> Self {
         match volume_normalization {
-            VolumeNormalization::None => audionimbus_sys::IPLHRTFNormType::IPL_HRTFNORMTYPE_NONE,
-            VolumeNormalization::RootMeanSquared => {
-                audionimbus_sys::IPLHRTFNormType::IPL_HRTFNORMTYPE_RMS
-            }
+            VolumeNormalization::None => Self::IPL_HRTFNORMTYPE_NONE,
+            VolumeNormalization::RootMeanSquared => Self::IPL_HRTFNORMTYPE_RMS,
         }
     }
 }
@@ -219,12 +216,8 @@ pub enum HrtfInterpolation {
 impl From<HrtfInterpolation> for audionimbus_sys::IPLHRTFInterpolation {
     fn from(hrtf_interpolation: HrtfInterpolation) -> Self {
         match hrtf_interpolation {
-            HrtfInterpolation::Nearest => {
-                audionimbus_sys::IPLHRTFInterpolation::IPL_HRTFINTERPOLATION_NEAREST
-            }
-            HrtfInterpolation::Bilinear => {
-                audionimbus_sys::IPLHRTFInterpolation::IPL_HRTFINTERPOLATION_BILINEAR
-            }
+            HrtfInterpolation::Nearest => Self::IPL_HRTFINTERPOLATION_NEAREST,
+            HrtfInterpolation::Bilinear => Self::IPL_HRTFINTERPOLATION_BILINEAR,
         }
     }
 }

--- a/audionimbus/src/impulse_response.rs
+++ b/audionimbus/src/impulse_response.rs
@@ -88,14 +88,14 @@ impl ImpulseResponse {
     /// If the source and destination impulse responses have different numbers of channels, only the smaller of the two numbers of channels will be copied.
     ///
     /// If the source and destination impulse responses have different numbers of samples, only the smaller of the two numbers of samples will be copied.
-    pub fn copy_into(&self, dst: &mut ImpulseResponse) {
+    pub fn copy_into(&self, dst: &mut Self) {
         unsafe { audionimbus_sys::iplImpulseResponseCopy(self.raw_ptr(), dst.raw_ptr()) }
     }
 
     /// Swaps the data contained in one impulse response with the data contained in another impulse response.
     ///
     /// The two impulse responses may contain different numbers of channels or samples.
-    pub fn swap(&mut self, other: &mut ImpulseResponse) {
+    pub fn swap(&mut self, other: &mut Self) {
         unsafe { audionimbus_sys::iplImpulseResponseSwap(self.raw_ptr(), other.raw_ptr()) }
     }
 
@@ -104,9 +104,9 @@ impl ImpulseResponse {
     /// If the impulse responses have different numbers of channels, only the smallest of the three numbers of channels will be added.
     ///
     /// If the impulse responses have different numbers of samples, only the smallest of the three numbers of samples will be added.
-    pub fn add(&mut self, other: &ImpulseResponse) {
+    pub fn add(&mut self, other: &Self) {
         unsafe {
-            audionimbus_sys::iplImpulseResponseAdd(self.raw_ptr(), other.raw_ptr(), self.raw_ptr())
+            audionimbus_sys::iplImpulseResponseAdd(self.raw_ptr(), other.raw_ptr(), self.raw_ptr());
         }
     }
 
@@ -118,14 +118,14 @@ impl ImpulseResponse {
     /// Returns the raw FFI pointer to the underlying impulse response.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLImpulseResponse {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLImpulseResponse {
         self.0
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLImpulseResponse {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLImpulseResponse {
         &mut self.0
     }
 }
@@ -141,7 +141,7 @@ impl Clone for ImpulseResponse {
 
 impl Drop for ImpulseResponse {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplImpulseResponseRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplImpulseResponseRelease(&raw mut self.0) }
     }
 }
 
@@ -178,7 +178,7 @@ impl From<&ImpulseResponseSettings> for audionimbus_sys::IPLImpulseResponseSetti
 }
 
 /// [`ImpulseResponse`] errors.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ImpulseResponseError {
     /// Channel index is out of bounds.
     ChannelIndexOutOfBounds {
@@ -227,7 +227,7 @@ pub fn scale_impulse_response(
     out: &mut ImpulseResponse,
 ) {
     unsafe {
-        audionimbus_sys::iplImpulseResponseScale(impulse_response.raw_ptr(), scalar, out.raw_ptr())
+        audionimbus_sys::iplImpulseResponseScale(impulse_response.raw_ptr(), scalar, out.raw_ptr());
     }
 }
 

--- a/audionimbus/src/prelude.rs
+++ b/audionimbus/src/prelude.rs
@@ -1,6 +1,10 @@
 //! Convenient re-exports of commonly used types and traits.
 
-use crate::*;
+use crate::{
+    audio_buffer, audio_settings, baking, callback, context, device, effect, energy_field, error,
+    geometry, hrtf, impulse_response, model, probe, ray_tracing, reconstructor, serialized_object,
+    simulation, version,
+};
 
 pub use audio_buffer::*;
 pub use audio_settings::*;

--- a/audionimbus/src/prelude.rs
+++ b/audionimbus/src/prelude.rs
@@ -8,8 +8,8 @@ use crate::{
 
 pub use audio_buffer::*;
 pub use audio_settings::*;
-pub use baking::pathing::*;
-pub use baking::reflections::*;
+pub use baking::pathing::{PathBakeParams, PathBaker};
+pub use baking::reflections::{ReflectionsBakeFlags, ReflectionsBakeParams, ReflectionsBaker};
 pub use baking::{BakeError, BakedDataIdentifier, BakedDataVariation};
 pub use callback::*;
 pub use context::*;

--- a/audionimbus/src/probe.rs
+++ b/audionimbus/src/probe.rs
@@ -72,14 +72,14 @@ impl ProbeArray {
     /// Returns the raw FFI pointer to the underlying probe array.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLProbeArray {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLProbeArray {
         self.0
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLProbeArray {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLProbeArray {
         &mut self.0
     }
 }
@@ -95,7 +95,7 @@ impl Clone for ProbeArray {
 
 impl Drop for ProbeArray {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplProbeArrayRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplProbeArrayRelease(&raw mut self.0) }
     }
 }
 
@@ -103,7 +103,7 @@ unsafe impl Send for ProbeArray {}
 unsafe impl Sync for ProbeArray {}
 
 /// [`ProbeArray`] errors.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ProbeArrayError {
     /// Probe index is out of bounds.
     ProbeIndexOutOfBounds {
@@ -230,7 +230,7 @@ impl ProbeBatch {
     }
 
     /// Returns the number of committed probes in the probe batch.
-    pub fn committed_num_probes(&self) -> usize {
+    pub const fn committed_num_probes(&self) -> usize {
         self.committed_num_probes
     }
 
@@ -239,7 +239,7 @@ impl ProbeBatch {
         let mut ffi_identifier: audionimbus_sys::IPLBakedDataIdentifier = identifier.into();
 
         unsafe {
-            audionimbus_sys::iplProbeBatchGetDataSize(self.raw_ptr(), &mut ffi_identifier as *mut _)
+            audionimbus_sys::iplProbeBatchGetDataSize(self.raw_ptr(), &raw mut ffi_identifier)
                 as usize
         }
     }
@@ -248,7 +248,7 @@ impl ProbeBatch {
         let mut ffi_identifier: audionimbus_sys::IPLBakedDataIdentifier = identifier.into();
 
         unsafe {
-            audionimbus_sys::iplProbeBatchRemoveData(self.raw_ptr(), &mut ffi_identifier as *mut _)
+            audionimbus_sys::iplProbeBatchRemoveData(self.raw_ptr(), &raw mut ffi_identifier);
         }
     }
 
@@ -321,7 +321,7 @@ impl ProbeBatch {
         unsafe {
             audionimbus_sys::iplProbeBatchGetReverb(
                 self.raw_ptr(),
-                &mut ffi_identifier as *mut _,
+                &raw mut ffi_identifier,
                 probe_index as i32,
                 reverb_times.as_mut_ptr(),
             );
@@ -354,7 +354,7 @@ impl ProbeBatch {
         unsafe {
             audionimbus_sys::iplProbeBatchGetEnergyField(
                 self.raw_ptr(),
-                &mut ffi_identifier as *mut _,
+                &raw mut ffi_identifier,
                 probe_index as i32,
                 energy_field.raw_ptr(),
             );
@@ -364,6 +364,7 @@ impl ProbeBatch {
     }
 
     /// Commits all changes made to a probe batch since this function was last called (or since the probe batch was first created, if this function was never called).
+    ///
     /// This function must be called after adding, removing, or updating any probes in the batch, for the changes to take effect.
     pub fn commit(&mut self) {
         unsafe { audionimbus_sys::iplProbeBatchCommit(self.raw_ptr()) }
@@ -374,6 +375,7 @@ impl ProbeBatch {
     }
 
     /// Saves a probe batch to a serialized object.
+    ///
     /// Typically, the serialized object will then be saved to disk.
     pub fn save(&self, serialized_object: &mut SerializedObject) {
         unsafe {
@@ -382,7 +384,12 @@ impl ProbeBatch {
     }
 
     /// Loads a probe batch from a serialized object.
+    ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if loading fails.
     pub fn load(
         context: &Context,
         serialized_object: &mut SerializedObject,
@@ -413,14 +420,14 @@ impl ProbeBatch {
     /// Returns the raw FFI pointer to the underlying probe batch.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLProbeBatch {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLProbeBatch {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLProbeBatch {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLProbeBatch {
         &mut self.inner
     }
 }
@@ -441,7 +448,7 @@ impl Clone for ProbeBatch {
 
 impl Drop for ProbeBatch {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplProbeBatchRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplProbeBatchRelease(&raw mut self.inner) }
     }
 }
 
@@ -449,7 +456,7 @@ unsafe impl Send for ProbeBatch {}
 unsafe impl Sync for ProbeBatch {}
 
 /// [`ProbeBatch`] errors.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ProbeBatchError {
     /// Probe index is out of bounds.
     ProbeIndexOutOfBounds {

--- a/audionimbus/src/reconstructor.rs
+++ b/audionimbus/src/reconstructor.rs
@@ -103,11 +103,11 @@ impl Reconstructor {
             audionimbus_sys::iplReconstructorReconstruct(
                 self.raw_ptr(),
                 inputs.len() as i32,
-                c_inputs.as_ptr() as *mut audionimbus_sys::IPLReconstructorInputs,
+                c_inputs.as_ptr().cast_mut(),
                 &c_shared_inputs as *const audionimbus_sys::IPLReconstructorSharedInputs
                     as *mut audionimbus_sys::IPLReconstructorSharedInputs,
-                c_outputs.as_ptr() as *mut audionimbus_sys::IPLReconstructorOutputs,
-            )
+                c_outputs.as_ptr().cast_mut(),
+            );
         }
 
         Ok(())
@@ -116,14 +116,14 @@ impl Reconstructor {
     /// Returns the raw FFI pointer to the underlying reconstructor.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLReconstructor {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLReconstructor {
         self.inner
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLReconstructor {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLReconstructor {
         &mut self.inner
     }
 }
@@ -143,7 +143,7 @@ impl Clone for Reconstructor {
 
 impl Drop for Reconstructor {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplReconstructorRelease(&mut self.inner) }
+        unsafe { audionimbus_sys::iplReconstructorRelease(&raw mut self.inner) }
     }
 }
 

--- a/audionimbus/src/serialized_object.rs
+++ b/audionimbus/src/serialized_object.rs
@@ -57,7 +57,7 @@ impl SerializedObject {
         buffer: &mut Vec<u8>,
     ) -> Result<Self, SteamAudioError> {
         let serialized_object_settings = audionimbus_sys::IPLSerializedObjectSettings {
-            data: buffer.as_mut_ptr() as *mut audionimbus_sys::IPLbyte,
+            data: buffer.as_mut_ptr().cast::<audionimbus_sys::IPLbyte>(),
             size: buffer.len(),
         };
 
@@ -78,7 +78,7 @@ impl SerializedObject {
         let status = unsafe {
             audionimbus_sys::iplSerializedObjectCreate(
                 context.raw_ptr(),
-                &mut serialized_object_settings,
+                &raw mut serialized_object_settings,
                 serialized_object.raw_ptr_mut(),
             )
         };
@@ -93,14 +93,14 @@ impl SerializedObject {
     /// Returns the raw FFI pointer to the underlying object.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr(&self) -> audionimbus_sys::IPLSerializedObject {
+    pub const fn raw_ptr(&self) -> audionimbus_sys::IPLSerializedObject {
         self.0
     }
 
     /// Returns a mutable reference to the raw FFI pointer.
     ///
     /// This is intended for internal use and advanced scenarios.
-    pub fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLSerializedObject {
+    pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLSerializedObject {
         &mut self.0
     }
 
@@ -152,7 +152,7 @@ impl Clone for SerializedObject {
 
 impl Drop for SerializedObject {
     fn drop(&mut self) {
-        unsafe { audionimbus_sys::iplSerializedObjectRelease(&mut self.0) }
+        unsafe { audionimbus_sys::iplSerializedObjectRelease(&raw mut self.0) }
     }
 }
 

--- a/audionimbus/src/version.rs
+++ b/audionimbus/src/version.rs
@@ -43,6 +43,6 @@ mod tests {
 
         let version_u32: u32 = version.into();
 
-        assert_eq!(version_u32, 264192);
+        assert_eq!(version_u32, 264_192);
     }
 }

--- a/audionimbus/src/version.rs
+++ b/audionimbus/src/version.rs
@@ -15,7 +15,7 @@ pub struct SteamAudioVersion {
 
 impl From<SteamAudioVersion> for u32 {
     fn from(version: SteamAudioVersion) -> Self {
-        ((version.major << 16) + (version.minor << 8) + version.patch) as u32
+        ((version.major << 16) + (version.minor << 8) + version.patch) as Self
     }
 }
 

--- a/audionimbus/src/wwise.rs
+++ b/audionimbus/src/wwise.rs
@@ -20,8 +20,7 @@ pub fn initialize(context: &Context, settings: Option<WwiseSettings>) {
 
     let ipl_settings = ffi_settings
         .as_mut()
-        .map(|s| s as *mut _)
-        .unwrap_or(std::ptr::null_mut());
+        .map_or(std::ptr::null_mut(), std::ptr::from_mut);
 
     unsafe { audionimbus_sys::wwise::iplWwiseInitialize(context.raw_ptr(), ipl_settings) }
 }
@@ -80,7 +79,7 @@ pub fn version() -> WwiseIntegrationVersion {
     let mut patch: c_uint = 0;
 
     unsafe {
-        audionimbus_sys::wwise::iplWwiseGetVersion(&mut major, &mut minor, &mut patch);
+        audionimbus_sys::wwise::iplWwiseGetVersion(&raw mut major, &raw mut minor, &raw mut patch);
     }
 
     WwiseIntegrationVersion {

--- a/audionimbus/tests/scene.rs
+++ b/audionimbus/tests/scene.rs
@@ -95,8 +95,7 @@ fn test_instanced_mesh() {
         sub_scene: &sub_scene,
         transform,
     };
-
-    let mut instanced_mesh = InstancedMesh::try_new(&main_scene, instanced_mesh_settings).unwrap();
+    let mut instanced_mesh = InstancedMesh::try_new(&main_scene, &instanced_mesh_settings).unwrap();
     main_scene.add_instanced_mesh(instanced_mesh.clone());
     main_scene.commit();
 


### PR DESCRIPTION
This PR applies suggestions from `cargo clippy` with `pedantic` and `nursery` lints enabled.

### Highlights

- Updated to use modern pointer syntax (`&raw mut` and `&raw const`) for creating raw pointers, replacing the older `&mut *` pattern
- Marked methods as `const` where appropriate, enabling compile-time evaluation
- Added `Eq` to types that already derive `PartialEq` where appropriate
- Added comprehensive `# Errors` sections to fallible functions
- Updated C-style casts to use `.cast()` and `.cast_mut()` methods for better type safety
