### PR TITLE
Enforce compile-time compatibility between Source and Simulator simulation types

### DIFF
--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fixed a segmentation fault when calling `ReflectionEffect::apply()` with TrueAudioNext effects (which require a mixer).
 - `SerializedObject::to_vec()` now safely handles empty objects, returning an empty vector instead of panicking.
 - Fixed data races when running simulations concurrently on multiple threads by adding per-simulation-type locks.
+- Fixed silent failures when setting/getting simulation inputs for incompatible simulation types by enforcing compatibility at compile-time.
 
 ### Changed
 
@@ -91,6 +92,7 @@
 - `BakedDataIdentifier` and `BakedDataVariation` are now part of the new `baking` module instead of `simulation`.
 - Bake operations now return a `BakeError` error if another bake operation is already in progress.
 - Renamed `path` and `reflection` submodules of `effect` to `pathing` and `reflections` for consistency.
+- `SimulationInputs` fields are now private; use builder methods `with_direct()`, `with_reflections()`, and `with_pathing()` to configure simulation types.
 
 ### Added
 
@@ -117,6 +119,7 @@
 - Add a `prelude` module to re-export commonly used types and traits.
 - Add `SimulationSettings`, which replaces `SimulatorBuilder`. `Simulator` is now created using `Simulator::try_new` instead of `SimulatorBuilder::build`.
 - Add builder-pattern constructors for `SimulationInputs`, `DirectSimulationParameters`, and `Occlusion` with `new()` and `with_*()`.
+- Add compatibility traits (`DirectCompatible`, `ReflectionsCompatible`, `PathingCompatible`) to enforce type-safe Source creation.
 
 ### Removed
 

--- a/audionimbus/src/effect/pathing.rs
+++ b/audionimbus/src/effect/pathing.rs
@@ -44,6 +44,16 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 /// const MAX_ORDER: u32 = 1;
 ///
 /// let simulation_settings = SimulationSettings::new(SAMPLING_RATE, FRAME_SIZE, MAX_ORDER)
+///     .with_direct(DirectSimulationSettings {
+///         max_num_occlusion_samples: 4,
+///     })
+///    .with_reflections(ReflectionsSimulationSettings::Convolution {
+///         max_num_rays: 4096,
+///         num_diffuse_samples: 32,
+///         max_duration: 2.0,
+///         max_num_sources: 8,
+///         num_threads: 2,
+///     })
 ///     .with_pathing(PathingSimulationSettings {
 ///         num_visibility_samples: 4,
 ///     });

--- a/audionimbus/tests/effect.rs
+++ b/audionimbus/tests/effect.rs
@@ -211,6 +211,16 @@ fn test_pathing() {
     const MAX_ORDER: u32 = 1;
 
     let simulation_settings = SimulationSettings::new(SAMPLING_RATE, FRAME_SIZE, MAX_ORDER)
+        .with_direct(DirectSimulationSettings {
+            max_num_occlusion_samples: 4,
+        })
+        .with_reflections(ReflectionsSimulationSettings::Convolution {
+            max_num_rays: 4096,
+            num_diffuse_samples: 32,
+            max_duration: 2.0,
+            max_num_sources: 8,
+            num_threads: 2,
+        })
         .with_pathing(PathingSimulationSettings {
             num_visibility_samples: 4,
         });

--- a/audionimbus/tests/simulation.rs
+++ b/audionimbus/tests/simulation.rs
@@ -136,6 +136,16 @@ fn test_pathing_without_probes() {
     const MAX_ORDER: u32 = 1;
 
     let simulation_settings = SimulationSettings::new(SAMPLING_RATE, FRAME_SIZE, MAX_ORDER)
+        .with_direct(DirectSimulationSettings {
+            max_num_occlusion_samples: 4,
+        })
+        .with_reflections(ReflectionsSimulationSettings::Convolution {
+            max_num_rays: 4096,
+            num_diffuse_samples: 32,
+            max_duration: 2.0,
+            max_num_sources: 8,
+            num_threads: 2,
+        })
         .with_pathing(PathingSimulationSettings {
             num_visibility_samples: 4,
         });


### PR DESCRIPTION
### Summary

This PR adds compile-time safety to prevent Sources from using simulation types that weren't enabled on their Simulator. Previously, attempting to set inputs or get outputs for incompatible simulation flags would silently fail, leading to confusing runtime behavior.

### Changes

- Added trait-based compatibility constraints (`DirectCompatible`, `ReflectionsCompatible`, `PathingCompatible`) to ensure `Source`s can only enable simulation types that are available in their `Simulator`
- Added type parameters `D`, `R`, `P` to `Source` and `SimulationInputs` to track which simulation types are enabled
- Updated `Source::try_new()` to enforce compatibility via trait bounds
- Made `SimulationInputs` fields private and changed builder methods (`with_direct`, `with_reflections`, `with_pathing`) to return appropriately typed instances

### Examples

```rust
// Valid: Source uses subset of Simulator's features.
let simulator = Simulator::try_new(&context, &settings.with_direct(...).with_reflections(...))?;
let source = Source::<Direct, (), ()>::try_new(&simulator, &settings)?;

// Compile error: Source cannot enable Pathing if Simulator doesn't have it.
let simulator = Simulator::try_new(&context, &settings.with_direct(...))?;
let source = Source::<(), (), Pathing>::try_new(&simulator, &settings)?; // Compile error
```