### PR TITLE
Fix use-after-free device errors

### DIFF
--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Fixed use-after-free error by ensuring `Source` outlives any `SimulationOutputs` borrowed from it.
 - Added validation to prevent runtime parameters from exceeding maximum values set during simulator initialization.
 - Fixed use-after-free error by ensuring devices outlive [`Simulator`].
+- Fixed use-after-free error by ensuring [`TrueAudioNextDevice`] outlives [`ReflectionEffectParams`].
 
 ### Changed
 
@@ -99,6 +100,8 @@
 - `SimulationOutputs` is now generic over the same simulation types as the `Source` it originated from, preventing misuse.
 - `SimulationSharedInputs` fields are now private; use builder methods `with_direct()`, `with_reflections()`, and `with_pathing()` to configure simulation types.
 - `Simulator::set_shared_inputs` and `Source::set_inputs` now return a `ParameterValidationError` if any parameters exceed that maximums set during simulator initialization.
+- All fields of `ReflectionEffectParams` are now private. Constructors should be used instead.
+- `ReflectionEffectParams<'_, TrueAudioNext>::new` now takes `TrueAudioNextDevice` by reference instead of value to ensure it outlives methods using it.
 
 ### Added
 
@@ -140,6 +143,7 @@
 - Removed `SimulatorBuilder`, which is superseded by `SimulationSettings`.
 - Removed `InstancedMesh::update_transform`. Use `Scene::update_instanced_mesh_transform` instead.
 - Removed `Clone` and `Sync` implementations from all Steam Audio wrapper types. These types can still be moved between threads (`Send`) but cannot be shared or cloned, as the underlying objects are not thread-safe for concurrent access.
+- Removed `From<IPLReflectionEffectParams>` trait implementation for `ReflectionEffectParams`.
 
 ## [0.11.0] - 2026-01-14
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Added validation to prevent runtime parameters from exceeding maximum values set during simulator initialization.
 - Fixed use-after-free error by ensuring devices outlive [`Simulator`].
 - Fixed use-after-free error by ensuring [`TrueAudioNextDevice`] outlives [`ReflectionEffectParams`].
+- Fixed use-after-free error by ensuring devices outlive [`Scene`].
 
 ### Changed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fixed silent failures when setting/getting simulation inputs for incompatible simulation types by enforcing compatibility at compile-time.
 - Fixed use-after-free error by ensuring `Source` outlives any `SimulationOutputs` borrowed from it.
 - Added validation to prevent runtime parameters from exceeding maximum values set during simulator initialization.
+- Fixed use-after-free error by ensuring devices outlive [`Simulator`].
 
 ### Changed
 

--- a/audionimbus/src/baking/pathing.rs
+++ b/audionimbus/src/baking/pathing.rs
@@ -187,7 +187,7 @@ pub struct PathBakeParams {
 pub mod tests {
     use crate::*;
 
-    fn test_scene(context: &Context) -> Scene<DefaultRayTracer> {
+    fn test_scene(context: &Context) -> Scene<'_, DefaultRayTracer> {
         let mut scene = Scene::try_new(context).unwrap();
 
         // Create a simple room mesh.

--- a/audionimbus/src/baking/reflections.rs
+++ b/audionimbus/src/baking/reflections.rs
@@ -262,7 +262,7 @@ impl From<ReflectionsBakeFlags> for audionimbus_sys::IPLReflectionsBakeFlags {
 pub mod tests {
     use crate::*;
 
-    fn test_scene(context: &Context) -> Scene<DefaultRayTracer> {
+    fn test_scene(context: &Context) -> Scene<'_, DefaultRayTracer> {
         let mut scene = Scene::try_new(context).unwrap();
 
         // Create a simple room mesh.

--- a/audionimbus/src/geometry/instanced_mesh.rs
+++ b/audionimbus/src/geometry/instanced_mesh.rs
@@ -69,7 +69,7 @@ unsafe impl Send for InstancedMesh {}
 #[derive(Debug, Clone)]
 pub struct InstancedMeshSettings<'a> {
     /// Handle to the scene to be instantiated.
-    pub sub_scene: &'a Scene,
+    pub sub_scene: &'a Scene<'a>,
 
     /// Local-to-world transform that places the instance within the parent scene.
     pub transform: Matrix<f32, 4, 4>,

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -148,6 +148,9 @@ pub struct Simulator<'a, T: RayTracer, D = (), R = (), P = ()> {
     /// Synchronization lock for pathing simulation operations.
     pathing_lock: Option<Arc<Mutex<()>>>,
 
+    _open_cl_device: Option<&'a OpenClDevice>,
+    _radeon_rays_device: Option<&'a RadeonRaysDevice>,
+    _true_audio_next_device: Option<&'a TrueAudioNextDevice>,
     _ray_tracer: PhantomData<T>,
     _direct: PhantomData<D>,
     _reflections: PhantomData<R>,
@@ -225,6 +228,9 @@ where
             direct_lock,
             reflections_lock,
             pathing_lock,
+            _open_cl_device: settings._open_cl_device,
+            _radeon_rays_device: settings._radeon_rays_device,
+            _true_audio_next_device: settings._true_audio_next_device,
             _ray_tracer: PhantomData,
             _direct: PhantomData,
             _reflections: PhantomData,
@@ -582,6 +588,9 @@ unsafe impl<T: RayTracer, D, R, P> Send for Simulator<'_, T, D, R, P> {}
 #[derive(Debug)]
 pub struct SimulationSettings<'a, T: RayTracer, D = (), R = (), P = ()> {
     settings: audionimbus_sys::IPLSimulationSettings,
+    _open_cl_device: Option<&'a OpenClDevice>,
+    _radeon_rays_device: Option<&'a RadeonRaysDevice>,
+    _true_audio_next_device: Option<&'a TrueAudioNextDevice>,
     _ray_tracer: PhantomData<T>,
     _direct: PhantomData<D>,
     _reflections: PhantomData<R>,
@@ -615,6 +624,9 @@ impl SimulationSettings<'_, DefaultRayTracer, (), (), ()> {
 
         Self {
             settings,
+            _open_cl_device: None,
+            _radeon_rays_device: None,
+            _true_audio_next_device: None,
             _ray_tracer: PhantomData,
             _direct: PhantomData,
             _reflections: PhantomData,
@@ -627,11 +639,20 @@ impl SimulationSettings<'_, DefaultRayTracer, (), (), ()> {
 impl<'a, D, R, P> SimulationSettings<'a, DefaultRayTracer, D, R, P> {
     /// Switches to the Embree ray tracer.
     pub fn with_embree(self) -> SimulationSettings<'a, Embree, (), (), ()> {
-        let Self { mut settings, .. } = self;
+        let Self {
+            mut settings,
+            _open_cl_device,
+            _radeon_rays_device,
+            _true_audio_next_device,
+            ..
+        } = self;
         settings.sceneType = Embree::scene_type();
 
         SimulationSettings {
             settings,
+            _open_cl_device,
+            _radeon_rays_device,
+            _true_audio_next_device,
             _ray_tracer: PhantomData,
             _direct: PhantomData,
             _reflections: PhantomData,
@@ -651,13 +672,20 @@ impl<'a, D, R, P> SimulationSettings<'a, DefaultRayTracer, D, R, P> {
         open_cl_device: &'a OpenClDevice,
         radeon_rays_device: &'a RadeonRaysDevice,
     ) -> SimulationSettings<'a, RadeonRays, (), (), ()> {
-        let Self { mut settings, .. } = self;
+        let Self {
+            mut settings,
+            _true_audio_next_device,
+            ..
+        } = self;
         settings.sceneType = RadeonRays::scene_type();
         settings.openCLDevice = open_cl_device.raw_ptr();
         settings.radeonRaysDevice = radeon_rays_device.raw_ptr();
 
         SimulationSettings {
             settings,
+            _open_cl_device: Some(open_cl_device),
+            _radeon_rays_device: Some(radeon_rays_device),
+            _true_audio_next_device,
             _ray_tracer: PhantomData,
             _direct: PhantomData,
             _reflections: PhantomData,
@@ -675,12 +703,21 @@ impl<'a, D, R, P> SimulationSettings<'a, DefaultRayTracer, D, R, P> {
         self,
         ray_batch_size: u32,
     ) -> SimulationSettings<'a, CustomRayTracer, (), (), ()> {
-        let Self { mut settings, .. } = self;
+        let Self {
+            mut settings,
+            _open_cl_device,
+            _radeon_rays_device,
+            _true_audio_next_device,
+            ..
+        } = self;
         settings.sceneType = CustomRayTracer::scene_type();
         settings.rayBatchSize = ray_batch_size as i32;
 
         SimulationSettings {
             settings,
+            _open_cl_device,
+            _radeon_rays_device,
+            _true_audio_next_device,
             _ray_tracer: PhantomData,
             _direct: PhantomData,
             _reflections: PhantomData,
@@ -698,6 +735,9 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
     ) -> SimulationSettings<'a, T, Direct, R, P> {
         let Self {
             mut settings,
+            _open_cl_device,
+            _radeon_rays_device,
+            _true_audio_next_device,
             _ray_tracer,
             _reflections,
             _pathing,
@@ -710,6 +750,9 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
 
         SimulationSettings {
             settings,
+            _open_cl_device,
+            _radeon_rays_device,
+            _true_audio_next_device,
             _ray_tracer,
             _direct: PhantomData,
             _reflections,
@@ -725,6 +768,9 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
     ) -> SimulationSettings<'a, T, D, Reflections, P> {
         let Self {
             mut settings,
+            mut _open_cl_device,
+            _radeon_rays_device,
+            mut _true_audio_next_device,
             _ray_tracer,
             _direct,
             _pathing,
@@ -795,6 +841,8 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
             } => {
                 settings.openCLDevice = open_cl_device.raw_ptr();
                 settings.tanDevice = true_audio_next_device.raw_ptr();
+                _open_cl_device = Some(open_cl_device);
+                _true_audio_next_device = Some(true_audio_next_device);
 
                 (
                     audionimbus_sys::IPLReflectionEffectType::IPL_REFLECTIONEFFECTTYPE_TAN,
@@ -816,6 +864,9 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
 
         SimulationSettings {
             settings,
+            _open_cl_device,
+            _radeon_rays_device,
+            _true_audio_next_device,
             _ray_tracer,
             _direct,
             _reflections: PhantomData,
@@ -831,6 +882,9 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
     ) -> SimulationSettings<'a, T, D, R, Pathing> {
         let Self {
             mut settings,
+            _open_cl_device,
+            _radeon_rays_device,
+            _true_audio_next_device,
             _ray_tracer,
             _direct,
             _reflections,
@@ -843,6 +897,9 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
 
         SimulationSettings {
             settings,
+            _open_cl_device,
+            _radeon_rays_device,
+            _true_audio_next_device,
             _ray_tracer,
             _direct,
             _reflections,

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -2335,10 +2335,14 @@ impl<'src, R, P> SimulationOutputs<'src, Direct, R, P> {
 }
 
 impl<'src, D, P> SimulationOutputs<'src, D, Reflections, P> {
-    pub fn reflections<T: ReflectionEffectType>(
-        &self,
-    ) -> FFIWrapper<'_, ReflectionEffectParams<T>, Self> {
-        unsafe { FFIWrapper::new((*self.inner).reflections.into()) }
+    pub fn reflections<'a, T: ReflectionEffectType>(
+        &'a self,
+    ) -> FFIWrapper<'a, ReflectionEffectParams<'a, T>, Self> {
+        unsafe {
+            FFIWrapper::new(ReflectionEffectParams::from_ffi_unchecked(
+                (*self.inner).reflections,
+            ))
+        }
     }
 }
 

--- a/audionimbus/tests/simulation.rs
+++ b/audionimbus/tests/simulation.rs
@@ -124,9 +124,7 @@ fn test_simulation() {
     )
     .unwrap();
 
-    let mut reflection_effect_params = simulation_outputs.reflections();
-    reflection_effect_params.num_channels = 4; // use all channels of the IR.
-    reflection_effect_params.impulse_response_size = 2 * sampling_rate; // use the full duration of the IR.
+    let reflection_effect_params = simulation_outputs.reflections();
     let _ = reflection_effect.apply(&reflection_effect_params, &input_buffer, &output_buffer);
 }
 


### PR DESCRIPTION
### Summary

This PR fixes three use-after-free bugs by introducing lifetime parameters to ensure that devices outlive the objects that reference them. These fixes prevent undefined behavior when device pointers are accessed after their owning objects have been dropped.

### Problem

Several types were storing raw pointers to device objects without enforcing that the devices remain alive. This could lead to use-after-free errors.

Affected types:

- `Scene`: Stores device pointers for `Embree`, `RadeonRays`, and `CustomRayTracer`
-` Simulator`: Stores device pointers for `OpenCL`, `RadeonRays`, and `TrueAudioNext`
- `ReflectionEffectParams`: Stores `TrueAudioNext` device pointer

### Solution

Added lifetime parameters to affected types, `PhantomData` or actual references.
Also replaced `From` trait implementation of `ReflectionEffectParams` with `from_ffi_unchecked` since it now has a lifetime parameter and we can't implement `From`.