### PR TITLE
Remove `Clone` and `Sync` implementations from Steam Audio wrappersClones thread safety

### DIFF
--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -135,6 +135,7 @@
 - Removed functions `bake_path` and `cancel_bake_path`. They are superseded by methods `bake` and `cancel_bake` of `PathBaker`.
 - Removed `SceneParams`.
 - Removed `SimulatorBuilder`, which is superseded by `SimulationSettings`.
+- Removed `InstancedMesh::update_transform`. Use `Scene::update_instanced_mesh_transform` instead.
 
 ## [0.11.0] - 2026-01-14
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -136,6 +136,7 @@
 - Removed `SceneParams`.
 - Removed `SimulatorBuilder`, which is superseded by `SimulationSettings`.
 - Removed `InstancedMesh::update_transform`. Use `Scene::update_instanced_mesh_transform` instead.
+- Removed `Clone` and `Sync` implementations from all Steam Audio wrapper types. These types can still be moved between threads (`Send`) but cannot be shared or cloned, as the underlying objects are not thread-safe for concurrent access.
 
 ## [0.11.0] - 2026-01-14
 

--- a/audionimbus/src/context.rs
+++ b/audionimbus/src/context.rs
@@ -80,15 +80,6 @@ impl Default for Context {
     }
 }
 
-impl Clone for Context {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplContextRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for Context {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplContextRelease(&raw mut self.0) }
@@ -96,7 +87,6 @@ impl Drop for Context {
 }
 
 unsafe impl Send for Context {}
-unsafe impl Sync for Context {}
 
 /// Settings used to create a [`Context`].
 pub struct ContextSettings {

--- a/audionimbus/src/device/embree.rs
+++ b/audionimbus/src/device/embree.rs
@@ -51,15 +51,6 @@ impl EmbreeDevice {
     }
 }
 
-impl Clone for EmbreeDevice {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplEmbreeDeviceRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for EmbreeDevice {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplEmbreeDeviceRelease(&raw mut self.0) }
@@ -67,4 +58,3 @@ impl Drop for EmbreeDevice {
 }
 
 unsafe impl Send for EmbreeDevice {}
-unsafe impl Sync for EmbreeDevice {}

--- a/audionimbus/src/device/open_cl.rs
+++ b/audionimbus/src/device/open_cl.rs
@@ -100,15 +100,6 @@ impl OpenClDevice {
     }
 }
 
-impl Clone for OpenClDevice {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplOpenCLDeviceRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for OpenClDevice {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplOpenCLDeviceRelease(&raw mut self.0) }
@@ -116,7 +107,6 @@ impl Drop for OpenClDevice {
 }
 
 unsafe impl Send for OpenClDevice {}
-unsafe impl Sync for OpenClDevice {}
 
 /// Provides a list of OpenCL devices available on the user’s system.
 ///
@@ -211,15 +201,6 @@ impl std::ops::DerefMut for OpenClDeviceList {
     }
 }
 
-impl Clone for OpenClDeviceList {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplOpenCLDeviceListRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for OpenClDeviceList {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplOpenCLDeviceListRelease(&raw mut self.0) }
@@ -227,7 +208,6 @@ impl Drop for OpenClDeviceList {
 }
 
 unsafe impl Send for OpenClDeviceList {}
-unsafe impl Sync for OpenClDeviceList {}
 
 /// [`OpenClDeviceList`] errors.
 #[derive(Debug, PartialEq, Eq)]

--- a/audionimbus/src/device/radeon_rays.rs
+++ b/audionimbus/src/device/radeon_rays.rs
@@ -51,15 +51,6 @@ impl RadeonRaysDevice {
     }
 }
 
-impl Clone for RadeonRaysDevice {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplRadeonRaysDeviceRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for RadeonRaysDevice {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplRadeonRaysDeviceRelease(&raw mut self.0) }
@@ -67,4 +58,3 @@ impl Drop for RadeonRaysDevice {
 }
 
 unsafe impl Send for RadeonRaysDevice {}
-unsafe impl Sync for RadeonRaysDevice {}

--- a/audionimbus/src/device/true_audio_next.rs
+++ b/audionimbus/src/device/true_audio_next.rs
@@ -57,15 +57,6 @@ impl From<audionimbus_sys::IPLTrueAudioNextDevice> for TrueAudioNextDevice {
     }
 }
 
-impl Clone for TrueAudioNextDevice {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplTrueAudioNextDeviceRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for TrueAudioNextDevice {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplTrueAudioNextDeviceRelease(&raw mut self.0) }
@@ -73,7 +64,6 @@ impl Drop for TrueAudioNextDevice {
 }
 
 unsafe impl Send for TrueAudioNextDevice {}
-unsafe impl Sync for TrueAudioNextDevice {}
 
 /// Settings used to create a TrueAudio Next device.
 #[derive(Debug)]

--- a/audionimbus/src/effect/ambisonics/binaural.rs
+++ b/audionimbus/src/effect/ambisonics/binaural.rs
@@ -198,15 +198,6 @@ impl AmbisonicsBinauralEffect {
     }
 }
 
-impl Clone for AmbisonicsBinauralEffect {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplAmbisonicsBinauralEffectRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for AmbisonicsBinauralEffect {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplAmbisonicsBinauralEffectRelease(&raw mut self.0) }
@@ -214,7 +205,6 @@ impl Drop for AmbisonicsBinauralEffect {
 }
 
 unsafe impl Send for AmbisonicsBinauralEffect {}
-unsafe impl Sync for AmbisonicsBinauralEffect {}
 
 /// Settings used to create an ambisonics binaural effect.
 #[derive(Debug)]

--- a/audionimbus/src/effect/ambisonics/decode.rs
+++ b/audionimbus/src/effect/ambisonics/decode.rs
@@ -247,21 +247,6 @@ impl AmbisonicsDecodeEffect {
     }
 }
 
-impl Clone for AmbisonicsDecodeEffect {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplAmbisonicsDecodeEffectRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            num_input_channels: self.num_input_channels,
-            num_output_channels: self.num_output_channels,
-            rendering: self.rendering,
-        }
-    }
-}
-
 impl Drop for AmbisonicsDecodeEffect {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplAmbisonicsDecodeEffectRelease(&raw mut self.inner) }
@@ -269,7 +254,6 @@ impl Drop for AmbisonicsDecodeEffect {
 }
 
 unsafe impl Send for AmbisonicsDecodeEffect {}
-unsafe impl Sync for AmbisonicsDecodeEffect {}
 
 /// Settings used to create an ambisonics decode effect.
 #[derive(Debug)]

--- a/audionimbus/src/effect/ambisonics/encode.rs
+++ b/audionimbus/src/effect/ambisonics/encode.rs
@@ -203,19 +203,6 @@ impl AmbisonicsEncodeEffect {
     }
 }
 
-impl Clone for AmbisonicsEncodeEffect {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplAmbisonicsEncodeEffectRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            num_output_channels: self.num_output_channels,
-        }
-    }
-}
-
 impl Drop for AmbisonicsEncodeEffect {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplAmbisonicsEncodeEffectRelease(&raw mut self.inner) }
@@ -223,7 +210,6 @@ impl Drop for AmbisonicsEncodeEffect {
 }
 
 unsafe impl Send for AmbisonicsEncodeEffect {}
-unsafe impl Sync for AmbisonicsEncodeEffect {}
 
 /// Settings used to create an ambisonics decode effect.
 #[derive(Debug)]

--- a/audionimbus/src/effect/ambisonics/panning.rs
+++ b/audionimbus/src/effect/ambisonics/panning.rs
@@ -213,19 +213,6 @@ impl AmbisonicsPanningEffect {
     }
 }
 
-impl Clone for AmbisonicsPanningEffect {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplAmbisonicsPanningEffectRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            num_output_channels: self.num_output_channels,
-        }
-    }
-}
-
 impl Drop for AmbisonicsPanningEffect {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplAmbisonicsPanningEffectRelease(&raw mut self.inner) }
@@ -233,7 +220,6 @@ impl Drop for AmbisonicsPanningEffect {
 }
 
 unsafe impl Send for AmbisonicsPanningEffect {}
-unsafe impl Sync for AmbisonicsPanningEffect {}
 
 /// Settings used to create an ambisonics panning effect.
 #[derive(Debug)]

--- a/audionimbus/src/effect/ambisonics/rotation.rs
+++ b/audionimbus/src/effect/ambisonics/rotation.rs
@@ -205,19 +205,6 @@ impl AmbisonicsRotationEffect {
     }
 }
 
-impl Clone for AmbisonicsRotationEffect {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplAmbisonicsRotationEffectRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            num_channels: self.num_channels,
-        }
-    }
-}
-
 impl Drop for AmbisonicsRotationEffect {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplAmbisonicsRotationEffectRelease(&raw mut self.inner) }
@@ -225,7 +212,6 @@ impl Drop for AmbisonicsRotationEffect {
 }
 
 unsafe impl Send for AmbisonicsRotationEffect {}
-unsafe impl Sync for AmbisonicsRotationEffect {}
 
 /// Settings used to create an ambisonics rotation effect.
 #[derive(Debug)]

--- a/audionimbus/src/effect/binaural.rs
+++ b/audionimbus/src/effect/binaural.rs
@@ -189,15 +189,6 @@ impl BinauralEffect {
     }
 }
 
-impl Clone for BinauralEffect {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplBinauralEffectRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for BinauralEffect {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplBinauralEffectRelease(&raw mut self.0) }
@@ -205,7 +196,6 @@ impl Drop for BinauralEffect {
 }
 
 unsafe impl Send for BinauralEffect {}
-unsafe impl Sync for BinauralEffect {}
 
 /// Settings used to create a binaural effect.
 #[derive(Debug)]

--- a/audionimbus/src/effect/direct.rs
+++ b/audionimbus/src/effect/direct.rs
@@ -194,19 +194,6 @@ impl DirectEffect {
     }
 }
 
-impl Clone for DirectEffect {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplDirectEffectRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            num_channels: self.num_channels,
-        }
-    }
-}
-
 impl Drop for DirectEffect {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplDirectEffectRelease(&raw mut self.inner) }
@@ -214,7 +201,6 @@ impl Drop for DirectEffect {
 }
 
 unsafe impl Send for DirectEffect {}
-unsafe impl Sync for DirectEffect {}
 
 /// Settings used to create a direct effect.
 #[derive(Debug)]

--- a/audionimbus/src/effect/panning.rs
+++ b/audionimbus/src/effect/panning.rs
@@ -204,19 +204,6 @@ impl PanningEffect {
     }
 }
 
-impl Clone for PanningEffect {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplPanningEffectRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            num_output_channels: self.num_output_channels,
-        }
-    }
-}
-
 impl Drop for PanningEffect {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplPanningEffectRelease(&raw mut self.inner) }
@@ -224,7 +211,6 @@ impl Drop for PanningEffect {
 }
 
 unsafe impl Send for PanningEffect {}
-unsafe impl Sync for PanningEffect {}
 
 /// Settings used to create a panning effect.
 #[derive(Debug)]

--- a/audionimbus/src/effect/pathing.rs
+++ b/audionimbus/src/effect/pathing.rs
@@ -333,19 +333,6 @@ impl PathEffect {
     }
 }
 
-impl Clone for PathEffect {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplPathEffectRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            num_output_channels: self.num_output_channels,
-        }
-    }
-}
-
 impl Drop for PathEffect {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplPathEffectRelease(&raw mut self.inner) }
@@ -353,7 +340,6 @@ impl Drop for PathEffect {
 }
 
 unsafe impl Send for PathEffect {}
-unsafe impl Sync for PathEffect {}
 
 /// Settings used to create a path effect.
 #[derive(Debug)]

--- a/audionimbus/src/effect/reflections.rs
+++ b/audionimbus/src/effect/reflections.rs
@@ -622,20 +622,6 @@ impl<T: ReflectionEffectType + CanUseReflectionMixer> ReflectionEffect<T> {
     }
 }
 
-impl<T: ReflectionEffectType> Clone for ReflectionEffect<T> {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplReflectionEffectRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            num_output_channels: self.num_output_channels,
-            _marker: PhantomData,
-        }
-    }
-}
-
 impl<T: ReflectionEffectType> Drop for ReflectionEffect<T> {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplReflectionEffectRelease(&raw mut self.inner) }
@@ -643,7 +629,6 @@ impl<T: ReflectionEffectType> Drop for ReflectionEffect<T> {
 }
 
 unsafe impl<T: ReflectionEffectType> Send for ReflectionEffect<T> {}
-unsafe impl<T: ReflectionEffectType> Sync for ReflectionEffect<T> {}
 
 /// Settings used to create a reflection effect.
 #[derive(Copy, Clone, Debug)]
@@ -959,20 +944,6 @@ impl<T: ReflectionEffectType> ReflectionMixer<T> {
     }
 }
 
-impl<T: ReflectionEffectType> Clone for ReflectionMixer<T> {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplReflectionMixerRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            num_output_channels: self.num_output_channels,
-            _marker: PhantomData,
-        }
-    }
-}
-
 impl<T: ReflectionEffectType> Drop for ReflectionMixer<T> {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplReflectionMixerRelease(&raw mut self.inner) }
@@ -980,7 +951,6 @@ impl<T: ReflectionEffectType> Drop for ReflectionMixer<T> {
 }
 
 unsafe impl<T: ReflectionEffectType> Send for ReflectionMixer<T> {}
-unsafe impl<T: ReflectionEffectType> Sync for ReflectionMixer<T> {}
 
 #[cfg(test)]
 mod tests {

--- a/audionimbus/src/effect/virtual_surround.rs
+++ b/audionimbus/src/effect/virtual_surround.rs
@@ -213,19 +213,6 @@ impl VirtualSurroundEffect {
     }
 }
 
-impl Clone for VirtualSurroundEffect {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplVirtualSurroundEffectRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            num_input_channels: self.num_input_channels,
-        }
-    }
-}
-
 impl Drop for VirtualSurroundEffect {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplVirtualSurroundEffectRelease(&raw mut self.inner) }
@@ -233,7 +220,6 @@ impl Drop for VirtualSurroundEffect {
 }
 
 unsafe impl Send for VirtualSurroundEffect {}
-unsafe impl Sync for VirtualSurroundEffect {}
 
 /// Settings used to create a virtual surround effect.
 #[derive(Debug)]

--- a/audionimbus/src/energy_field.rs
+++ b/audionimbus/src/energy_field.rs
@@ -170,15 +170,6 @@ impl EnergyField {
     }
 }
 
-impl Clone for EnergyField {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplEnergyFieldRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for EnergyField {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplEnergyFieldRelease(&raw mut self.0) }
@@ -186,7 +177,6 @@ impl Drop for EnergyField {
 }
 
 unsafe impl Send for EnergyField {}
-unsafe impl Sync for EnergyField {}
 
 /// Settings used to create an [`EnergyField`].
 #[derive(Debug)]

--- a/audionimbus/src/geometry/instanced_mesh.rs
+++ b/audionimbus/src/geometry/instanced_mesh.rs
@@ -42,21 +42,6 @@ impl InstancedMesh {
         Ok(instanced_mesh)
     }
 
-    /// Updates the local-to-world transform of the instanced mesh within its parent scene.
-    ///
-    /// This function allows the instanced mesh to be moved, rotated, and scaled dynamically.
-    ///
-    /// After calling this function, [`Scene::commit`] must be called for the changes to take effect.
-    pub fn update_transform(&mut self, scene: &Scene, new_transform: Matrix<f32, 4, 4>) {
-        unsafe {
-            audionimbus_sys::iplInstancedMeshUpdateTransform(
-                self.raw_ptr(),
-                scene.raw_ptr(),
-                new_transform.into(),
-            );
-        }
-    }
-
     /// Returns the raw FFI pointer to the underlying instanced mesh.
     ///
     /// This is intended for internal use and advanced scenarios.
@@ -72,15 +57,6 @@ impl InstancedMesh {
     }
 }
 
-impl Clone for InstancedMesh {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplInstancedMeshRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for InstancedMesh {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplInstancedMeshRelease(&raw mut self.0) }
@@ -88,7 +64,6 @@ impl Drop for InstancedMesh {
 }
 
 unsafe impl Send for InstancedMesh {}
-unsafe impl Sync for InstancedMesh {}
 
 /// Settings used to create an instanced mesh.
 #[derive(Debug, Clone)]

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -767,23 +767,6 @@ impl<T: RayTracer + SaveableAsObj> Scene<T> {
     }
 }
 
-impl<T: RayTracer> Clone for Scene<T> {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplSceneRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            static_meshes: self.static_meshes.clone(),
-            instanced_meshes: self.instanced_meshes.clone(),
-            static_meshes_to_remove: self.static_meshes_to_remove.clone(),
-            instanced_meshes_to_remove: self.instanced_meshes_to_remove.clone(),
-            _marker: PhantomData,
-        }
-    }
-}
-
 impl<T: RayTracer> Drop for Scene<T> {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplSceneRelease(&raw mut self.inner) }
@@ -791,7 +774,6 @@ impl<T: RayTracer> Drop for Scene<T> {
 }
 
 unsafe impl<T: RayTracer> Send for Scene<T> {}
-unsafe impl<T: RayTracer> Sync for Scene<T> {}
 
 /// Callbacks used for a custom ray tracer.
 pub struct CustomCallbacks {

--- a/audionimbus/src/geometry/static_mesh.rs
+++ b/audionimbus/src/geometry/static_mesh.rs
@@ -188,19 +188,6 @@ impl StaticMesh<DefaultRayTracer> {
     }
 }
 
-impl<T: RayTracer> Clone for StaticMesh<T> {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplStaticMeshRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            _marker: PhantomData,
-        }
-    }
-}
-
 impl<T> Drop for StaticMesh<T> {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplStaticMeshRelease(&raw mut self.inner) }
@@ -208,7 +195,6 @@ impl<T> Drop for StaticMesh<T> {
 }
 
 unsafe impl<T: RayTracer> Send for StaticMesh<T> {}
-unsafe impl<T: RayTracer> Sync for StaticMesh<T> {}
 
 /// Settings used to create a static mesh.
 #[derive(Default, Debug)]

--- a/audionimbus/src/hrtf.rs
+++ b/audionimbus/src/hrtf.rs
@@ -80,15 +80,6 @@ impl From<audionimbus_sys::IPLHRTF> for Hrtf {
     }
 }
 
-impl Clone for Hrtf {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplHRTFRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for Hrtf {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplHRTFRelease(&raw mut self.0) }
@@ -96,7 +87,6 @@ impl Drop for Hrtf {
 }
 
 unsafe impl Send for Hrtf {}
-unsafe impl Sync for Hrtf {}
 
 /// Settings used to create an [`Hrtf`].
 #[derive(Debug)]

--- a/audionimbus/src/impulse_response.rs
+++ b/audionimbus/src/impulse_response.rs
@@ -130,15 +130,6 @@ impl ImpulseResponse {
     }
 }
 
-impl Clone for ImpulseResponse {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplImpulseResponseRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for ImpulseResponse {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplImpulseResponseRelease(&raw mut self.0) }
@@ -146,7 +137,6 @@ impl Drop for ImpulseResponse {
 }
 
 unsafe impl Send for ImpulseResponse {}
-unsafe impl Sync for ImpulseResponse {}
 
 /// Settings used to create an impulse response.
 #[derive(Debug)]

--- a/audionimbus/src/probe.rs
+++ b/audionimbus/src/probe.rs
@@ -84,15 +84,6 @@ impl ProbeArray {
     }
 }
 
-impl Clone for ProbeArray {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplProbeArrayRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for ProbeArray {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplProbeArrayRelease(&raw mut self.0) }
@@ -100,7 +91,6 @@ impl Drop for ProbeArray {
 }
 
 unsafe impl Send for ProbeArray {}
-unsafe impl Sync for ProbeArray {}
 
 /// [`ProbeArray`] errors.
 #[derive(Debug, PartialEq, Eq)]
@@ -432,20 +422,6 @@ impl ProbeBatch {
     }
 }
 
-impl Clone for ProbeBatch {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplProbeBatchRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            committed_num_probes: self.committed_num_probes,
-            pending_num_probes: self.pending_num_probes,
-        }
-    }
-}
-
 impl Drop for ProbeBatch {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplProbeBatchRelease(&raw mut self.inner) }
@@ -453,7 +429,6 @@ impl Drop for ProbeBatch {
 }
 
 unsafe impl Send for ProbeBatch {}
-unsafe impl Sync for ProbeBatch {}
 
 /// [`ProbeBatch`] errors.
 #[derive(Debug, PartialEq, Eq)]

--- a/audionimbus/src/reconstructor.rs
+++ b/audionimbus/src/reconstructor.rs
@@ -128,19 +128,6 @@ impl Reconstructor {
     }
 }
 
-impl Clone for Reconstructor {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplReconstructorRetain(self.inner);
-        }
-        Self {
-            inner: self.inner,
-            max_duration: self.max_duration,
-            max_order: self.max_order,
-        }
-    }
-}
-
 impl Drop for Reconstructor {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplReconstructorRelease(&raw mut self.inner) }
@@ -148,7 +135,6 @@ impl Drop for Reconstructor {
 }
 
 unsafe impl Send for Reconstructor {}
-unsafe impl Sync for Reconstructor {}
 
 /// Settings used to create a reconstructor.
 #[derive(Debug)]

--- a/audionimbus/src/serialized_object.rs
+++ b/audionimbus/src/serialized_object.rs
@@ -141,15 +141,6 @@ impl SerializedObject {
     }
 }
 
-impl Clone for SerializedObject {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplSerializedObjectRetain(self.0);
-        }
-        Self(self.0)
-    }
-}
-
 impl Drop for SerializedObject {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplSerializedObjectRelease(&raw mut self.0) }
@@ -157,7 +148,6 @@ impl Drop for SerializedObject {
 }
 
 unsafe impl Send for SerializedObject {}
-unsafe impl Sync for SerializedObject {}
 
 #[cfg(test)]
 mod tests {

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -496,30 +496,6 @@ where
     }
 }
 
-impl<T: RayTracer, D, R, P> Clone for Simulator<'_, T, D, R, P> {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplSimulatorRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            committed_num_probes: self.committed_num_probes,
-            pending_probe_batches: self.pending_probe_batches.clone(),
-            has_committed_scene: self.has_committed_scene,
-            has_pending_scene: self.has_pending_scene,
-            direct_lock: self.direct_lock.clone(),
-            reflections_lock: self.reflections_lock.clone(),
-            pathing_lock: self.pathing_lock.clone(),
-            _ray_tracer: PhantomData,
-            _direct: PhantomData,
-            _reflections: PhantomData,
-            _pathing: PhantomData,
-            _lifetime: PhantomData,
-        }
-    }
-}
-
 impl<T: RayTracer, D, R, P> Drop for Simulator<'_, T, D, R, P> {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplSimulatorRelease(&raw mut self.inner) }
@@ -527,7 +503,6 @@ impl<T: RayTracer, D, R, P> Drop for Simulator<'_, T, D, R, P> {
 }
 
 unsafe impl<T: RayTracer, D, R, P> Send for Simulator<'_, T, D, R, P> {}
-unsafe impl<T: RayTracer, D, R, P> Sync for Simulator<'_, T, D, R, P> {}
 
 /// Settings used to create a [`Simulator`].
 ///
@@ -1249,25 +1224,6 @@ where
     }
 }
 
-impl<'a, D, R, P> Clone for Source<'a, D, R, P> {
-    fn clone(&self) -> Self {
-        unsafe {
-            audionimbus_sys::iplSourceRetain(self.inner);
-        }
-
-        Self {
-            inner: self.inner,
-            direct_lock: self.direct_lock.clone(),
-            reflections_lock: self.reflections_lock.clone(),
-            pathing_lock: self.pathing_lock.clone(),
-            _direct: PhantomData,
-            _reflections: PhantomData,
-            _pathing: PhantomData,
-            _lifetime: PhantomData,
-        }
-    }
-}
-
 impl<D, R, P> Drop for Source<'_, D, R, P> {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplSourceRelease(&raw mut self.inner) }
@@ -1275,7 +1231,6 @@ impl<D, R, P> Drop for Source<'_, D, R, P> {
 }
 
 unsafe impl Send for Source<'_> {}
-unsafe impl Sync for Source<'_> {}
 
 /// Settings used to create a source.
 #[derive(Debug)]

--- a/audionimbus/tests/scene.rs
+++ b/audionimbus/tests/scene.rs
@@ -91,8 +91,8 @@ fn test_instanced_mesh() {
         sub_scene: &sub_scene,
         transform,
     };
-    let mut instanced_mesh = InstancedMesh::try_new(&main_scene, &instanced_mesh_settings).unwrap();
-    main_scene.add_instanced_mesh(instanced_mesh.clone());
+    let instanced_mesh = InstancedMesh::try_new(&main_scene, &instanced_mesh_settings).unwrap();
+    let handle = main_scene.add_instanced_mesh(instanced_mesh);
     main_scene.commit();
 
     let new_transform = Matrix::new([
@@ -102,7 +102,7 @@ fn test_instanced_mesh() {
         [0.0, 0.0, 0.0, 1.0],
     ]);
 
-    instanced_mesh.update_transform(&main_scene, new_transform);
+    main_scene.update_instanced_mesh_transform(handle, new_transform);
     main_scene.commit();
 }
 


### PR DESCRIPTION
### Summary

This PR removes `Clone` and `Sync` trait implementations from all AudioNimbus wrapper types while retaining `Send`.

### Rationale

Steam Audio's `ipl*Retain`/`ipl*Release` functions implement reference counting for the same underlying C object, not deep copying. The previous `Clone` implementation created multiple Rust wrappers pointing to the same C pointer with shared mutable state, which is unsafe when used concurrently.

As documented in https://github.com/ValveSoftware/steam-audio/issues/413, Steam Audio objects like `IPLHRTF` and effects are not thread-safe when shared across threads:

> IPLHRTF is currently safe to use only from a single thread. If you need to use an HRTF from multiple threads, you'll have to create an IPLHRTF on each thread.

This same principle applies to all stateful Steam Audio objects (effects, simulators, sources, scenes, etc.).