### PR TITLE
Implement `Sync` and `Clone` for wrappers

### DIFF
--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Implement `Sync` and `Clone` traits for `Hrtf`, `Scene`, `Source`, `Context`, `Simulator`, `ProbeArray`, `ProbeBatch`, `StaticMesh`, `EnergyField`, `EmbreeDevice`, `OpenClDevice`, `OpenClDeviceList`, `RadeonRaysDevice`, `InstancedMesh`, `Reconstructor`, `ImpulseResponse`, `ReflectionMixer`, `SerializedObject`, `TrueAudioNextDevice`, `PathEffect`, `DirectEffect`, `PanningEffect`, `BinauralEffect`, `ReflectionEffect`, `VirtualSurroundEffect`, `AmbisonicsDecodeEffect`, `AmbisonicsEncodeEffect`, `AmbisonicsPanningEffect`, `AmbisonicsBinauralEffect`, `AmbisonicsRotationEffect`.
+
 ### Removed
 
 - Removed the `Default` trait implementation for `StaticMeshSettings`.

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Removed
+
+- Removed the `Default` trait implementation for `StaticMeshSettings`.
+
 ## [0.12.0] - 2026-02-12
 
 ### Fixed

--- a/audionimbus/src/context.rs
+++ b/audionimbus/src/context.rs
@@ -84,6 +84,20 @@ impl Drop for Context {
 }
 
 unsafe impl Send for Context {}
+unsafe impl Sync for Context {}
+
+impl Clone for Context {
+    /// Retains an additional reference to the context.
+    ///
+    /// The returned [`Context`] shares the same underlying Steam Audio object.
+    /// The context will not be destroyed until all clones are dropped.
+    fn clone(&self) -> Self {
+        // SAFETY: iplContextRetain increments the reference count of the underlying
+        // Steam Audio context and returns a new handle to it. The context will not
+        // be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplContextRetain(self.0) })
+    }
+}
 
 /// Settings used to create a [`Context`].
 pub struct ContextSettings {
@@ -426,6 +440,15 @@ impl From<ContextFlags> for audionimbus_sys::IPLContextFlags {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_context_clone() {
+        let context = Context::default();
+        let clone = context.clone();
+        assert_eq!(context.raw_ptr(), clone.raw_ptr());
+        drop(context);
+        assert!(!clone.raw_ptr().is_null());
+    }
 
     #[test]
     fn test_context_settings_simd_levels() {

--- a/audionimbus/src/device/embree.rs
+++ b/audionimbus/src/device/embree.rs
@@ -58,3 +58,32 @@ impl Drop for EmbreeDevice {
 }
 
 unsafe impl Send for EmbreeDevice {}
+unsafe impl Sync for EmbreeDevice {}
+
+impl Clone for EmbreeDevice {
+    /// Retains an additional reference to the Embree device.
+    ///
+    /// The returned [`EmbreeDevice`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The device will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplEmbreeDeviceRetain(self.0) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clone() {
+        let context = Context::default();
+        let Ok(device) = EmbreeDevice::try_new(&context) else {
+            // Device not available
+            return;
+        };
+        let clone = device.clone();
+        assert_eq!(device.raw_ptr(), clone.raw_ptr());
+        drop(device);
+        assert!(!clone.raw_ptr().is_null());
+    }
+}

--- a/audionimbus/src/device/open_cl.rs
+++ b/audionimbus/src/device/open_cl.rs
@@ -107,6 +107,17 @@ impl Drop for OpenClDevice {
 }
 
 unsafe impl Send for OpenClDevice {}
+unsafe impl Sync for OpenClDevice {}
+
+impl Clone for OpenClDevice {
+    /// Retains an additional reference to the OpenCL device.
+    ///
+    /// The returned [`OpenClDevice`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The device will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplOpenCLDeviceRetain(self.0) })
+    }
+}
 
 /// Provides a list of OpenCL devices available on the user’s system.
 ///
@@ -208,6 +219,17 @@ impl Drop for OpenClDeviceList {
 }
 
 unsafe impl Send for OpenClDeviceList {}
+unsafe impl Sync for OpenClDeviceList {}
+
+impl Clone for OpenClDeviceList {
+    /// Retains an additional reference to the OpenCL device list.
+    ///
+    /// The returned [`OpenClDeviceList`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The device will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplOpenCLDeviceListRetain(self.0) })
+    }
+}
 
 /// [`OpenClDeviceList`] errors.
 #[derive(Debug, PartialEq, Eq)]
@@ -460,6 +482,35 @@ mod tests {
                     }),
                 );
             }
+        }
+
+        #[test]
+        fn test_device_list_clone() {
+            let context = Context::default();
+            let settings = OpenClDeviceSettings::default();
+            let Ok(device_list) = OpenClDeviceList::try_new(&context, &settings) else {
+                // OpenCL not available
+                return;
+            };
+            let clone = device_list.clone();
+            assert_eq!(device_list.raw_ptr(), clone.raw_ptr());
+            drop(device_list);
+            assert!(!clone.raw_ptr().is_null());
+        }
+
+        #[test]
+        fn test_device_clone() {
+            let context = Context::default();
+            let settings = OpenClDeviceSettings::default();
+            let Ok(device_list) = OpenClDeviceList::try_new(&context, &settings) else {
+                // OpenCL not available
+                return;
+            };
+            let device = OpenClDevice::try_new(&context, &device_list, 0).unwrap();
+            let clone = device.clone();
+            assert_eq!(device.raw_ptr(), clone.raw_ptr());
+            drop(device);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/device/radeon_rays.rs
+++ b/audionimbus/src/device/radeon_rays.rs
@@ -63,7 +63,7 @@ unsafe impl Sync for RadeonRaysDevice {}
 impl Clone for RadeonRaysDevice {
     /// Retains an additional reference to the Radeon Rays device.
     ///
-    /// The returned [`RadeonRays`] shares the same underlying Steam Audio object.
+    /// The returned [`RadeonRaysDevice`] shares the same underlying Steam Audio object.
     fn clone(&self) -> Self {
         // SAFETY: The device will not be destroyed until all references are released.
         Self(unsafe { audionimbus_sys::iplRadeonRaysDeviceRetain(self.0) })

--- a/audionimbus/src/device/radeon_rays.rs
+++ b/audionimbus/src/device/radeon_rays.rs
@@ -58,3 +58,35 @@ impl Drop for RadeonRaysDevice {
 }
 
 unsafe impl Send for RadeonRaysDevice {}
+unsafe impl Sync for RadeonRaysDevice {}
+
+impl Clone for RadeonRaysDevice {
+    /// Retains an additional reference to the Radeon Rays device.
+    ///
+    /// The returned [`RadeonRays`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The device will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplRadeonRaysDeviceRetain(self.0) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+
+    #[test]
+    fn test_clone() {
+        let context = Context::default();
+        let settings = OpenClDeviceSettings::default();
+        let Ok(device_list) = OpenClDeviceList::try_new(&context, &settings) else {
+            // OpenCL not available
+            return;
+        };
+        let open_cl_device = OpenClDevice::try_new(&context, &device_list, 0).unwrap();
+        let radeon_rays_device = RadeonRaysDevice::try_new(&open_cl_device).unwrap();
+        let clone = radeon_rays_device.clone();
+        assert_eq!(radeon_rays_device.raw_ptr(), clone.raw_ptr());
+        drop(radeon_rays_device);
+        assert!(!clone.raw_ptr().is_null());
+    }
+}

--- a/audionimbus/src/device/true_audio_next.rs
+++ b/audionimbus/src/device/true_audio_next.rs
@@ -69,7 +69,7 @@ unsafe impl Sync for TrueAudioNextDevice {}
 impl Clone for TrueAudioNextDevice {
     /// Retains an additional reference to the TrueAudio Next device.
     ///
-    /// The returned [`TrueAudioNext`] shares the same underlying Steam Audio object.
+    /// The returned [`TrueAudioNextDevice`] shares the same underlying Steam Audio object.
     fn clone(&self) -> Self {
         // SAFETY: The device will not be destroyed until all references are released.
         Self(unsafe { audionimbus_sys::iplTrueAudioNextDeviceRetain(self.0) })

--- a/audionimbus/src/device/true_audio_next.rs
+++ b/audionimbus/src/device/true_audio_next.rs
@@ -64,6 +64,17 @@ impl Drop for TrueAudioNextDevice {
 }
 
 unsafe impl Send for TrueAudioNextDevice {}
+unsafe impl Sync for TrueAudioNextDevice {}
+
+impl Clone for TrueAudioNextDevice {
+    /// Retains an additional reference to the TrueAudio Next device.
+    ///
+    /// The returned [`TrueAudioNext`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The device will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplTrueAudioNextDeviceRetain(self.0) })
+    }
+}
 
 /// Settings used to create a TrueAudio Next device.
 #[derive(Debug)]
@@ -89,5 +100,33 @@ impl From<&TrueAudioNextDeviceSettings> for audionimbus_sys::IPLTrueAudioNextDev
             order: settings.order as i32,
             maxSources: settings.max_sources as i32,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+
+    #[test]
+    fn test_clone() {
+        let context = Context::default();
+        let open_cl_settings = OpenClDeviceSettings::default();
+        let Ok(device_list) = OpenClDeviceList::try_new(&context, &open_cl_settings) else {
+            // OpenCL not available
+            return;
+        };
+        let open_cl_device = OpenClDevice::try_new(&context, &device_list, 0).unwrap();
+        let true_audio_next_settings = TrueAudioNextDeviceSettings {
+            frame_size: 1024,
+            impulse_response_size: 1024,
+            order: 1,
+            max_sources: 1,
+        };
+        let true_audio_next_device =
+            TrueAudioNextDevice::try_new(&open_cl_device, &true_audio_next_settings).unwrap();
+        let clone = true_audio_next_device.clone();
+        assert_eq!(true_audio_next_device.raw_ptr(), clone.raw_ptr());
+        drop(true_audio_next_device);
+        assert!(!clone.raw_ptr().is_null());
     }
 }

--- a/audionimbus/src/effect/ambisonics/binaural.rs
+++ b/audionimbus/src/effect/ambisonics/binaural.rs
@@ -205,6 +205,17 @@ impl Drop for AmbisonicsBinauralEffect {
 }
 
 unsafe impl Send for AmbisonicsBinauralEffect {}
+unsafe impl Sync for AmbisonicsBinauralEffect {}
+
+impl Clone for AmbisonicsBinauralEffect {
+    /// Retains an additional reference to the ambisonics binaural effect.
+    ///
+    /// The returned [`AmbisonicsBinauralEffect`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The ambisonics binaural effect will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplAmbisonicsBinauralEffectRetain(self.0) })
+    }
+}
 
 /// Settings used to create an ambisonics binaural effect.
 #[derive(Debug)]
@@ -446,6 +457,31 @@ mod tests {
                     actual: 3
                 })
             );
+        }
+    }
+
+    mod clone {
+        use super::*;
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+            let hrtf = Hrtf::try_new(&context, &audio_settings, &HrtfSettings::default()).unwrap();
+
+            let effect = AmbisonicsBinauralEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsBinauralEffectSettings {
+                    hrtf: &hrtf,
+                    max_order: 1,
+                },
+            )
+            .unwrap();
+            let clone = effect.clone();
+            assert_eq!(effect.raw_ptr(), clone.raw_ptr());
+            drop(effect);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/effect/ambisonics/decode.rs
+++ b/audionimbus/src/effect/ambisonics/decode.rs
@@ -254,6 +254,22 @@ impl Drop for AmbisonicsDecodeEffect {
 }
 
 unsafe impl Send for AmbisonicsDecodeEffect {}
+unsafe impl Sync for AmbisonicsDecodeEffect {}
+
+impl Clone for AmbisonicsDecodeEffect {
+    /// Retains an additional reference to the ambisonics decode effect.
+    ///
+    /// The returned [`AmbisonicsDecodeEffect`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The ambisonics decode effect will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplAmbisonicsDecodeEffectRetain(self.inner) },
+            num_input_channels: self.num_input_channels,
+            num_output_channels: self.num_output_channels,
+            rendering: self.rendering,
+        }
+    }
+}
 
 /// Settings used to create an ambisonics decode effect.
 #[derive(Debug)]
@@ -561,6 +577,33 @@ mod tests {
                     actual: 4,
                 })
             );
+        }
+    }
+
+    mod clone {
+        use super::*;
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+            let hrtf = Hrtf::try_new(&context, &audio_settings, &HrtfSettings::default()).unwrap();
+
+            let effect = AmbisonicsDecodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsDecodeEffectSettings {
+                    speaker_layout: SpeakerLayout::Stereo,
+                    hrtf: &hrtf,
+                    max_order: 1,
+                    rendering: Rendering::Binaural,
+                },
+            )
+            .unwrap();
+            let clone = effect.clone();
+            assert_eq!(effect.raw_ptr(), clone.raw_ptr());
+            drop(effect);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/effect/ambisonics/encode.rs
+++ b/audionimbus/src/effect/ambisonics/encode.rs
@@ -210,6 +210,20 @@ impl Drop for AmbisonicsEncodeEffect {
 }
 
 unsafe impl Send for AmbisonicsEncodeEffect {}
+unsafe impl Sync for AmbisonicsEncodeEffect {}
+
+impl Clone for AmbisonicsEncodeEffect {
+    /// Retains an additional reference to the ambisonics encode effect.
+    ///
+    /// The returned [`AmbisonicsEncodeEffect`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The ambisonics encode effect will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplAmbisonicsEncodeEffectRetain(self.inner) },
+            num_output_channels: self.num_output_channels,
+        }
+    }
+}
 
 /// Settings used to create an ambisonics decode effect.
 #[derive(Debug)]
@@ -420,6 +434,27 @@ mod tests {
                     actual: 2,
                 })
             );
+        }
+    }
+
+    mod clone {
+        use super::*;
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let effect = AmbisonicsEncodeEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsEncodeEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+            let clone = effect.clone();
+            assert_eq!(effect.raw_ptr(), clone.raw_ptr());
+            drop(effect);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/effect/ambisonics/panning.rs
+++ b/audionimbus/src/effect/ambisonics/panning.rs
@@ -220,6 +220,20 @@ impl Drop for AmbisonicsPanningEffect {
 }
 
 unsafe impl Send for AmbisonicsPanningEffect {}
+unsafe impl Sync for AmbisonicsPanningEffect {}
+
+impl Clone for AmbisonicsPanningEffect {
+    /// Retains an additional reference to the ambisonics panning effect.
+    ///
+    /// The returned [`AmbisonicsPanningEffect`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The ambisonics panning effect will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplAmbisonicsPanningEffectRetain(self.inner) },
+            num_output_channels: self.num_output_channels,
+        }
+    }
+}
 
 /// Settings used to create an ambisonics panning effect.
 #[derive(Debug)]
@@ -442,6 +456,30 @@ mod tests {
                     actual: 3,
                 })
             );
+        }
+    }
+
+    mod clone {
+        use super::*;
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let effect = AmbisonicsPanningEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsPanningEffectSettings {
+                    speaker_layout: SpeakerLayout::Stereo,
+                    max_order: 1,
+                },
+            )
+            .unwrap();
+            let clone = effect.clone();
+            assert_eq!(effect.raw_ptr(), clone.raw_ptr());
+            drop(effect);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/effect/ambisonics/rotation.rs
+++ b/audionimbus/src/effect/ambisonics/rotation.rs
@@ -212,6 +212,20 @@ impl Drop for AmbisonicsRotationEffect {
 }
 
 unsafe impl Send for AmbisonicsRotationEffect {}
+unsafe impl Sync for AmbisonicsRotationEffect {}
+
+impl Clone for AmbisonicsRotationEffect {
+    /// Retains an additional reference to the ambisonics rotation effect.
+    ///
+    /// The returned [`AmbisonicsRotationEffect`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The ambisonics rotation effect will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplAmbisonicsRotationEffectRetain(self.inner) },
+            num_channels: self.num_channels,
+        }
+    }
+}
 
 /// Settings used to create an ambisonics rotation effect.
 #[derive(Debug)]
@@ -429,6 +443,27 @@ mod tests {
                     actual: 2,
                 })
             );
+        }
+    }
+
+    mod clone {
+        use super::*;
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let effect = AmbisonicsRotationEffect::try_new(
+                &context,
+                &audio_settings,
+                &AmbisonicsRotationEffectSettings { max_order: 1 },
+            )
+            .unwrap();
+            let clone = effect.clone();
+            assert_eq!(effect.raw_ptr(), clone.raw_ptr());
+            drop(effect);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/effect/binaural.rs
+++ b/audionimbus/src/effect/binaural.rs
@@ -196,6 +196,17 @@ impl Drop for BinauralEffect {
 }
 
 unsafe impl Send for BinauralEffect {}
+unsafe impl Sync for BinauralEffect {}
+
+impl Clone for BinauralEffect {
+    /// Retains an additional reference to the binaural effect.
+    ///
+    /// The returned [`BinauralEffect`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The binaural effect will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplBinauralEffectRetain(self.0) })
+    }
+}
 
 /// Settings used to create a binaural effect.
 #[derive(Debug)]
@@ -471,6 +482,28 @@ mod tests {
                     actual: 4
                 })
             );
+        }
+    }
+
+    mod clone {
+        use super::*;
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+            let hrtf = Hrtf::try_new(&context, &audio_settings, &HrtfSettings::default()).unwrap();
+
+            let effect = BinauralEffect::try_new(
+                &context,
+                &audio_settings,
+                &BinauralEffectSettings { hrtf: &hrtf },
+            )
+            .unwrap();
+            let clone = effect.clone();
+            assert_eq!(effect.raw_ptr(), clone.raw_ptr());
+            drop(effect);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/effect/direct.rs
+++ b/audionimbus/src/effect/direct.rs
@@ -201,6 +201,20 @@ impl Drop for DirectEffect {
 }
 
 unsafe impl Send for DirectEffect {}
+unsafe impl Sync for DirectEffect {}
+
+impl Clone for DirectEffect {
+    /// Retains an additional reference to the direct effect.
+    ///
+    /// The returned [`DirectEffect`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The direct effect will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplDirectEffectRetain(self.inner) },
+            num_channels: self.num_channels,
+        }
+    }
+}
 
 /// Settings used to create a direct effect.
 #[derive(Debug)]
@@ -515,6 +529,27 @@ mod tests {
                     actual: 2,
                 })
             );
+        }
+    }
+
+    mod clone {
+        use super::*;
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let effect = DirectEffect::try_new(
+                &context,
+                &audio_settings,
+                &DirectEffectSettings { num_channels: 1 },
+            )
+            .unwrap();
+            let clone = effect.clone();
+            assert_eq!(effect.raw_ptr(), clone.raw_ptr());
+            drop(effect);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/effect/panning.rs
+++ b/audionimbus/src/effect/panning.rs
@@ -211,6 +211,20 @@ impl Drop for PanningEffect {
 }
 
 unsafe impl Send for PanningEffect {}
+unsafe impl Sync for PanningEffect {}
+
+impl Clone for PanningEffect {
+    /// Retains an additional reference to the panning effect.
+    ///
+    /// The returned [`PanningEffect`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The panning effect will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplPanningEffectRetain(self.inner) },
+            num_output_channels: self.num_output_channels,
+        }
+    }
+}
 
 /// Settings used to create a panning effect.
 #[derive(Debug)]
@@ -460,6 +474,29 @@ mod tests {
                     actual: 4
                 })
             );
+        }
+    }
+
+    mod clone {
+        use super::*;
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let effect = PanningEffect::try_new(
+                &context,
+                &audio_settings,
+                &PanningEffectSettings {
+                    speaker_layout: SpeakerLayout::Stereo,
+                },
+            )
+            .unwrap();
+            let clone = effect.clone();
+            assert_eq!(effect.raw_ptr(), clone.raw_ptr());
+            drop(effect);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/effect/pathing.rs
+++ b/audionimbus/src/effect/pathing.rs
@@ -340,6 +340,20 @@ impl Drop for PathEffect {
 }
 
 unsafe impl Send for PathEffect {}
+unsafe impl Sync for PathEffect {}
+
+impl Clone for PathEffect {
+    /// Retains an additional reference to the path effect.
+    ///
+    /// The returned [`PathEffect`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The path effect will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplPathEffectRetain(self.inner) },
+            num_output_channels: self.num_output_channels,
+        }
+    }
+}
 
 /// Settings used to create a path effect.
 #[derive(Debug)]
@@ -704,6 +718,30 @@ mod tests {
                     actual: 2
                 })
             );
+        }
+    }
+
+    mod clone {
+        use super::*;
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+
+            let effect = PathEffect::try_new(
+                &context,
+                &audio_settings,
+                &PathEffectSettings {
+                    max_order: 1,
+                    spatialization: None,
+                },
+            )
+            .unwrap();
+            let clone = effect.clone();
+            assert_eq!(effect.raw_ptr(), clone.raw_ptr());
+            drop(effect);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/effect/reflections.rs
+++ b/audionimbus/src/effect/reflections.rs
@@ -629,6 +629,21 @@ impl<T: ReflectionEffectType> Drop for ReflectionEffect<T> {
 }
 
 unsafe impl<T: ReflectionEffectType> Send for ReflectionEffect<T> {}
+unsafe impl<T: ReflectionEffectType> Sync for ReflectionEffect<T> {}
+
+impl<T: ReflectionEffectType> Clone for ReflectionEffect<T> {
+    /// Retains an additional reference to the reflection effect.
+    ///
+    /// The returned [`ReflectionEffect`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The reflection effect will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplReflectionEffectRetain(self.inner) },
+            num_output_channels: self.num_output_channels,
+            _marker: PhantomData,
+        }
+    }
+}
 
 /// Settings used to create a reflection effect.
 #[derive(Copy, Clone, Debug)]
@@ -1701,6 +1716,36 @@ mod tests {
                         actual: 1
                     })
                 );
+            }
+        }
+
+        mod clone {
+            use super::*;
+
+            #[test]
+            fn test_reset() {
+                const SAMPLING_RATE: u32 = 48000;
+                const IR_SIZE: u32 = 2 * SAMPLING_RATE;
+
+                let context = Context::default();
+                let audio_settings = AudioSettings::default();
+
+                let num_output_channels = num_ambisonics_channels(1);
+                let reflection_effect_settings = ReflectionEffectSettings {
+                    impulse_response_size: IR_SIZE,
+                    num_channels: num_output_channels,
+                };
+
+                let effect = ReflectionEffect::<Convolution>::try_new(
+                    &context,
+                    &audio_settings,
+                    &reflection_effect_settings,
+                )
+                .unwrap();
+                let clone = effect.clone();
+                assert_eq!(effect.raw_ptr(), clone.raw_ptr());
+                drop(effect);
+                assert!(!clone.raw_ptr().is_null());
             }
         }
     }

--- a/audionimbus/src/effect/reflections.rs
+++ b/audionimbus/src/effect/reflections.rs
@@ -971,6 +971,21 @@ impl<T: ReflectionEffectType> Drop for ReflectionMixer<T> {
 }
 
 unsafe impl<T: ReflectionEffectType> Send for ReflectionMixer<T> {}
+unsafe impl<T: ReflectionEffectType> Sync for ReflectionMixer<T> {}
+
+impl<T: ReflectionEffectType> Clone for ReflectionMixer<T> {
+    /// Retains an additional reference to the reflection mixer.
+    ///
+    /// The returned [`ReflectionMixer`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The reflection mixer will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplReflectionMixerRetain(self.inner) },
+            num_output_channels: self.num_output_channels,
+            _marker: PhantomData,
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -2032,6 +2047,37 @@ mod tests {
                 .unwrap();
 
                 mixer.reset();
+            }
+        }
+
+        mod clone {
+            use super::*;
+
+            #[test]
+            fn test_reset() {
+                const SAMPLING_RATE: u32 = 48000;
+                const IR_SIZE: u32 = 2 * SAMPLING_RATE;
+
+                let context = Context::default();
+
+                let audio_settings = AudioSettings::default();
+
+                let num_output_channels = num_ambisonics_channels(1);
+                let reflection_effect_settings = ReflectionEffectSettings {
+                    impulse_response_size: IR_SIZE,
+                    num_channels: num_output_channels,
+                };
+
+                let mixer = ReflectionMixer::<Convolution>::try_new(
+                    &context,
+                    &audio_settings,
+                    &reflection_effect_settings,
+                )
+                .unwrap();
+                let clone = mixer.clone();
+                assert_eq!(mixer.raw_ptr(), clone.raw_ptr());
+                drop(mixer);
+                assert!(!clone.raw_ptr().is_null());
             }
         }
     }

--- a/audionimbus/src/effect/reflections.rs
+++ b/audionimbus/src/effect/reflections.rs
@@ -1723,7 +1723,7 @@ mod tests {
             use super::*;
 
             #[test]
-            fn test_reset() {
+            fn test_clone() {
                 const SAMPLING_RATE: u32 = 48000;
                 const IR_SIZE: u32 = 2 * SAMPLING_RATE;
 
@@ -2099,7 +2099,7 @@ mod tests {
             use super::*;
 
             #[test]
-            fn test_reset() {
+            fn test_clone() {
                 const SAMPLING_RATE: u32 = 48000;
                 const IR_SIZE: u32 = 2 * SAMPLING_RATE;
 

--- a/audionimbus/src/effect/virtual_surround.rs
+++ b/audionimbus/src/effect/virtual_surround.rs
@@ -220,6 +220,20 @@ impl Drop for VirtualSurroundEffect {
 }
 
 unsafe impl Send for VirtualSurroundEffect {}
+unsafe impl Sync for VirtualSurroundEffect {}
+
+impl Clone for VirtualSurroundEffect {
+    /// Retains an additional reference to the virtual surround effect.
+    ///
+    /// The returned [`VirtualSurroundEffect`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The virtual surround effect will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplVirtualSurroundEffectRetain(self.inner) },
+            num_input_channels: self.num_input_channels,
+        }
+    }
+}
 
 /// Settings used to create a virtual surround effect.
 #[derive(Debug)]
@@ -481,6 +495,31 @@ mod tests {
                     actual: 4
                 })
             );
+        }
+    }
+
+    mod clone {
+        use super::*;
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+            let hrtf = Hrtf::try_new(&context, &audio_settings, &HrtfSettings::default()).unwrap();
+
+            let effect = VirtualSurroundEffect::try_new(
+                &context,
+                &audio_settings,
+                &VirtualSurroundEffectSettings {
+                    speaker_layout: SpeakerLayout::Stereo,
+                    hrtf: &hrtf,
+                },
+            )
+            .unwrap();
+            let clone = effect.clone();
+            assert_eq!(effect.raw_ptr(), clone.raw_ptr());
+            drop(effect);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/energy_field.rs
+++ b/audionimbus/src/energy_field.rs
@@ -177,6 +177,17 @@ impl Drop for EnergyField {
 }
 
 unsafe impl Send for EnergyField {}
+unsafe impl Sync for EnergyField {}
+
+impl Clone for EnergyField {
+    /// Retains an additional reference to the energy field.
+    ///
+    /// The returned [`EnergyField`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The energy field will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplEnergyFieldRetain(self.0) })
+    }
+}
 
 /// Settings used to create an [`EnergyField`].
 #[derive(Debug)]
@@ -375,6 +386,20 @@ mod tests {
                     }),
                 );
             }
+        }
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let settings = EnergyFieldSettings {
+                duration: 1.0,
+                order: 1,
+            };
+            let energy_field = EnergyField::try_new(&context, &settings).unwrap();
+            let clone = energy_field.clone();
+            assert_eq!(energy_field.raw_ptr(), clone.raw_ptr());
+            drop(energy_field);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/geometry/instanced_mesh.rs
+++ b/audionimbus/src/geometry/instanced_mesh.rs
@@ -64,6 +64,17 @@ impl Drop for InstancedMesh {
 }
 
 unsafe impl Send for InstancedMesh {}
+unsafe impl Sync for InstancedMesh {}
+
+impl Clone for InstancedMesh {
+    /// Retains an additional reference to the instanced mesh.
+    ///
+    /// The returned [`InstancedMesh`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The instanced mesh will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplInstancedMeshRetain(self.0) })
+    }
+}
 
 /// Settings used to create an instanced mesh.
 #[derive(Debug, Clone)]
@@ -73,4 +84,33 @@ pub struct InstancedMeshSettings<'a> {
 
     /// Local-to-world transform that places the instance within the parent scene.
     pub transform: Matrix<f32, 4, 4>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+
+    #[test]
+    fn test_instanced_mesh_clone() {
+        let context = Context::default();
+        let main_scene = Scene::try_new(&context).unwrap();
+        let sub_scene = Scene::try_new(&context).unwrap();
+
+        let transform = Matrix::new([
+            [1.0, 0.0, 0.0, 5.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]);
+
+        let instanced_mesh_settings = geometry::InstancedMeshSettings {
+            sub_scene: &sub_scene,
+            transform,
+        };
+        let instanced_mesh = InstancedMesh::try_new(&main_scene, &instanced_mesh_settings).unwrap();
+        let clone = instanced_mesh.clone();
+        assert_eq!(instanced_mesh.raw_ptr(), clone.raw_ptr());
+        drop(instanced_mesh);
+        assert!(!clone.raw_ptr().is_null());
+    }
 }

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -10,6 +10,7 @@ use crate::serialized_object::SerializedObject;
 use crate::Sealed;
 use slotmap::{DefaultKey, SlotMap};
 use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
 
 /// Marker trait for scenes that can use `save()`.
 pub trait SaveableAsSerialized: Sealed {}
@@ -28,7 +29,14 @@ impl SaveableAsObj for Embree {}
 #[derive(Debug)]
 pub struct Scene<'a, T: RayTracer = DefaultRayTracer> {
     inner: audionimbus_sys::IPLScene,
+    shared: Arc<Mutex<SceneShared<T>>>,
+    _ray_tracing_device: PhantomData<&'a ()>,
+    _marker: PhantomData<T>,
+}
 
+/// Shared ownership of [`Scene`] data across clones.
+#[derive(Debug)]
+struct SceneShared<T: RayTracer> {
     /// Used to keep static meshes alive for the lifetime of the scene.
     static_meshes: SlotMap<DefaultKey, StaticMesh<T>>,
 
@@ -43,21 +51,34 @@ pub struct Scene<'a, T: RayTracer = DefaultRayTracer> {
 
     /// Keeps the callback user data alive for custom ray tracers.
     _callback_user_data: Option<Box<CustomRayTracingUserData>>,
-
-    _ray_tracing_device: PhantomData<&'a ()>,
-    _marker: PhantomData<T>,
 }
 
-impl<T: RayTracer> Scene<'_, T> {
-    /// Creates an empty scene.
-    fn empty() -> Self {
+impl<T: RayTracer> Default for SceneShared<T> {
+    fn default() -> Self {
         Self {
-            inner: std::ptr::null_mut(),
             static_meshes: SlotMap::new(),
             instanced_meshes: SlotMap::new(),
             static_meshes_to_remove: Vec::new(),
             instanced_meshes_to_remove: Vec::new(),
             _callback_user_data: None,
+        }
+    }
+}
+
+impl<T: RayTracer> Scene<'_, T> {
+    /// Creates an empty scene.
+    fn empty() -> Self {
+        let shared = SceneShared {
+            static_meshes: SlotMap::new(),
+            instanced_meshes: SlotMap::new(),
+            static_meshes_to_remove: Vec::new(),
+            instanced_meshes_to_remove: Vec::new(),
+            _callback_user_data: None,
+        };
+
+        Self {
+            inner: std::ptr::null_mut(),
+            shared: Arc::new(Mutex::new(shared)),
             _ray_tracing_device: PhantomData,
             _marker: PhantomData,
         }
@@ -70,7 +91,7 @@ impl<T: RayTracer> Scene<'_, T> {
         callback_user_data: Option<Box<CustomRayTracingUserData>>,
     ) -> Result<Self, SteamAudioError> {
         let mut scene = Self::empty();
-        scene._callback_user_data = callback_user_data;
+        scene.shared.lock().unwrap()._callback_user_data = callback_user_data;
 
         let status = unsafe {
             audionimbus_sys::iplSceneCreate(context.raw_ptr(), settings, scene.raw_ptr_mut())
@@ -96,7 +117,7 @@ impl<T: RayTracer> Scene<'_, T> {
         progress_callback: Option<ProgressCallback>,
     ) -> Result<Self, SteamAudioError> {
         let mut scene = Self::empty();
-        scene._callback_user_data = callback_user_data;
+        scene.shared.lock().unwrap()._callback_user_data = callback_user_data;
 
         let (callback_fn, user_data) =
             progress_callback.map_or((None, std::ptr::null_mut()), |callback| {
@@ -216,11 +237,7 @@ impl<'a> Scene<'a, Embree> {
     ) -> Result<Self, SteamAudioError> {
         let mut scene = Self {
             inner: std::ptr::null_mut(),
-            static_meshes: SlotMap::new(),
-            instanced_meshes: SlotMap::new(),
-            static_meshes_to_remove: Vec::new(),
-            instanced_meshes_to_remove: Vec::new(),
-            _callback_user_data: None,
+            shared: Arc::new(Mutex::new(SceneShared::default())),
             _ray_tracing_device: PhantomData,
             _marker: PhantomData,
         };
@@ -448,7 +465,14 @@ impl<T: RayTracer> Scene<'_, T> {
         unsafe {
             audionimbus_sys::iplStaticMeshAdd(static_mesh.raw_ptr(), self.raw_ptr());
         }
-        let key = self.static_meshes.insert(static_mesh);
+
+        let key = self
+            .shared
+            .lock()
+            .unwrap()
+            .static_meshes
+            .insert(static_mesh);
+
         StaticMeshHandle(key)
     }
 
@@ -487,9 +511,9 @@ impl<T: RayTracer> Scene<'_, T> {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn remove_static_mesh(&mut self, handle: StaticMeshHandle) -> bool {
-        let handle = handle.0;
+        let mut shared = self.shared.lock().unwrap();
 
-        let Some(static_mesh) = self.static_meshes.remove(handle) else {
+        let Some(static_mesh) = shared.static_meshes.remove(handle.0) else {
             return false;
         };
 
@@ -497,7 +521,7 @@ impl<T: RayTracer> Scene<'_, T> {
             audionimbus_sys::iplStaticMeshRemove(static_mesh.raw_ptr(), self.raw_ptr());
         }
 
-        self.static_meshes_to_remove.push(static_mesh);
+        shared.static_meshes_to_remove.push(static_mesh);
 
         true
     }
@@ -549,7 +573,9 @@ impl<T: RayTracer> Scene<'_, T> {
         unsafe {
             audionimbus_sys::iplInstancedMeshAdd(instanced_mesh.raw_ptr(), self.raw_ptr());
         }
-        let key = self.instanced_meshes.insert(instanced_mesh);
+
+        let mut shared = self.shared.lock().unwrap();
+        let key = shared.instanced_meshes.insert(instanced_mesh);
         InstancedMeshHandle(key)
     }
 
@@ -599,9 +625,9 @@ impl<T: RayTracer> Scene<'_, T> {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn remove_instanced_mesh(&mut self, handle: InstancedMeshHandle) -> bool {
-        let handle = handle.0;
+        let mut shared = self.shared.lock().unwrap();
 
-        let Some(instanced_mesh) = self.instanced_meshes.remove(handle) else {
+        let Some(instanced_mesh) = shared.instanced_meshes.remove(handle.0) else {
             return false;
         };
 
@@ -609,7 +635,7 @@ impl<T: RayTracer> Scene<'_, T> {
             audionimbus_sys::iplInstancedMeshRemove(instanced_mesh.raw_ptr(), self.raw_ptr());
         }
 
-        self.instanced_meshes_to_remove.push(instanced_mesh);
+        shared.instanced_meshes_to_remove.push(instanced_mesh);
 
         true
     }
@@ -672,7 +698,8 @@ impl<T: RayTracer> Scene<'_, T> {
         handle: InstancedMeshHandle,
         transform: Matrix<f32, 4, 4>,
     ) -> bool {
-        let Some(instanced_mesh) = self.instanced_meshes.get(handle.0) else {
+        let shared = self.shared.lock().unwrap();
+        let Some(instanced_mesh) = shared.instanced_meshes.get(handle.0) else {
             return false;
         };
 
@@ -729,8 +756,9 @@ impl<T: RayTracer> Scene<'_, T> {
             audionimbus_sys::iplSceneCommit(self.raw_ptr());
         }
 
-        self.static_meshes_to_remove.clear();
-        self.instanced_meshes_to_remove.clear();
+        let mut shared = self.shared.lock().unwrap();
+        shared.static_meshes_to_remove.clear();
+        shared.instanced_meshes_to_remove.clear();
     }
 
     /// Returns the raw FFI pointer to the underlying scene.
@@ -789,6 +817,22 @@ impl<T: RayTracer> Drop for Scene<'_, T> {
 }
 
 unsafe impl<T: RayTracer> Send for Scene<'_, T> {}
+unsafe impl<T: RayTracer> Sync for Scene<'_, T> {}
+
+impl<T: RayTracer> Clone for Scene<'_, T> {
+    /// Retains an additional reference to the scene.
+    ///
+    /// The returned [`Scene`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The scene will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplSceneRetain(self.inner) },
+            shared: Arc::clone(&self.shared),
+            _ray_tracing_device: PhantomData,
+            _marker: PhantomData,
+        }
+    }
+}
 
 /// Calculates the relative direction from the listener to a sound source.
 ///
@@ -977,5 +1021,15 @@ mod tests {
         );
 
         assert!(Scene::<CustomRayTracer>::try_with_custom(&context, &callbacks).is_ok());
+    }
+
+    #[test]
+    fn test_scene_clone() {
+        let context = Context::default();
+        let scene = Scene::<DefaultRayTracer>::try_new(&context).unwrap();
+        let clone = scene.clone();
+        assert_eq!(scene.raw_ptr(), clone.raw_ptr());
+        drop(scene);
+        assert!(!clone.raw_ptr().is_null());
     }
 }

--- a/audionimbus/src/geometry/static_mesh.rs
+++ b/audionimbus/src/geometry/static_mesh.rs
@@ -191,9 +191,23 @@ impl<T> Drop for StaticMesh<T> {
 }
 
 unsafe impl<T: RayTracer> Send for StaticMesh<T> {}
+unsafe impl<T: RayTracer> Sync for StaticMesh<T> {}
+
+impl<T: RayTracer> Clone for StaticMesh<T> {
+    /// Retains an additional reference to the static mesh.
+    ///
+    /// The returned [`StaticMesh`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The static mesh will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplStaticMeshRetain(self.inner) },
+            _marker: PhantomData,
+        }
+    }
+}
 
 /// Settings used to create a static mesh.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct StaticMeshSettings<'a> {
     /// Array containing vertices.
     pub vertices: &'a [Point],
@@ -206,4 +220,48 @@ pub struct StaticMeshSettings<'a> {
 
     /// Array of materials.
     pub materials: &'a [Material],
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+
+    #[test]
+    fn test_static_mesh_clone() {
+        let context = Context::default();
+        let scene = Scene::<DefaultRayTracer>::try_new(&context).unwrap();
+
+        let vertices = vec![
+            geometry::Point::new(0.0, 0.0, 0.0),
+            geometry::Point::new(1.0, 0.0, 0.0),
+            geometry::Point::new(1.0, 1.0, 0.0),
+            geometry::Point::new(0.0, 1.0, 0.0),
+        ];
+
+        let triangles = vec![
+            geometry::Triangle::new(0, 1, 2),
+            geometry::Triangle::new(0, 2, 2),
+        ];
+
+        let materials = vec![geometry::Material {
+            absorption: [0.1, 0.1, 0.1],
+            scattering: 0.5,
+            transmission: [0.2, 0.2, 0.2],
+        }];
+
+        let material_indices = vec![0, 0];
+
+        let settings = geometry::StaticMeshSettings {
+            vertices: &vertices,
+            triangles: &triangles,
+            material_indices: &material_indices,
+            materials: &materials,
+        };
+
+        let static_mesh = StaticMesh::<DefaultRayTracer>::try_new(&scene, &settings).unwrap();
+        let clone = static_mesh.clone();
+        assert_eq!(static_mesh.raw_ptr(), clone.raw_ptr());
+        drop(static_mesh);
+        assert!(!clone.raw_ptr().is_null());
+    }
 }

--- a/audionimbus/src/hrtf.rs
+++ b/audionimbus/src/hrtf.rs
@@ -87,6 +87,19 @@ impl Drop for Hrtf {
 }
 
 unsafe impl Send for Hrtf {}
+unsafe impl Sync for Hrtf {}
+
+impl Clone for Hrtf {
+    /// Retains an additional reference to the HRTF.
+    ///
+    /// The returned [`Hrtf`] shares the same underlying Steam Audio object.
+    /// The HRTF will not be destroyed until all clones are dropped.
+    fn clone(&self) -> Self {
+        // SAFETY: iplHRTFRetain increments the reference count and returns a new handle.
+        // The HRTF will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplHRTFRetain(self.0) })
+    }
+}
 
 /// Settings used to create an [`Hrtf`].
 #[derive(Debug)]
@@ -243,5 +256,17 @@ mod tests {
         let hrtf_settings = HrtfSettings::default();
         let hrtf_result = Hrtf::try_new(&context, &audio_settings, &hrtf_settings);
         assert!(hrtf_result.is_ok());
+    }
+
+    #[test]
+    fn test_hrtf_clone() {
+        let context = Context::default();
+        let audio_settings = AudioSettings::default();
+        let hrtf_settings = HrtfSettings::default();
+        let hrtf = Hrtf::try_new(&context, &audio_settings, &hrtf_settings).unwrap();
+        let clone = hrtf.clone();
+        assert_eq!(hrtf.raw_ptr(), clone.raw_ptr());
+        drop(hrtf);
+        assert!(!clone.raw_ptr().is_null());
     }
 }

--- a/audionimbus/src/impulse_response.rs
+++ b/audionimbus/src/impulse_response.rs
@@ -137,6 +137,17 @@ impl Drop for ImpulseResponse {
 }
 
 unsafe impl Send for ImpulseResponse {}
+unsafe impl Sync for ImpulseResponse {}
+
+impl Clone for ImpulseResponse {
+    /// Retains an additional reference to the impulse response.
+    ///
+    /// The returned [`ImpulseResponse`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The impulse response will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplImpulseResponseRetain(self.0) })
+    }
+}
 
 /// Settings used to create an impulse response.
 #[derive(Debug)]
@@ -329,5 +340,21 @@ mod tests {
         let data = impulse_response.data();
         // Values before scaling are 0.0, so they should remain 0.0.
         assert!(data.iter().all(|&x| x == 0.0));
+    }
+
+    #[test]
+    fn test_clone() {
+        let context = Context::default();
+        let settings = ImpulseResponseSettings {
+            duration: 1.0,
+            order: 1,
+            sampling_rate: 48000,
+        };
+
+        let impulse_response = ImpulseResponse::try_new(&context, &settings).unwrap();
+        let clone = impulse_response.clone();
+        assert_eq!(impulse_response.raw_ptr(), clone.raw_ptr());
+        drop(impulse_response);
+        assert!(!clone.raw_ptr().is_null());
     }
 }

--- a/audionimbus/src/probe.rs
+++ b/audionimbus/src/probe.rs
@@ -6,6 +6,7 @@ use crate::energy_field::EnergyField;
 use crate::error::{to_option_error, SteamAudioError};
 use crate::geometry::{Matrix, Scene, Sphere};
 use crate::serialized_object::SerializedObject;
+use std::sync::{Arc, Mutex};
 
 /// An array of sound probes.
 ///
@@ -182,7 +183,12 @@ impl From<ProbeGenerationParams> for audionimbus_sys::IPLProbeGenerationParams {
 #[derive(Debug)]
 pub struct ProbeBatch {
     inner: audionimbus_sys::IPLProbeBatch,
+    shared: Arc<Mutex<ProbeBatchShared>>,
+}
 
+/// Shared ownership of [`ProbeBatch`] data across clones.
+#[derive(Default, Debug)]
+struct ProbeBatchShared {
     /// Number of probes after the last commit.
     committed_num_probes: usize,
 
@@ -199,8 +205,7 @@ impl ProbeBatch {
     pub fn try_new(context: &Context) -> Result<Self, SteamAudioError> {
         let mut probe_batch = Self {
             inner: std::ptr::null_mut(),
-            committed_num_probes: 0,
-            pending_num_probes: 0,
+            shared: Arc::new(Mutex::new(ProbeBatchShared::default())),
         };
 
         let status = unsafe {
@@ -220,8 +225,8 @@ impl ProbeBatch {
     }
 
     /// Returns the number of committed probes in the probe batch.
-    pub const fn committed_num_probes(&self) -> usize {
-        self.committed_num_probes
+    pub fn committed_num_probes(&self) -> usize {
+        self.shared.lock().unwrap().committed_num_probes
     }
 
     /// Returns the size (in bytes) of a specific baked data layer in the probe batch.
@@ -252,7 +257,7 @@ impl ProbeBatch {
             );
         }
 
-        self.pending_num_probes += 1;
+        self.shared.lock().unwrap().pending_num_probes += 1;
     }
 
     /// Removes a probe from the batch.
@@ -273,7 +278,8 @@ impl ProbeBatch {
             audionimbus_sys::iplProbeBatchRemoveProbe(self.raw_ptr(), probe_index as i32);
         }
 
-        self.pending_num_probes -= 1;
+        self.shared.lock().unwrap().pending_num_probes -= 1;
+
         Ok(())
     }
 
@@ -284,7 +290,7 @@ impl ProbeBatch {
             audionimbus_sys::iplProbeBatchAddProbeArray(self.raw_ptr(), probe_array.raw_ptr());
         }
 
-        self.pending_num_probes += probe_array.num_probes() as i32;
+        self.shared.lock().unwrap().pending_num_probes += probe_array.num_probes() as i32;
     }
 
     /// Retrieves a single array of parametric reverb times in a specific baked data layer of a specific probe in the probe batch.
@@ -359,9 +365,11 @@ impl ProbeBatch {
     pub fn commit(&mut self) {
         unsafe { audionimbus_sys::iplProbeBatchCommit(self.raw_ptr()) }
 
-        self.committed_num_probes = self
+        let mut shared = self.shared.lock().unwrap();
+
+        shared.committed_num_probes = shared
             .committed_num_probes
-            .saturating_add_signed(self.pending_num_probes as isize);
+            .saturating_add_signed(shared.pending_num_probes as isize);
     }
 
     /// Saves a probe batch to a serialized object.
@@ -384,10 +392,11 @@ impl ProbeBatch {
         context: &Context,
         serialized_object: &mut SerializedObject,
     ) -> Result<Self, SteamAudioError> {
+        let shared = Arc::new(Mutex::new(ProbeBatchShared::default()));
+
         let mut probe_batch = Self {
             inner: std::ptr::null_mut(),
-            committed_num_probes: 0,
-            pending_num_probes: 0,
+            shared: shared.clone(),
         };
 
         let status = unsafe {
@@ -402,7 +411,7 @@ impl ProbeBatch {
             return Err(error);
         }
 
-        probe_batch.committed_num_probes = probe_batch.num_probes();
+        shared.lock().unwrap().committed_num_probes = probe_batch.num_probes();
 
         Ok(probe_batch)
     }
@@ -429,6 +438,20 @@ impl Drop for ProbeBatch {
 }
 
 unsafe impl Send for ProbeBatch {}
+unsafe impl Sync for ProbeBatch {}
+
+impl Clone for ProbeBatch {
+    /// Retains an additional reference to the probe batch.
+    ///
+    /// The returned [`ProbeBatch`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The probe batch will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplProbeBatchRetain(self.inner) },
+            shared: Arc::clone(&self.shared),
+        }
+    }
+}
 
 /// [`ProbeBatch`] errors.
 #[derive(Debug, PartialEq, Eq)]
@@ -597,6 +620,16 @@ mod tests {
                     num_probes: 0,
                 })
             );
+        }
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let probe_batch = ProbeBatch::try_new(&context).unwrap();
+            let clone = probe_batch.clone();
+            assert_eq!(probe_batch.raw_ptr(), clone.raw_ptr());
+            drop(probe_batch);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/probe.rs
+++ b/audionimbus/src/probe.rs
@@ -381,6 +381,7 @@ impl ProbeBatch {
         shared.committed_num_probes = shared
             .committed_num_probes
             .saturating_add_signed(shared.pending_num_probes as isize);
+        shared.pending_num_probes = 0;
     }
 
     /// Saves a probe batch to a serialized object.

--- a/audionimbus/src/probe.rs
+++ b/audionimbus/src/probe.rs
@@ -92,6 +92,17 @@ impl Drop for ProbeArray {
 }
 
 unsafe impl Send for ProbeArray {}
+unsafe impl Sync for ProbeArray {}
+
+impl Clone for ProbeArray {
+    /// Retains an additional reference to the probe array.
+    ///
+    /// The returned [`ProbeArray`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The probe array will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplProbeArrayRetain(self.0) })
+    }
+}
 
 /// [`ProbeArray`] errors.
 #[derive(Debug, PartialEq, Eq)]
@@ -555,6 +566,16 @@ mod tests {
 
             probe_array.generate_probes(&scene, &params);
             assert_eq!(probe_array.num_probes(), 121);
+        }
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let probe_array = ProbeArray::try_new(&context).unwrap();
+            let clone = probe_array.clone();
+            assert_eq!(probe_array.raw_ptr(), clone.raw_ptr());
+            drop(probe_array);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 

--- a/audionimbus/src/reconstructor.rs
+++ b/audionimbus/src/reconstructor.rs
@@ -135,6 +135,21 @@ impl Drop for Reconstructor {
 }
 
 unsafe impl Send for Reconstructor {}
+unsafe impl Sync for Reconstructor {}
+
+impl Clone for Reconstructor {
+    /// Retains an additional reference to the reconstructor.
+    ///
+    /// The returned [`Reconstructor`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The reconstructor will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplReconstructorRetain(self.inner) },
+            max_duration: self.max_duration,
+            max_order: self.max_order,
+        }
+    }
+}
 
 /// Settings used to create a reconstructor.
 #[derive(Debug)]
@@ -472,6 +487,21 @@ mod tests {
                     outputs_len: 1,
                 }),
             );
+        }
+
+        #[test]
+        fn test_clone() {
+            let context = Context::default();
+            let reconstructor_settings = ReconstructorSettings {
+                max_duration: MAX_DURATION,
+                max_order: MAX_ORDER,
+                sampling_rate: SAMPLING_RATE,
+            };
+            let reconstructor = Reconstructor::try_new(&context, &reconstructor_settings).unwrap();
+            let clone = reconstructor.clone();
+            assert_eq!(reconstructor.raw_ptr(), clone.raw_ptr());
+            drop(reconstructor);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/serialized_object.rs
+++ b/audionimbus/src/serialized_object.rs
@@ -148,6 +148,17 @@ impl Drop for SerializedObject {
 }
 
 unsafe impl Send for SerializedObject {}
+unsafe impl Sync for SerializedObject {}
+
+impl Clone for SerializedObject {
+    /// Retains an additional reference to the serialized object.
+    ///
+    /// The returned [`SerializedObject`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The serialized object will not be destroyed until all references are released.
+        Self(unsafe { audionimbus_sys::iplSerializedObjectRetain(self.0) })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -166,5 +177,15 @@ mod tests {
         let mut buffer = vec![0u8; 1024];
         let serialized_object = SerializedObject::try_with_buffer(&context, &mut buffer);
         assert!(serialized_object.is_ok());
+    }
+
+    #[test]
+    fn test_clone() {
+        let context = Context::default();
+        let serialized_object = SerializedObject::try_new(&context).unwrap();
+        let clone = serialized_object.clone();
+        assert_eq!(serialized_object.raw_ptr(), clone.raw_ptr());
+        drop(serialized_object);
+        assert!(!clone.raw_ptr().is_null());
     }
 }

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -148,7 +148,7 @@ pub struct Simulator<'a, T: RayTracer, D = (), R = (), P = ()> {
 
 /// Shared ownership of [`Simulator`] data across clones.
 #[derive(Default, Debug)]
-pub struct SimulatorShared {
+struct SimulatorShared {
     /// Number of probes after the last commit.
     /// Used to ensure the simulator has probes before running pathing.
     committed_num_probes: usize,
@@ -1482,7 +1482,7 @@ impl<D, R, P> Drop for Source<'_, D, R, P> {
     }
 }
 
-unsafe impl Send for Source<'_> {}
+unsafe impl<D, R, P> Send for Source<'_, D, R, P> {}
 unsafe impl<D, R, P> Sync for Source<'_, D, R, P> {}
 
 impl<'a, D, R, P> Clone for Source<'a, D, R, P>

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -116,19 +116,7 @@ pub struct Pathing;
 #[derive(Debug)]
 pub struct Simulator<'a, T: RayTracer, D = (), R = (), P = ()> {
     inner: audionimbus_sys::IPLSimulator,
-
-    /// Number of probes after the last commit.
-    /// Used to ensure the simulator has probes before running pathing.
-    committed_num_probes: usize,
-
-    /// Pending probe batches to be committed.
-    pending_probe_batches: HashMap<audionimbus_sys::IPLProbeBatch, usize>,
-
-    /// Whether a scene has been set and committed.
-    has_committed_scene: bool,
-
-    /// Whether a scene is pending commit.
-    has_pending_scene: bool,
+    shared: Arc<Mutex<SimulatorShared>>,
 
     /// The maximum number of occlusion samples specified during creation.
     max_num_occlusion_samples: Option<u32>,
@@ -156,6 +144,23 @@ pub struct Simulator<'a, T: RayTracer, D = (), R = (), P = ()> {
     _reflections: PhantomData<R>,
     _pathing: PhantomData<P>,
     _lifetime: PhantomData<&'a ()>,
+}
+
+/// Shared ownership of [`Simulator`] data across clones.
+#[derive(Default, Debug)]
+pub struct SimulatorShared {
+    /// Number of probes after the last commit.
+    /// Used to ensure the simulator has probes before running pathing.
+    committed_num_probes: usize,
+
+    /// Pending probe batches to be committed.
+    pending_probe_batches: HashMap<audionimbus_sys::IPLProbeBatch, usize>,
+
+    /// Whether a scene has been set and committed.
+    has_committed_scene: bool,
+
+    /// Whether a scene is pending commit.
+    has_pending_scene: bool,
 }
 
 impl<'a, T, D, R, P> Simulator<'a, T, D, R, P>
@@ -218,10 +223,7 @@ where
 
         let mut simulator = Self {
             inner: std::ptr::null_mut(),
-            committed_num_probes: 0,
-            pending_probe_batches: HashMap::new(),
-            has_committed_scene: false,
-            has_pending_scene: false,
+            shared: Arc::new(Mutex::new(SimulatorShared::default())),
             max_num_occlusion_samples: settings.max_num_occlusion_samples(),
             max_num_rays: settings.max_num_rays(),
             max_duration: settings.max_duration(),
@@ -260,7 +262,8 @@ where
     /// This function cannot be called while any simulation is running.
     pub fn set_scene(&mut self, scene: &Scene<T>) {
         unsafe { audionimbus_sys::iplSimulatorSetScene(self.raw_ptr(), scene.raw_ptr()) }
-        self.has_pending_scene = true;
+        let mut shared = self.shared.lock().unwrap();
+        shared.has_pending_scene = true;
     }
 
     /// Adds a probe batch for use in subsequent simulations.
@@ -276,7 +279,9 @@ where
             audionimbus_sys::iplSimulatorAddProbeBatch(self.raw_ptr(), probe_batch.raw_ptr());
         }
 
-        self.pending_probe_batches
+        let mut shared = self.shared.lock().unwrap();
+        shared
+            .pending_probe_batches
             .insert(raw_ptr, probe_batch.committed_num_probes());
     }
 
@@ -293,7 +298,8 @@ where
             audionimbus_sys::iplSimulatorRemoveProbeBatch(self.raw_ptr(), probe_batch.raw_ptr());
         }
 
-        self.pending_probe_batches.remove(&raw_ptr);
+        let mut shared = self.shared.lock().unwrap();
+        shared.pending_probe_batches.remove(&raw_ptr);
     }
 
     /// Adds a source to the set of sources processed by a simulator in subsequent simulations.
@@ -331,11 +337,12 @@ where
 
         unsafe { audionimbus_sys::iplSimulatorCommit(self.raw_ptr()) }
 
-        self.committed_num_probes = self.pending_probe_batches.values().sum();
+        let mut shared = self.shared.lock().unwrap();
+        shared.committed_num_probes = shared.pending_probe_batches.values().sum();
 
-        if self.has_pending_scene {
-            self.has_committed_scene = true;
-            self.has_pending_scene = false;
+        if shared.has_pending_scene {
+            shared.has_committed_scene = true;
+            shared.has_pending_scene = false;
         }
     }
 
@@ -503,7 +510,8 @@ where
             .lock()
             .unwrap();
 
-        if !self.has_committed_scene {
+        let shared = self.shared.lock().unwrap();
+        if !shared.has_committed_scene {
             return Err(SimulationError::ReflectionsWithoutScene);
         }
 
@@ -543,7 +551,8 @@ where
             .lock()
             .unwrap();
 
-        if self.committed_num_probes == 0 {
+        let shared = self.shared.lock().unwrap();
+        if shared.committed_num_probes == 0 {
             return Err(SimulationError::PathingWithoutProbes);
         }
 
@@ -562,6 +571,40 @@ impl<T: RayTracer, D, R, P> Drop for Simulator<'_, T, D, R, P> {
 }
 
 unsafe impl<T: RayTracer, D, R, P> Send for Simulator<'_, T, D, R, P> {}
+unsafe impl<T: RayTracer, D, R, P> Sync for Simulator<'_, T, D, R, P> {}
+
+impl<'a, T, D, R, P> Clone for Simulator<'a, T, D, R, P>
+where
+    T: RayTracer,
+    D: 'static,
+    R: 'static,
+    P: 'static,
+{
+    /// Retains an additional reference to the simulator.
+    ///
+    /// The returned [`Simulator`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The simulator will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplSimulatorRetain(self.inner) },
+            shared: Arc::clone(&self.shared),
+            max_num_occlusion_samples: self.max_num_occlusion_samples,
+            max_num_rays: self.max_num_rays,
+            max_duration: self.max_duration,
+            direct_lock: self.direct_lock.clone(),
+            reflections_lock: self.reflections_lock.clone(),
+            pathing_lock: self.pathing_lock.clone(),
+            _open_cl_device: self._open_cl_device,
+            _radeon_rays_device: self._radeon_rays_device,
+            _true_audio_next_device: self._true_audio_next_device,
+            _ray_tracer: PhantomData,
+            _direct: PhantomData,
+            _reflections: PhantomData,
+            _pathing: PhantomData,
+            _lifetime: PhantomData,
+        }
+    }
+}
 
 /// Settings used to create a [`Simulator`].
 ///
@@ -2555,6 +2598,21 @@ mod tests {
                 simulator.run_direct();
                 let _ = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
             }
+        }
+    }
+
+    mod simulator {
+        use super::*;
+
+        #[test]
+        fn test_simulator_clone() {
+            let context = Context::default();
+            let settings = SimulationSettings::new(48_000, 1024, 1);
+            let simulator = Simulator::try_new(&context, &settings).unwrap();
+            let clone = simulator.clone();
+            assert_eq!(simulator.raw_ptr(), clone.raw_ptr());
+            drop(simulator);
+            assert!(!clone.raw_ptr().is_null());
         }
     }
 }

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -1184,13 +1184,10 @@ impl PathingCompatible<()> for () {}
 #[derive(Debug)]
 pub struct Source<'a, D = (), R = (), P = ()> {
     inner: audionimbus_sys::IPLSource,
+    shared: Arc<Mutex<SourceShared>>,
 
     /// The maximum number of occlusion samples specified during creation of the [Simulator].
     max_num_occlusion_samples: Option<u32>,
-
-    /// Stored deviation model to keep `callback` and `user_data` alive.
-    /// Only used when pathing simulation is enabled.
-    deviation_model: Option<DeviationModel>,
 
     /// Reference to the simulator's direct simulation lock.
     /// Used to synchronize access to direct simulation data.
@@ -1208,6 +1205,14 @@ pub struct Source<'a, D = (), R = (), P = ()> {
     _reflections: PhantomData<R>,
     _pathing: PhantomData<P>,
     _lifetime: PhantomData<&'a ()>,
+}
+
+/// Shared ownership of [`Source`] data across clones.
+#[derive(Default, Debug)]
+struct SourceShared {
+    /// Stored deviation model to keep `callback` and `user_data` alive.
+    /// Only used when pathing simulation is enabled.
+    deviation_model: Option<DeviationModel>,
 }
 
 impl<'a, D, R, P> Source<'a, D, R, P>
@@ -1254,8 +1259,8 @@ where
 
         let source = Self {
             inner,
+            shared: Arc::new(Mutex::new(SourceShared::default())),
             max_num_occlusion_samples: simulator.max_num_occlusion_samples,
-            deviation_model: None,
             direct_lock,
             reflections_lock,
             pathing_lock,
@@ -1305,7 +1310,7 @@ where
         let mut ffi_inputs = inputs.to_ffi();
 
         if let Some(pathing_params) = inputs.pathing_simulation {
-            self.deviation_model = Some(pathing_params.deviation);
+            self.shared.lock().unwrap().deviation_model = Some(pathing_params.deviation);
         }
 
         let _guards = self.acquire_locks_for_flags(simulation_flags);
@@ -1478,6 +1483,33 @@ impl<D, R, P> Drop for Source<'_, D, R, P> {
 }
 
 unsafe impl Send for Source<'_> {}
+unsafe impl<D, R, P> Sync for Source<'_, D, R, P> {}
+
+impl<'a, D, R, P> Clone for Source<'a, D, R, P>
+where
+    D: 'static,
+    R: 'static,
+    P: 'static,
+{
+    /// Retains an additional reference to the source.
+    ///
+    /// The returned [`Source`] shares the same underlying Steam Audio object.
+    fn clone(&self) -> Self {
+        // SAFETY: The source will not be destroyed until all references are released.
+        Self {
+            inner: unsafe { audionimbus_sys::iplSourceRetain(self.inner) },
+            max_num_occlusion_samples: self.max_num_occlusion_samples,
+            shared: Arc::clone(&self.shared),
+            direct_lock: self.direct_lock.clone(),
+            reflections_lock: self.reflections_lock.clone(),
+            pathing_lock: self.pathing_lock.clone(),
+            _direct: PhantomData,
+            _reflections: PhantomData,
+            _pathing: PhantomData,
+            _lifetime: PhantomData,
+        }
+    }
+}
 
 /// Settings used to create a source.
 #[derive(Debug)]
@@ -2597,6 +2629,25 @@ mod tests {
 
                 simulator.run_direct();
                 let _ = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
+            }
+        }
+
+        mod clone {
+            use super::*;
+
+            #[test]
+            fn test_clone() {
+                let context = Context::default();
+                let simulator_settings = SimulationSettings::new(48_000, 1024, 1);
+                let simulator = Simulator::try_new(&context, &simulator_settings).unwrap();
+                let source_settings = SourceSettings {
+                    flags: SimulationFlags::empty(),
+                };
+                let source = Source::<(), (), ()>::try_new(&simulator, &source_settings).unwrap();
+                let clone = source.clone();
+                assert_eq!(source.raw_ptr(), clone.raw_ptr());
+                drop(source);
+                assert!(!clone.raw_ptr().is_null());
             }
         }
     }


### PR DESCRIPTION
Implements `Sync` and `Clone` for all Steam Audio wrappers, enabling shared ownership and use across threads.

All types implement `Clone` via the corresponding `ipl*Retain` `audionimbus_sys` function, sharing the underlying Steam Audio object. The object is not destroyed until all clones are dropped.

Types with mutable Rust-side bookkeeping (`Scene`, `Simulator`, `Source`, `ProbeBatch`) wrap their shared state in `Arc<Mutex<…>>` so that mutations (e.g. `commit()`, `add_probe()`, `set_inputs()`) are visible across all clones.

#### Changes

- `Sync` and `Clone` added for: `Context`, `Hrtf`, `Scene`, `StaticMesh`, `InstancedMesh`, `Simulator`, `Source`, `ProbeBatch`, `ProbeArray`, `EnergyField`, `ImpulseResponse`, `Reconstructor`, `ReflectionMixer`, `SerializedObject`, `EmbreeDevice`, `OpenClDevice`, `OpenClDeviceList`, `RadeonRaysDevice`, `TrueAudioNextDevice`, `PathEffect`, `DirectEffect`, `PanningEffect`, `BinauralEffect`, `VirtualSurroundEffect`, `ReflectionEffect`, `AmbisonicsDecodeEffect`, `AmbisonicsEncodeEffect`, `AmbisonicsPanningEffect`, `AmbisonicsBinauralEffect`, `AmbisonicsRotationEffect`
- `SceneShared`, `SimulatorShared`, `SourceShared`, `ProbeBatchShared` introduced to hold shared mutable state
- `Default` removed from `StaticMeshSettings`

Note on `Sync`: [Steam Audio's documented internal thread safety](https://valvesoftware.github.io/steam-audio/doc/capi/guide.html#destroying-steam-audio-api-objects)