### PR TITLE
Remove lifetime parameters from handle types

### DIFF
--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -12,6 +12,10 @@
 - `PathingSimulationParameters::pathing_probes` is now an owned `ProbeBatch` instead of `&ProbeBatch`.
 - `ReflectionsSimulationSettings::TrueAudioNext` now owns its `OpenClDevice` and `TrueAudioNextDevice` fields instead of borrowing them. As a result, `ReflectionsSimulationSettings` no longer implements `Copy`.
 - Lifetime parameters have been removed from `Simulator`, `SimulationSettings`, `SimulationInputs`, `PathingSimulationParameters`, and `ReflectionsSimulationSettings`.
+- `Scene::try_with_embree`, `Scene::load_embree`, and `Scene::load_embree_with_progress` now take `EmbreeDevice` by value instead of by reference.
+- `Scene::try_with_radeon_rays`, `Scene::load_radeon_rays`, and `Scene::load_radeon_rays_with_progress` now take `RadeonRaysDevice` by value instead of by reference.
+- `Scene::try_with_custom`, `Scene::load_custom`, and `Scene::load_custom_with_progress` now take `CustomRayTracingCallbacks` by value instead of by reference.
+- Lifetime parameters have been removed from `Scene`.
 
 ### Added
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Changed
 
 - All callback types (`DistanceAttenuationCallback`, `AirAbsorptionCallback`, `DirectivityCallback`, `DeviationCallback`, `PathingVisualizationCallback`, `ClosestHitCallback`, `AnyHitCallback`, `BatchedClosestHitCallback`, `BatchedAnyHitCallback`) now require `Fn + Send + Sync` instead of `FnMut + Send`. Closures that previously captured mutable state must now use interior mutability (e.g. `Mutex`, `RwLock`) instead.
+- `Simulator::try_new` now takes `SimulationSettings` by value instead of by reference.
+- `Source::try_new` now takes `SourceSettings` by value instead of by reference.
+- `Source::set_inputs` now takes `SimulationInputs` by value instead of by reference.
+- `SimulationSettings::with_radeon_rays` now takes `OpenClDevice` and `RadeonRaysDevice` by value instead of by reference.
+- `PathingSimulationParameters::pathing_probes` is now an owned `ProbeBatch` instead of `&ProbeBatch`.
+- `ReflectionsSimulationSettings::TrueAudioNext` now owns its `OpenClDevice` and `TrueAudioNextDevice` fields instead of borrowing them. As a result, `ReflectionsSimulationSettings` no longer implements `Copy`.
+- Lifetime parameters have been removed from `Simulator`, `SimulationSettings`, `SimulationInputs`, `PathingSimulationParameters`, and `ReflectionsSimulationSettings`.
 
 ### Added
 
@@ -12,6 +19,7 @@
 - Implement `Clone` for all models (`AirAbsorptionModel`, `DeviationModel`, `Directivity`, `DistanceAttenuationModel`).
 - Implement `Clone` for `SimulationInputs`, `DirectSimulationParameters`, `PathingSimulationParameters`.
 - Implement `Copy`, `Clone` for `AudioEffectState`.
+- Implement `Copy`, `Clone` for `SourceSettings`.
 
 ## [0.13.0] - 2026-03-04
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Implement `Clone` for all callback types (`DistanceAttenuationCallback`, `AirAbsorptionCallback`, `DirectivityCallback`, `DeviationCallback`, `PathingVisualizationCallback`, `ClosestHitCallback`, `AnyHitCallback`, `BatchedClosestHitCallback`, `BatchedAnyHitCallback`, `CustomRayTracingCallbacks`).
 - Implement `Clone` for all models (`AirAbsorptionModel`, `DeviationModel`, `Directivity`, `DistanceAttenuationModel`).
 - Implement `Clone` for `SimulationInputs`, `DirectSimulationParameters`, `PathingSimulationParameters`.
+- Implement `Copy`, `Clone` for `AudioEffectState`.
 
 ## [0.13.0] - 2026-03-04
 

--- a/audionimbus/src/baking/pathing.rs
+++ b/audionimbus/src/baking/pathing.rs
@@ -175,7 +175,7 @@ pub struct PathBakeParams {
 pub mod tests {
     use crate::*;
 
-    fn test_scene(context: &Context) -> Scene<'_, DefaultRayTracer> {
+    fn test_scene(context: &Context) -> Scene<DefaultRayTracer> {
         let mut scene = Scene::try_new(context).unwrap();
 
         // Create a simple room mesh.

--- a/audionimbus/src/baking/reflections.rs
+++ b/audionimbus/src/baking/reflections.rs
@@ -262,7 +262,7 @@ impl From<ReflectionsBakeFlags> for audionimbus_sys::IPLReflectionsBakeFlags {
 pub mod tests {
     use crate::*;
 
-    fn test_scene(context: &Context) -> Scene<'_, DefaultRayTracer> {
+    fn test_scene(context: &Context) -> Scene<DefaultRayTracer> {
         let mut scene = Scene::try_new(context).unwrap();
 
         // Create a simple room mesh.

--- a/audionimbus/src/context.rs
+++ b/audionimbus/src/context.rs
@@ -7,6 +7,11 @@ use crate::version::SteamAudioVersion;
 ///
 /// Typically, a context is specified once during the execution of the client program, before calling any other API functions.
 ///
+/// `Context` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// ```
@@ -24,7 +29,7 @@ use crate::version::SteamAudioVersion;
 pub struct Context(pub(crate) audionimbus_sys::IPLContext);
 
 impl Context {
-    /// Creates a new context with the given [`ContextSettings`].
+    /// Creates a new context with the given [`ContextSettings`] and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/device/embree.rs
+++ b/audionimbus/src/device/embree.rs
@@ -6,11 +6,16 @@ use crate::error::{to_option_error, SteamAudioError};
 /// Application-wide state for the Embree ray tracer.
 ///
 /// An Embree device must be created before using any of Steam Audio’s Embree ray tracing functionality.
+///
+/// `EmbreeDevice` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct EmbreeDevice(audionimbus_sys::IPLEmbreeDevice);
 
 impl EmbreeDevice {
-    /// Creates a new Embree device for ray tracing.
+    /// Creates a new Embree device for ray tracing and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/device/open_cl.rs
+++ b/audionimbus/src/device/open_cl.rs
@@ -7,11 +7,16 @@ use std::string::ToString;
 /// Application-wide state for OpenCL.
 ///
 /// An OpenCL device must be created before using any of Steam Audio’s Radeon Rays or TrueAudio Next functionality.
+///
+/// `OpenClDevice` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct OpenClDevice(audionimbus_sys::IPLOpenCLDevice);
 
 impl OpenClDevice {
-    /// Creates a new OpenCL device from a device list.
+    /// Creates a new OpenCL device from a device list and returns a handle to it.
     ///
     /// # Arguments
     ///
@@ -122,10 +127,15 @@ impl Clone for OpenClDevice {
 /// Provides a list of OpenCL devices available on the user’s system.
 ///
 /// Use this to enumerate the available OpenCL devices, inspect their capabilities, and select the most suitable one for your application’s needs.
+///
+/// `OpenClDeviceList` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 pub struct OpenClDeviceList(audionimbus_sys::IPLOpenCLDeviceList);
 
 impl OpenClDeviceList {
-    /// Creates a new [`OpenClDeviceList`].
+    /// Creates a new [`OpenClDeviceList`] and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/device/radeon_rays.rs
+++ b/audionimbus/src/device/radeon_rays.rs
@@ -6,11 +6,16 @@ use crate::error::{to_option_error, SteamAudioError};
 /// Application-wide state for the Radeon Rays ray tracer.
 ///
 /// A Radeon Rays device must be created before using any of Steam Audio’s Radeon Rays ray tracing functionality.
+///
+/// `RadeonRaysDevice` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct RadeonRaysDevice(audionimbus_sys::IPLRadeonRaysDevice);
 
 impl RadeonRaysDevice {
-    /// Creates a new Radeon Rays device for GPU-accelerated ray tracing.
+    /// Creates a new Radeon Rays device for GPU-accelerated ray tracing and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/device/true_audio_next.rs
+++ b/audionimbus/src/device/true_audio_next.rs
@@ -6,11 +6,17 @@ use crate::error::{to_option_error, SteamAudioError};
 /// Application-wide state for the TrueAudio Next convolution engine.
 ///
 /// A TrueAudio Next device must be created before using any of Steam Audio’s TrueAudio Next convolution functionality.
+///
+/// `TrueAudioNextDevice` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug, Eq, PartialEq)]
 pub struct TrueAudioNextDevice(pub(crate) audionimbus_sys::IPLTrueAudioNextDevice);
 
 impl TrueAudioNextDevice {
-    /// Creates a new TrueAudio Next device for GPU-accelerated convolution.
+    /// Creates a new TrueAudio Next device for GPU-accelerated convolution and returns a handle to
+    /// it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/effect/ambisonics/binaural.rs
+++ b/audionimbus/src/effect/ambisonics/binaural.rs
@@ -14,6 +14,11 @@ use crate::{ChannelPointers, ChannelRequirement};
 ///
 /// This results in more immersive spatialization of the ambisonic audio as compared to using an ambisonics binaural effect, at the cost of slightly increased CPU usage.
 ///
+/// `AmbisonicsBinauralEffect` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// ```
@@ -54,7 +59,7 @@ use crate::{ChannelPointers, ChannelRequirement};
 pub struct AmbisonicsBinauralEffect(audionimbus_sys::IPLAmbisonicsBinauralEffect);
 
 impl AmbisonicsBinauralEffect {
-    /// Creates a new ambisonics binaural effect.
+    /// Creates a new ambisonics binaural effect and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/effect/ambisonics/decode.rs
+++ b/audionimbus/src/effect/ambisonics/decode.rs
@@ -14,6 +14,11 @@ use crate::{ChannelPointers, ChannelRequirement};
 ///
 /// This is essentially an ambisonics rotate effect followed by either an ambisonics panning effect or an ambisonics binaural effect.
 ///
+/// `AmbisonicsDecodeEffect` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// ```
@@ -69,7 +74,7 @@ pub struct AmbisonicsDecodeEffect {
 }
 
 impl AmbisonicsDecodeEffect {
-    /// Creates a new ambisonics decode effect.
+    /// Creates a new ambisonics decode effect and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/effect/ambisonics/encode.rs
+++ b/audionimbus/src/effect/ambisonics/encode.rs
@@ -15,6 +15,11 @@ use crate::{ChannelPointers, ChannelRequirement};
 /// Given a point source with some direction relative to the listener, this effect generates an Ambisonic audio buffer that approximates a point source in the given direction.
 /// This allows multiple point sources and ambiences to mixed to a single ambisonics buffer before being spatialized.
 ///
+/// `AmbisonicsEncodeEffect` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// ```
@@ -56,7 +61,7 @@ pub struct AmbisonicsEncodeEffect {
 }
 
 impl AmbisonicsEncodeEffect {
-    /// Creates a new ambisonics encode effect.
+    /// Creates a new ambisonics encode effect and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/effect/ambisonics/panning.rs
+++ b/audionimbus/src/effect/ambisonics/panning.rs
@@ -13,6 +13,11 @@ use crate::{ChannelPointers, ChannelRequirement};
 ///
 /// This involves calculating signals to emit from each speaker so as to approximate the Ambisonic sound field.
 ///
+/// `AmbisonicsPanningEffect` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// ```
@@ -54,7 +59,7 @@ pub struct AmbisonicsPanningEffect {
 }
 
 impl AmbisonicsPanningEffect {
-    /// Creates a new ambisonics panning effect.
+    /// Creates a new ambisonics panning effect and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/effect/ambisonics/rotation.rs
+++ b/audionimbus/src/effect/ambisonics/rotation.rs
@@ -15,6 +15,11 @@ use crate::{ChannelPointers, ChannelRequirement};
 /// The input buffer is assumed to describe a sound field in "world space".
 /// The output buffer is then the same sound field, but expressed relative to the listener’s orientation.
 ///
+/// `AmbisonicsRotationEffect` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// ```
@@ -58,7 +63,7 @@ pub struct AmbisonicsRotationEffect {
 }
 
 impl AmbisonicsRotationEffect {
-    /// Creates a new ambisonics rotation effect.
+    /// Creates a new ambisonics rotation effect and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/effect/audio_effect_state.rs
+++ b/audionimbus/src/effect/audio_effect_state.rs
@@ -10,7 +10,7 @@
 /// 1. Apply the effect normally while audio is playing using `apply()`
 /// 2. When input stops, call `tail()` repeatedly until it returns [`AudioEffectState::TailComplete`]
 /// 3. Optionally check `tail_size()` to know how many samples remain
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum AudioEffectState {
     /// One or more samples of tail remain in the effect’s internal buffers.
     TailRemaining,

--- a/audionimbus/src/effect/binaural.rs
+++ b/audionimbus/src/effect/binaural.rs
@@ -15,6 +15,11 @@ use crate::{ChannelPointers, ChannelRequirement};
 ///
 /// The source audio can be 1- or 2-channel; in either case all input channels are spatialized from the same position.
 ///
+/// `BinauralEffect` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// ```
@@ -52,7 +57,7 @@ use crate::{ChannelPointers, ChannelRequirement};
 pub struct BinauralEffect(audionimbus_sys::IPLBinauralEffect);
 
 impl BinauralEffect {
-    /// Creates a new binaural effect.
+    /// Creates a new binaural effect and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/effect/direct.rs
+++ b/audionimbus/src/effect/direct.rs
@@ -11,6 +11,11 @@ use crate::{ChannelPointers, ChannelRequirement};
 
 /// Filters and attenuates an audio signal based on various properties of the direct path between a point source and the listener.
 ///
+/// `DirectEffect` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// ```
@@ -51,7 +56,7 @@ pub struct DirectEffect {
 }
 
 impl DirectEffect {
-    /// Creates a new direct effect.
+    /// Creates a new direct effect and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/effect/panning.rs
+++ b/audionimbus/src/effect/panning.rs
@@ -12,6 +12,11 @@ use crate::{ChannelPointers, ChannelRequirement};
 
 /// Pans a single-channel point source to a multi-channel speaker layout based on the 3D position of the source relative to the listener.
 ///
+/// `PanningEffect` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// ```
@@ -52,7 +57,7 @@ pub struct PanningEffect {
 }
 
 impl PanningEffect {
-    /// Creates a new panning effect.
+    /// Creates a new panning effect and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/effect/pathing.rs
+++ b/audionimbus/src/effect/pathing.rs
@@ -62,7 +62,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 ///     .with_pathing(PathingSimulationSettings {
 ///         num_visibility_samples: 4,
 ///     });
-/// let mut simulator = Simulator::try_new(&context, &simulation_settings)?;
+/// let mut simulator = Simulator::try_new(&context, simulation_settings)?;
 ///
 /// let mut scene = Scene::try_new(&context)?;
 /// let vertices = vec![
@@ -128,7 +128,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 /// let source_settings = SourceSettings {
 ///     flags: SimulationFlags::PATHING,
 /// };
-/// let mut source = Source::try_new(&simulator, &source_settings)?;
+/// let mut source = Source::try_new(&simulator, source_settings)?;
 /// let simulation_inputs = SimulationInputs::new(CoordinateSystem::default())
 ///     .with_direct(
 ///         DirectSimulationParameters::new()
@@ -147,7 +147,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 ///         baked_data_identifier: None,
 ///     })
 ///     .with_pathing(PathingSimulationParameters {
-///         pathing_probes: &probe_batch,
+///         pathing_probes: probe_batch,
 ///         visibility_radius: 1.0,
 ///         visibility_threshold: 10.0,
 ///         visibility_range: 10.0,

--- a/audionimbus/src/effect/pathing.rs
+++ b/audionimbus/src/effect/pathing.rs
@@ -25,6 +25,11 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 ///
 /// Multiple paths that sound can take as it propagates from the source to the listener are combined into an Ambisonic sound field.
 ///
+/// `PathEffect` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// Applying pathing involves:
@@ -190,7 +195,7 @@ pub struct PathEffect {
 }
 
 impl PathEffect {
-    /// Creates a new path effect.
+    /// Creates a new path effect and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/effect/reflections.rs
+++ b/audionimbus/src/effect/reflections.rs
@@ -185,14 +185,14 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 ///         max_num_sources: 8,
 ///         num_threads: 2,
 ///     });
-/// let mut simulator = Simulator::try_new(&context, &simulation_settings)?;
+/// let mut simulator = Simulator::try_new(&context, simulation_settings)?;
 ///
 /// let scene = Scene::try_new(&context)?;
 /// simulator.set_scene(&scene);
 ///
 /// let mut source = Source::try_new(
 ///     &simulator,
-///     &SourceSettings {
+///     SourceSettings {
 ///         flags: SimulationFlags::REFLECTIONS,
 ///     },
 /// )?;
@@ -271,7 +271,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 ///         max_num_sources: 8,
 ///         num_threads: 2,
 ///     });
-/// let mut simulator = Simulator::try_new(&context, &simulation_settings)?;
+/// let mut simulator = Simulator::try_new(&context, simulation_settings)?;
 ///
 /// let scene = Scene::try_new(&context)?;
 /// simulator.set_scene(&scene);
@@ -279,7 +279,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 /// // Create a reverb source positioned at the listener.
 /// let mut reverb_source = Source::try_new(
 ///     &simulator,
-///     &SourceSettings {
+///     SourceSettings {
 ///         flags: SimulationFlags::REFLECTIONS,
 ///     },
 /// )?;
@@ -1109,7 +1109,7 @@ mod tests {
                             num_threads: 1,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -1118,7 +1118,7 @@ mod tests {
                     flags: SimulationFlags::REFLECTIONS,
                 };
                 let mut source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, &source_settings).unwrap();
+                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1190,7 +1190,7 @@ mod tests {
                             num_threads: 1,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -1199,7 +1199,7 @@ mod tests {
                     flags: SimulationFlags::REFLECTIONS,
                 };
                 let mut source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, &source_settings).unwrap();
+                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1283,7 +1283,7 @@ mod tests {
                             num_threads: 1,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -1292,7 +1292,7 @@ mod tests {
                     flags: SimulationFlags::REFLECTIONS,
                 };
                 let mut source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, &source_settings).unwrap();
+                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1375,7 +1375,7 @@ mod tests {
                             num_threads: 1,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -1384,7 +1384,7 @@ mod tests {
                     flags: SimulationFlags::REFLECTIONS,
                 };
                 let mut source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, &source_settings).unwrap();
+                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1468,7 +1468,7 @@ mod tests {
                             num_threads: 1,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -1477,7 +1477,7 @@ mod tests {
                     flags: SimulationFlags::REFLECTIONS,
                 };
                 let mut source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, &source_settings).unwrap();
+                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1569,7 +1569,7 @@ mod tests {
                             num_threads: 1,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -1578,7 +1578,7 @@ mod tests {
                     flags: SimulationFlags::REFLECTIONS,
                 };
                 let mut source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, &source_settings).unwrap();
+                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1859,7 +1859,7 @@ mod tests {
                             num_threads: 1,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -1868,7 +1868,7 @@ mod tests {
                     flags: SimulationFlags::REFLECTIONS,
                 };
                 let mut source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, &source_settings).unwrap();
+                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1937,7 +1937,7 @@ mod tests {
                             num_threads: 1,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -1946,7 +1946,7 @@ mod tests {
                     flags: SimulationFlags::REFLECTIONS,
                 };
                 let mut source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, &source_settings).unwrap();
+                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -2019,7 +2019,7 @@ mod tests {
                             num_threads: 1,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -2028,7 +2028,7 @@ mod tests {
                     flags: SimulationFlags::REFLECTIONS,
                 };
                 let mut source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, &source_settings).unwrap();
+                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -2097,7 +2097,7 @@ mod tests {
                             num_threads: 1,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -2106,7 +2106,7 @@ mod tests {
                     flags: SimulationFlags::REFLECTIONS,
                 };
                 let mut source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, &source_settings).unwrap();
+                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(

--- a/audionimbus/src/effect/reflections.rs
+++ b/audionimbus/src/effect/reflections.rs
@@ -152,6 +152,11 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 ///
 /// The result is encoded in ambisonics, and can be decoded using an ambisonics decode effect ([`AmbisonicsDecodeEffect`]).
 ///
+/// `ReflectionEffect` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// Applying reflections involves:
@@ -349,7 +354,7 @@ pub struct ReflectionEffect<T: ReflectionEffectType> {
 }
 
 impl<T: ReflectionEffectType> ReflectionEffect<T> {
-    /// Creates a new reflection effect.
+    /// Creates a new reflection effect and returns a handle to it.
     ///
     /// # Errors
     ///
@@ -936,6 +941,11 @@ impl<'a, T: ReflectionEffectType> ReflectionEffectParams<'a, T> {
 /// Mixes the outputs of multiple reflection effects, and generates a single sound field containing all the reflected sound reaching the listener.
 ///
 /// Using this is optional. Depending on the reflection effect algorithm used, a reflection mixer may provide a reduction in CPU usage.
+///
+/// `ReflectionMixer` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct ReflectionMixer<T: ReflectionEffectType> {
     inner: audionimbus_sys::IPLReflectionMixer,
@@ -947,7 +957,7 @@ pub struct ReflectionMixer<T: ReflectionEffectType> {
 }
 
 impl<T: ReflectionEffectType> ReflectionMixer<T> {
-    /// Creates a new reflection mixer.
+    /// Creates a new reflection mixer and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/effect/virtual_surround.rs
+++ b/audionimbus/src/effect/virtual_surround.rs
@@ -19,6 +19,11 @@ use crate::{ChannelPointers, ChannelRequirement, Hrtf};
 /// After the sources are mixed, the mix can be rendered using virtual surround.
 /// This can reduce CPU usage, at the cost of spatialization accuracy.
 ///
+/// `VirtualSurroundEffect` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// ```
@@ -61,7 +66,7 @@ pub struct VirtualSurroundEffect {
 }
 
 impl VirtualSurroundEffect {
-    /// Creates a new virtual surround effect.
+    /// Creates a new virtual surround effect and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/energy_field.rs
+++ b/audionimbus/src/energy_field.rs
@@ -14,11 +14,16 @@ use crate::NUM_BANDS;
 /// For a given frequency band and time bin, we store an Ambisonic representation of the variation of incident energy as a function of direction.
 ///
 /// Energy field data is stored as a 3D array of size #channels * #bands * #bins, in row-major order.
+///
+/// `EnergyField` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct EnergyField(pub(crate) audionimbus_sys::IPLEnergyField);
 
 impl EnergyField {
-    /// Creates a new energy field.
+    /// Creates a new energy field and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/geometry/instanced_mesh.rs
+++ b/audionimbus/src/geometry/instanced_mesh.rs
@@ -85,7 +85,7 @@ impl Clone for InstancedMesh {
 #[derive(Debug, Clone)]
 pub struct InstancedMeshSettings<'a> {
     /// Handle to the scene to be instantiated.
-    pub sub_scene: &'a Scene<'a>,
+    pub sub_scene: &'a Scene,
 
     /// Local-to-world transform that places the instance within the parent scene.
     pub transform: Matrix<f32, 4, 4>,

--- a/audionimbus/src/geometry/instanced_mesh.rs
+++ b/audionimbus/src/geometry/instanced_mesh.rs
@@ -7,11 +7,16 @@ use crate::error::{to_option_error, SteamAudioError};
 /// An instanced mesh is essentially a scene (called the “sub-scene”) with a transform applied to it.
 /// Adding an instanced mesh to a scene places the sub-scene into the scene with the transform applied.
 /// For example, the sub-scene may be a prefab door, and the transform can be used to place it in a doorway and animate it as it opens or closes.
+///
+/// `InstancedMesh` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct InstancedMesh(audionimbus_sys::IPLInstancedMesh);
 
 impl InstancedMesh {
-    /// Creates a new instanced mesh.
+    /// Creates a new instanced mesh and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -26,6 +26,11 @@ impl SaveableAsObj for Embree {}
 /// The scene object itself doesn’t contain any geometry, but is a container for [`StaticMesh`] and [`InstancedMesh`] objects, which do contain geometry.
 ///
 /// [`Scene`] is generic over the [`RayTracer`] implementation.
+///
+/// `Scene` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct Scene<'a, T: RayTracer = DefaultRayTracer> {
     inner: audionimbus_sys::IPLScene,
@@ -66,7 +71,7 @@ impl<T: RayTracer> Default for SceneShared<T> {
 }
 
 impl<T: RayTracer> Scene<'_, T> {
-    /// Creates an empty scene.
+    /// Creates an empty scene and returns a handle to it.
     fn empty() -> Self {
         let shared = SceneShared {
             static_meshes: SlotMap::new(),
@@ -84,7 +89,7 @@ impl<T: RayTracer> Scene<'_, T> {
         }
     }
 
-    /// Creates a scene from FFI settings.
+    /// Creates a scene from FFI settings and returns a handle to it.
     fn from_ffi_create(
         context: &Context,
         settings: &mut audionimbus_sys::IPLSceneSettings,
@@ -104,7 +109,7 @@ impl<T: RayTracer> Scene<'_, T> {
         Ok(scene)
     }
 
-    /// Loads a scene from FFI settings and serialized object.
+    /// Loads a scene from FFI settings and serialized object and returns a handle to it.
     ///
     /// # Errors
     ///
@@ -145,7 +150,7 @@ impl<T: RayTracer> Scene<'_, T> {
 }
 
 impl Scene<'_, DefaultRayTracer> {
-    /// Creates a new scene.
+    /// Creates a new scene and returns a handle to it.
     ///
     /// # Errors
     ///
@@ -154,7 +159,7 @@ impl Scene<'_, DefaultRayTracer> {
         Self::from_ffi_create(context, &mut Self::ffi_settings(), None)
     }
 
-    /// Loads a scene from a serialized object.
+    /// Loads a scene from a serialized object and returns a handle to it.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
     ///
@@ -174,7 +179,7 @@ impl Scene<'_, DefaultRayTracer> {
         )
     }
 
-    /// Loads a scene from a serialized object.
+    /// Loads a scene from a serialized object and returns a handle to it.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
     ///
@@ -211,7 +216,7 @@ impl Scene<'_, DefaultRayTracer> {
 }
 
 impl<'a> Scene<'a, Embree> {
-    /// Creates a new scene with the Embree ray tracer.
+    /// Creates a new scene with the Embree ray tracer and returns a handle to it.
     ///
     /// # Errors
     ///
@@ -223,7 +228,7 @@ impl<'a> Scene<'a, Embree> {
         Self::from_ffi_create(context, &mut Self::ffi_settings(device), None)
     }
 
-    /// Loads a scene from a serialized object using Embree.
+    /// Loads a scene from a serialized object using Embree and returns a handle to it.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
     ///
@@ -262,7 +267,8 @@ impl<'a> Scene<'a, Embree> {
         Ok(scene)
     }
 
-    /// Loads a scene from a serialized object using Embree with a progress callback.
+    /// Loads a scene from a serialized object using Embree with a progress callback, and returns a
+    /// handle to it.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
     ///
@@ -300,7 +306,7 @@ impl<'a> Scene<'a, Embree> {
 }
 
 impl<'a> Scene<'a, RadeonRays> {
-    /// Creates a new scene with the Radeon Rays ray tracer.
+    /// Creates a new scene with the Radeon Rays ray tracer and returns a handle to it.
     ///
     /// # Errors
     ///
@@ -312,7 +318,7 @@ impl<'a> Scene<'a, RadeonRays> {
         Self::from_ffi_create(context, &mut Self::ffi_settings(device), None)
     }
 
-    /// Loads a scene from a serialized object using Radeon Rays.
+    /// Loads a scene from a serialized object using Radeon Rays and returns a handle to it.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
     ///
@@ -333,7 +339,8 @@ impl<'a> Scene<'a, RadeonRays> {
         )
     }
 
-    /// Loads a scene from a serialized object using Radeon Rays with a progerss callback.
+    /// Loads a scene from a serialized object using Radeon Rays with a progress callback, and
+    /// returns a handle to it.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
     ///
@@ -371,7 +378,7 @@ impl<'a> Scene<'a, RadeonRays> {
 }
 
 impl<'a> Scene<'a, CustomRayTracer> {
-    /// Creates a new scene with a custom ray tracer.
+    /// Creates a new scene with a custom ray tracer and returns a handle to it.
     ///
     /// # Errors
     ///
@@ -384,7 +391,7 @@ impl<'a> Scene<'a, CustomRayTracer> {
         Self::from_ffi_create(context, &mut settings, Some(user_data))
     }
 
-    /// Loads a scene from a serialized object using a custom ray tracer.
+    /// Loads a scene from a serialized object using a custom ray tracer and returns a handle to it.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
     ///
@@ -406,7 +413,8 @@ impl<'a> Scene<'a, CustomRayTracer> {
         )
     }
 
-    /// Loads a scene from a serialized object using a custom ray tracer with a progress callback.
+    /// Loads a scene from a serialized object using a custom ray tracer with a progress callback,
+    /// and returns a handle to it.
     ///
     /// Typically, the serialized object will be created from a byte array loaded from disk or over the network.
     ///

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -1,11 +1,13 @@
 use super::{InstancedMesh, Matrix, StaticMesh};
-use crate::callback::{CustomRayTracingCallbacks, CustomRayTracingUserData, ProgressCallback};
+use crate::callback::{CustomRayTracingCallbacks, ProgressCallback};
 use crate::context::Context;
 use crate::device::embree::EmbreeDevice;
 use crate::device::radeon_rays::RadeonRaysDevice;
 use crate::error::{to_option_error, SteamAudioError};
 use crate::geometry::{Direction, Point};
-use crate::ray_tracing::{CustomRayTracer, DefaultRayTracer, Embree, RadeonRays, RayTracer};
+use crate::ray_tracing::{
+    CustomCallbackUserData, CustomRayTracer, DefaultRayTracer, Embree, RadeonRays, RayTracer,
+};
 use crate::serialized_object::SerializedObject;
 use crate::Sealed;
 use slotmap::{DefaultKey, SlotMap};
@@ -53,36 +55,32 @@ struct SceneShared<T: RayTracer> {
     /// Instanced meshes to be dropped by the next call to [`Self::commit`].
     instanced_meshes_to_remove: Vec<InstancedMesh>,
 
-    /// Keeps the Embree device alive for the lifetime of the scene.
-    _embree_device: Option<EmbreeDevice>,
-
-    /// Keeps the Radeon Rays device alive for the lifetime of the scene.
-    _radeon_rays_device: Option<RadeonRaysDevice>,
+    /// Keeps the device alive for the lifetime of the scene.
+    _device: T::Device,
 
     /// Keeps the callback user data alive for custom ray tracers.
-    _callback_user_data: Option<Arc<CustomRayTracingUserData>>,
+    _callback_user_data: T::CallbackUserData,
 }
 
-impl<T: RayTracer> Default for SceneShared<T> {
-    fn default() -> Self {
+impl<T: RayTracer> SceneShared<T> {
+    fn new(device: T::Device, callback_user_data: T::CallbackUserData) -> Self {
         Self {
             static_meshes: SlotMap::new(),
             instanced_meshes: SlotMap::new(),
             static_meshes_to_remove: Vec::new(),
             instanced_meshes_to_remove: Vec::new(),
-            _embree_device: None,
-            _radeon_rays_device: None,
-            _callback_user_data: None,
+            _device: device,
+            _callback_user_data: callback_user_data,
         }
     }
 }
 
 impl<T: RayTracer> Scene<T> {
-    /// Creates an empty scene and returns a handle to it.
-    fn empty() -> Self {
+    /// Creates an empty scene with the specified device and returns a handle to it.
+    fn empty(device: T::Device, callback_user_data: T::CallbackUserData) -> Self {
         Self {
             inner: std::ptr::null_mut(),
-            shared: Arc::new(Mutex::new(SceneShared::default())),
+            shared: Arc::new(Mutex::new(SceneShared::new(device, callback_user_data))),
             _marker: PhantomData,
         }
     }
@@ -91,10 +89,10 @@ impl<T: RayTracer> Scene<T> {
     fn from_ffi_create(
         context: &Context,
         settings: &mut audionimbus_sys::IPLSceneSettings,
-        callback_user_data: Option<Arc<CustomRayTracingUserData>>,
+        callback_user_data: T::CallbackUserData,
+        device: T::Device,
     ) -> Result<Self, SteamAudioError> {
-        let mut scene = Self::empty();
-        scene.shared.lock().unwrap()._callback_user_data = callback_user_data;
+        let mut scene = Self::empty(device, callback_user_data);
 
         let status = unsafe {
             audionimbus_sys::iplSceneCreate(context.raw_ptr(), settings, scene.raw_ptr_mut())
@@ -115,12 +113,12 @@ impl<T: RayTracer> Scene<T> {
     fn from_ffi_load(
         context: &Context,
         settings: &mut audionimbus_sys::IPLSceneSettings,
-        callback_user_data: Option<Arc<CustomRayTracingUserData>>,
+        callback_user_data: T::CallbackUserData,
+        device: T::Device,
         serialized_object: &SerializedObject,
         progress_callback: Option<ProgressCallback>,
     ) -> Result<Self, SteamAudioError> {
-        let mut scene = Self::empty();
-        scene.shared.lock().unwrap()._callback_user_data = callback_user_data;
+        let mut scene = Self::empty(device, callback_user_data);
 
         let (callback_fn, user_data) =
             progress_callback.map_or((None, std::ptr::null_mut()), |callback| {
@@ -154,7 +152,7 @@ impl Scene<DefaultRayTracer> {
     ///
     /// Returns [`SteamAudioError`] if creation fails.
     pub fn try_new(context: &Context) -> Result<Self, SteamAudioError> {
-        Self::from_ffi_create(context, &mut Self::ffi_settings(), None)
+        Self::from_ffi_create(context, &mut Self::ffi_settings(), (), ())
     }
 
     /// Loads a scene from a serialized object and returns a handle to it.
@@ -171,7 +169,8 @@ impl Scene<DefaultRayTracer> {
         Self::from_ffi_load(
             context,
             &mut Self::ffi_settings(),
-            None,
+            (),
+            (),
             serialized_object,
             None,
         )
@@ -192,7 +191,8 @@ impl Scene<DefaultRayTracer> {
         Self::from_ffi_load(
             context,
             &mut Self::ffi_settings(),
-            None,
+            (),
+            (),
             serialized_object,
             Some(progress_callback),
         )
@@ -223,8 +223,7 @@ impl Scene<Embree> {
         context: &Context,
         device: EmbreeDevice,
     ) -> Result<Self, SteamAudioError> {
-        let scene = Self::from_ffi_create(context, &mut Self::ffi_settings(&device), None)?;
-        scene.shared.lock().unwrap()._embree_device = Some(device);
+        let scene = Self::from_ffi_create(context, &mut Self::ffi_settings(&device), (), device)?;
         Ok(scene)
     }
 
@@ -243,11 +242,11 @@ impl Scene<Embree> {
         let scene = Self::from_ffi_load(
             context,
             &mut Self::ffi_settings(&device),
-            None,
+            (),
+            device,
             serialized_object,
             None,
         )?;
-        scene.shared.lock().unwrap()._embree_device = Some(device);
         Ok(scene)
     }
 
@@ -268,11 +267,11 @@ impl Scene<Embree> {
         let scene = Self::from_ffi_load(
             context,
             &mut Self::ffi_settings(&device),
-            None,
+            (),
+            device,
             serialized_object,
             Some(progress_callback),
         )?;
-        scene.shared.lock().unwrap()._embree_device = Some(device);
         Ok(scene)
     }
 
@@ -301,8 +300,7 @@ impl Scene<RadeonRays> {
         context: &Context,
         device: RadeonRaysDevice,
     ) -> Result<Self, SteamAudioError> {
-        let scene = Self::from_ffi_create(context, &mut Self::ffi_settings(&device), None)?;
-        scene.shared.lock().unwrap()._radeon_rays_device = Some(device);
+        let scene = Self::from_ffi_create(context, &mut Self::ffi_settings(&device), (), device)?;
         Ok(scene)
     }
 
@@ -321,11 +319,11 @@ impl Scene<RadeonRays> {
         let scene = Self::from_ffi_load(
             context,
             &mut Self::ffi_settings(&device),
-            None,
+            (),
+            device,
             serialized_object,
             None,
         )?;
-        scene.shared.lock().unwrap()._radeon_rays_device = Some(device);
         Ok(scene)
     }
 
@@ -346,11 +344,11 @@ impl Scene<RadeonRays> {
         let scene = Self::from_ffi_load(
             context,
             &mut Self::ffi_settings(&device),
-            None,
+            (),
+            device,
             serialized_object,
             Some(progress_callback),
         )?;
-        scene.shared.lock().unwrap()._radeon_rays_device = Some(device);
         Ok(scene)
     }
 
@@ -380,7 +378,12 @@ impl Scene<CustomRayTracer> {
         callbacks: CustomRayTracingCallbacks,
     ) -> Result<Self, SteamAudioError> {
         let (mut settings, user_data) = callbacks.as_ffi_settings();
-        Self::from_ffi_create(context, &mut settings, Some(user_data))
+        Self::from_ffi_create(
+            context,
+            &mut settings,
+            CustomCallbackUserData(user_data),
+            (),
+        )
     }
 
     /// Loads a scene from a serialized object using a custom ray tracer and returns a handle to it.
@@ -399,7 +402,8 @@ impl Scene<CustomRayTracer> {
         Self::from_ffi_load(
             context,
             &mut settings,
-            Some(user_data),
+            CustomCallbackUserData(user_data),
+            (),
             serialized_object,
             None,
         )
@@ -423,7 +427,8 @@ impl Scene<CustomRayTracer> {
         Self::from_ffi_load(
             context,
             &mut settings,
-            Some(user_data),
+            CustomCallbackUserData(user_data),
+            (),
             serialized_object,
             Some(progress_callback),
         )

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -32,10 +32,9 @@ impl SaveableAsObj for Embree {}
 /// incrementing a reference count.
 /// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
-pub struct Scene<'a, T: RayTracer = DefaultRayTracer> {
+pub struct Scene<T: RayTracer = DefaultRayTracer> {
     inner: audionimbus_sys::IPLScene,
     shared: Arc<Mutex<SceneShared<T>>>,
-    _ray_tracing_device: PhantomData<&'a ()>,
     _marker: PhantomData<T>,
 }
 
@@ -54,6 +53,12 @@ struct SceneShared<T: RayTracer> {
     /// Instanced meshes to be dropped by the next call to [`Self::commit`].
     instanced_meshes_to_remove: Vec<InstancedMesh>,
 
+    /// Keeps the Embree device alive for the lifetime of the scene.
+    _embree_device: Option<EmbreeDevice>,
+
+    /// Keeps the Radeon Rays device alive for the lifetime of the scene.
+    _radeon_rays_device: Option<RadeonRaysDevice>,
+
     /// Keeps the callback user data alive for custom ray tracers.
     _callback_user_data: Option<Arc<CustomRayTracingUserData>>,
 }
@@ -65,26 +70,19 @@ impl<T: RayTracer> Default for SceneShared<T> {
             instanced_meshes: SlotMap::new(),
             static_meshes_to_remove: Vec::new(),
             instanced_meshes_to_remove: Vec::new(),
+            _embree_device: None,
+            _radeon_rays_device: None,
             _callback_user_data: None,
         }
     }
 }
 
-impl<T: RayTracer> Scene<'_, T> {
+impl<T: RayTracer> Scene<T> {
     /// Creates an empty scene and returns a handle to it.
     fn empty() -> Self {
-        let shared = SceneShared {
-            static_meshes: SlotMap::new(),
-            instanced_meshes: SlotMap::new(),
-            static_meshes_to_remove: Vec::new(),
-            instanced_meshes_to_remove: Vec::new(),
-            _callback_user_data: None,
-        };
-
         Self {
             inner: std::ptr::null_mut(),
-            shared: Arc::new(Mutex::new(shared)),
-            _ray_tracing_device: PhantomData,
+            shared: Arc::new(Mutex::new(SceneShared::default())),
             _marker: PhantomData,
         }
     }
@@ -149,7 +147,7 @@ impl<T: RayTracer> Scene<'_, T> {
     }
 }
 
-impl Scene<'_, DefaultRayTracer> {
+impl Scene<DefaultRayTracer> {
     /// Creates a new scene and returns a handle to it.
     ///
     /// # Errors
@@ -215,7 +213,7 @@ impl Scene<'_, DefaultRayTracer> {
     }
 }
 
-impl<'a> Scene<'a, Embree> {
+impl Scene<Embree> {
     /// Creates a new scene with the Embree ray tracer and returns a handle to it.
     ///
     /// # Errors
@@ -223,9 +221,11 @@ impl<'a> Scene<'a, Embree> {
     /// Returns [`SteamAudioError`] if creation fails.
     pub fn try_with_embree(
         context: &Context,
-        device: &'a EmbreeDevice,
+        device: EmbreeDevice,
     ) -> Result<Self, SteamAudioError> {
-        Self::from_ffi_create(context, &mut Self::ffi_settings(device), None)
+        let scene = Self::from_ffi_create(context, &mut Self::ffi_settings(&device), None)?;
+        scene.shared.lock().unwrap()._embree_device = Some(device);
+        Ok(scene)
     }
 
     /// Loads a scene from a serialized object using Embree and returns a handle to it.
@@ -237,33 +237,17 @@ impl<'a> Scene<'a, Embree> {
     /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_embree(
         context: &Context,
-        device: &'a EmbreeDevice,
+        device: EmbreeDevice,
         serialized_object: &SerializedObject,
     ) -> Result<Self, SteamAudioError> {
-        let mut scene = Self {
-            inner: std::ptr::null_mut(),
-            // Safety: thread safety is upheld by the `unsafe impl Send + Sync` on `Scene`.
-            #[allow(clippy::arc_with_non_send_sync)]
-            shared: Arc::new(Mutex::new(SceneShared::default())),
-            _ray_tracing_device: PhantomData,
-            _marker: PhantomData,
-        };
-
-        let status = unsafe {
-            audionimbus_sys::iplSceneLoad(
-                context.raw_ptr(),
-                &mut Self::ffi_settings(device),
-                serialized_object.raw_ptr(),
-                None,
-                std::ptr::null_mut(),
-                scene.raw_ptr_mut(),
-            )
-        };
-
-        if let Some(error) = to_option_error(status) {
-            return Err(error);
-        }
-
+        let scene = Self::from_ffi_load(
+            context,
+            &mut Self::ffi_settings(&device),
+            None,
+            serialized_object,
+            None,
+        )?;
+        scene.shared.lock().unwrap()._embree_device = Some(device);
         Ok(scene)
     }
 
@@ -277,21 +261,23 @@ impl<'a> Scene<'a, Embree> {
     /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_embree_with_progress(
         context: &Context,
-        device: &'a EmbreeDevice,
+        device: EmbreeDevice,
         serialized_object: &SerializedObject,
         progress_callback: ProgressCallback,
     ) -> Result<Self, SteamAudioError> {
-        Self::from_ffi_load(
+        let scene = Self::from_ffi_load(
             context,
-            &mut Self::ffi_settings(device),
+            &mut Self::ffi_settings(&device),
             None,
             serialized_object,
             Some(progress_callback),
-        )
+        )?;
+        scene.shared.lock().unwrap()._embree_device = Some(device);
+        Ok(scene)
     }
 
     /// Returns FFI scene settings with the Embree ray tracer.
-    fn ffi_settings(device: &'a EmbreeDevice) -> audionimbus_sys::IPLSceneSettings {
+    fn ffi_settings(device: &EmbreeDevice) -> audionimbus_sys::IPLSceneSettings {
         audionimbus_sys::IPLSceneSettings {
             type_: Embree::scene_type(),
             closestHitCallback: None,
@@ -305,7 +291,7 @@ impl<'a> Scene<'a, Embree> {
     }
 }
 
-impl<'a> Scene<'a, RadeonRays> {
+impl Scene<RadeonRays> {
     /// Creates a new scene with the Radeon Rays ray tracer and returns a handle to it.
     ///
     /// # Errors
@@ -313,9 +299,11 @@ impl<'a> Scene<'a, RadeonRays> {
     /// Returns [`SteamAudioError`] if creation fails.
     pub fn try_with_radeon_rays(
         context: &Context,
-        device: &'a RadeonRaysDevice,
+        device: RadeonRaysDevice,
     ) -> Result<Self, SteamAudioError> {
-        Self::from_ffi_create(context, &mut Self::ffi_settings(device), None)
+        let scene = Self::from_ffi_create(context, &mut Self::ffi_settings(&device), None)?;
+        scene.shared.lock().unwrap()._radeon_rays_device = Some(device);
+        Ok(scene)
     }
 
     /// Loads a scene from a serialized object using Radeon Rays and returns a handle to it.
@@ -327,16 +315,18 @@ impl<'a> Scene<'a, RadeonRays> {
     /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_radeon_rays(
         context: &Context,
-        device: &'a RadeonRaysDevice,
+        device: RadeonRaysDevice,
         serialized_object: &SerializedObject,
     ) -> Result<Self, SteamAudioError> {
-        Self::from_ffi_load(
+        let scene = Self::from_ffi_load(
             context,
-            &mut Self::ffi_settings(device),
+            &mut Self::ffi_settings(&device),
             None,
             serialized_object,
             None,
-        )
+        )?;
+        scene.shared.lock().unwrap()._radeon_rays_device = Some(device);
+        Ok(scene)
     }
 
     /// Loads a scene from a serialized object using Radeon Rays with a progress callback, and
@@ -349,21 +339,23 @@ impl<'a> Scene<'a, RadeonRays> {
     /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_radeon_rays_with_progress(
         context: &Context,
-        device: &'a RadeonRaysDevice,
+        device: RadeonRaysDevice,
         serialized_object: &SerializedObject,
         progress_callback: ProgressCallback,
     ) -> Result<Self, SteamAudioError> {
-        Self::from_ffi_load(
+        let scene = Self::from_ffi_load(
             context,
-            &mut Self::ffi_settings(device),
+            &mut Self::ffi_settings(&device),
             None,
             serialized_object,
             Some(progress_callback),
-        )
+        )?;
+        scene.shared.lock().unwrap()._radeon_rays_device = Some(device);
+        Ok(scene)
     }
 
     /// Returns FFI scene settings with the Radeon Rays ray tracer.
-    fn ffi_settings(device: &'a RadeonRaysDevice) -> audionimbus_sys::IPLSceneSettings {
+    fn ffi_settings(device: &RadeonRaysDevice) -> audionimbus_sys::IPLSceneSettings {
         audionimbus_sys::IPLSceneSettings {
             type_: RadeonRays::scene_type(),
             closestHitCallback: None,
@@ -377,7 +369,7 @@ impl<'a> Scene<'a, RadeonRays> {
     }
 }
 
-impl<'a> Scene<'a, CustomRayTracer> {
+impl Scene<CustomRayTracer> {
     /// Creates a new scene with a custom ray tracer and returns a handle to it.
     ///
     /// # Errors
@@ -385,7 +377,7 @@ impl<'a> Scene<'a, CustomRayTracer> {
     /// Returns [`SteamAudioError`] if creation fails.
     pub fn try_with_custom(
         context: &Context,
-        callbacks: &'a CustomRayTracingCallbacks,
+        callbacks: CustomRayTracingCallbacks,
     ) -> Result<Self, SteamAudioError> {
         let (mut settings, user_data) = callbacks.as_ffi_settings();
         Self::from_ffi_create(context, &mut settings, Some(user_data))
@@ -400,7 +392,7 @@ impl<'a> Scene<'a, CustomRayTracer> {
     /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_custom(
         context: &Context,
-        callbacks: &'a CustomRayTracingCallbacks,
+        callbacks: CustomRayTracingCallbacks,
         serialized_object: &SerializedObject,
     ) -> Result<Self, SteamAudioError> {
         let (mut settings, user_data) = callbacks.as_ffi_settings();
@@ -423,7 +415,7 @@ impl<'a> Scene<'a, CustomRayTracer> {
     /// Returns [`SteamAudioError`] if loading fails.
     pub fn load_custom_with_progress(
         context: &Context,
-        callbacks: &'a CustomRayTracingCallbacks,
+        callbacks: CustomRayTracingCallbacks,
         serialized_object: &SerializedObject,
         progress_callback: ProgressCallback,
     ) -> Result<Self, SteamAudioError> {
@@ -438,7 +430,7 @@ impl<'a> Scene<'a, CustomRayTracer> {
     }
 }
 
-impl<T: RayTracer> Scene<'_, T> {
+impl<T: RayTracer> Scene<T> {
     /// Adds a static mesh to a scene and returns a handle to it.
     ///
     /// After calling this function, [`Self::commit`] must be called for the changes to take effect.
@@ -786,7 +778,7 @@ impl<T: RayTracer> Scene<'_, T> {
     }
 }
 
-impl<T: RayTracer + SaveableAsSerialized> Scene<'_, T> {
+impl<T: RayTracer + SaveableAsSerialized> Scene<T> {
     /// Saves a scene to a serialized object.
     ///
     /// Typically, the serialized object will then be saved to disk.
@@ -803,7 +795,7 @@ impl<T: RayTracer + SaveableAsSerialized> Scene<'_, T> {
     }
 }
 
-impl<T: RayTracer + SaveableAsObj> Scene<'_, T> {
+impl<T: RayTracer + SaveableAsObj> Scene<T> {
     /// Saves a scene to an OBJ file.
     ///
     /// An OBJ file is a widely-supported 3D model file format, that can be displayed using a variety of software on most PC platforms.
@@ -820,16 +812,16 @@ impl<T: RayTracer + SaveableAsObj> Scene<'_, T> {
     }
 }
 
-impl<T: RayTracer> Drop for Scene<'_, T> {
+impl<T: RayTracer> Drop for Scene<T> {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplSceneRelease(&raw mut self.inner) }
     }
 }
 
-unsafe impl<T: RayTracer> Send for Scene<'_, T> {}
-unsafe impl<T: RayTracer> Sync for Scene<'_, T> {}
+unsafe impl<T: RayTracer> Send for Scene<T> {}
+unsafe impl<T: RayTracer> Sync for Scene<T> {}
 
-impl<T: RayTracer> Clone for Scene<'_, T> {
+impl<T: RayTracer> Clone for Scene<T> {
     /// Retains an additional reference to the scene.
     ///
     /// The returned [`Scene`] shares the same underlying Steam Audio object.
@@ -838,7 +830,6 @@ impl<T: RayTracer> Clone for Scene<'_, T> {
         Self {
             inner: unsafe { audionimbus_sys::iplSceneRetain(self.inner) },
             shared: Arc::clone(&self.shared),
-            _ray_tracing_device: PhantomData,
             _marker: PhantomData,
         }
     }
@@ -1030,7 +1021,7 @@ mod tests {
             batched_any_hit,
         );
 
-        assert!(Scene::<CustomRayTracer>::try_with_custom(&context, &callbacks).is_ok());
+        assert!(Scene::<CustomRayTracer>::try_with_custom(&context, callbacks).is_ok());
     }
 
     #[test]

--- a/audionimbus/src/geometry/static_mesh.rs
+++ b/audionimbus/src/geometry/static_mesh.rs
@@ -12,6 +12,11 @@ use std::marker::PhantomData;
 ///
 /// [`StaticMesh`] is generic over the [`RayTracer`] implementation used to create the scene it
 /// belongs to.
+///
+/// `StaticMesh` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct StaticMesh<T> {
     inner: audionimbus_sys::IPLStaticMesh,
@@ -19,7 +24,7 @@ pub struct StaticMesh<T> {
 }
 
 impl<T: RayTracer> StaticMesh<T> {
-    /// Creates a new static mesh.
+    /// Creates a new static mesh and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/hrtf.rs
+++ b/audionimbus/src/hrtf.rs
@@ -9,11 +9,16 @@ use std::sync::{Mutex, OnceLock};
 ///
 /// HRTFs describe how sound from different directions is perceived by a each of a listener’s ears, and are a crucial component of spatial audio.
 /// Steam Audio includes a built-in HRTF, while also allowing developers and users to import their own custom HRTFs.
+///
+/// `Hrtf` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Hrtf(pub(crate) audionimbus_sys::IPLHRTF);
 
 impl Hrtf {
-    /// Creates a new Head-Related Transfer Function (HRTF).
+    /// Creates a new Head-Related Transfer Function (HRTF) and returns a handle to it.
     ///
     /// Calling this function is expensive; avoid creating HRTFs in your audio thread at all if possible.
     ///

--- a/audionimbus/src/impulse_response.rs
+++ b/audionimbus/src/impulse_response.rs
@@ -9,11 +9,16 @@ use crate::error::{to_option_error, SteamAudioError};
 /// Impulse responses are represented in Ambisonics to allow for directional variation of propagated sound.
 ///
 /// Impulse response data is stored as a 2D array of size #channels * #samples, in row-major order.
+///
+/// `ImpulseResponse` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct ImpulseResponse(audionimbus_sys::IPLImpulseResponse);
 
 impl ImpulseResponse {
-    /// Creates a new impulse response.
+    /// Creates a new impulse response and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/probe.rs
+++ b/audionimbus/src/probe.rs
@@ -11,11 +11,16 @@ use std::sync::{Arc, Mutex};
 /// An array of sound probes.
 ///
 /// Each probe has a position and a radius of influence.
+///
+/// `ProbeArray` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct ProbeArray(audionimbus_sys::IPLProbeArray);
 
 impl ProbeArray {
-    /// Creates a new probe array.
+    /// Creates a new probe array and returns a handle to it.
     ///
     /// # Errors
     ///
@@ -191,6 +196,11 @@ impl From<ProbeGenerationParams> for audionimbus_sys::IPLProbeGenerationParams {
 ///
 /// The associated data may include reverb, reflections from a static source position, pathing, and more.
 /// This data is loaded and unloaded as a unit, either from disk or over the network.
+///
+/// `ProbeBatch` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct ProbeBatch {
     inner: audionimbus_sys::IPLProbeBatch,
@@ -208,7 +218,7 @@ struct ProbeBatchShared {
 }
 
 impl ProbeBatch {
-    /// Creates a new probe batch.
+    /// Creates a new probe batch and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/ray_tracing.rs
+++ b/audionimbus/src/ray_tracing.rs
@@ -1,6 +1,10 @@
 //! Ray tracing implementations.
 
+use crate::callback::CustomRayTracingUserData;
+use crate::device::{EmbreeDevice, RadeonRaysDevice};
 use crate::Sealed;
+use std::fmt::Debug;
+use std::sync::Arc;
 
 /// Steam Audio’s built-in ray tracer.
 ///
@@ -43,30 +47,55 @@ impl Sealed for CustomRayTracer {}
 /// - [`RadeonRays`]: The AMD Radeon Rays ray tracer
 /// - [`CustomRayTracer`]: Allows you to specify callbacks to your own ray tracer
 pub trait RayTracer: Sealed {
+    type Device: Debug + Send + Sync;
+    type CallbackUserData: Debug + Send + Sync;
+
     /// Returns the FFI scene type for this ray tracer implementation.
     fn scene_type() -> audionimbus_sys::IPLSceneType;
 }
 
 impl RayTracer for DefaultRayTracer {
+    type Device = ();
+    type CallbackUserData = ();
+
     fn scene_type() -> audionimbus_sys::IPLSceneType {
         audionimbus_sys::IPLSceneType::IPL_SCENETYPE_DEFAULT
     }
 }
 
 impl RayTracer for Embree {
+    type Device = EmbreeDevice;
+    type CallbackUserData = ();
+
     fn scene_type() -> audionimbus_sys::IPLSceneType {
         audionimbus_sys::IPLSceneType::IPL_SCENETYPE_EMBREE
     }
 }
 
 impl RayTracer for RadeonRays {
+    type Device = RadeonRaysDevice;
+    type CallbackUserData = ();
+
     fn scene_type() -> audionimbus_sys::IPLSceneType {
         audionimbus_sys::IPLSceneType::IPL_SCENETYPE_RADEONRAYS
     }
 }
 
 impl RayTracer for CustomRayTracer {
+    type Device = ();
+    type CallbackUserData = CustomCallbackUserData;
+
     fn scene_type() -> audionimbus_sys::IPLSceneType {
         audionimbus_sys::IPLSceneType::IPL_SCENETYPE_CUSTOM
     }
 }
+
+/// Callback user data used with a custom ray tracer.
+#[derive(Debug)]
+pub struct CustomCallbackUserData(
+    /// Never read directly.
+    /// Held here so that the underlying data is not freed, since the FFI layer holds a raw pointer
+    /// to it.
+    #[allow(dead_code)]
+    pub(crate) Arc<CustomRayTracingUserData>,
+);

--- a/audionimbus/src/reconstructor.rs
+++ b/audionimbus/src/reconstructor.rs
@@ -8,6 +8,11 @@ use crate::impulse_response::ImpulseResponse;
 /// An object that can convert energy fields to impulse responses.
 ///
 /// Energy fields are typically much smaller in size than impulse responses, and therefore are used when storing baked reflections or reverb in a probe batch, but impulse responses are what is needed at runtime for convolution.
+///
+/// `Reconstructor` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct Reconstructor {
     inner: audionimbus_sys::IPLReconstructor,
@@ -22,7 +27,7 @@ pub struct Reconstructor {
 }
 
 impl Reconstructor {
-    /// Creates a new reconstructor.
+    /// Creates a new reconstructor and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/serialized_object.rs
+++ b/audionimbus/src/serialized_object.rs
@@ -9,11 +9,16 @@ use crate::probe::ProbeBatch;
 /// A serialized representation of an API object, like a [`Scene`] or [`ProbeBatch`].
 ///
 /// Create an empty serialized object if you want to serialize an existing object to a byte array, or create a serialized object that wraps an existing byte array if you want to deserialize it.
+///
+/// `SerializedObject` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct SerializedObject(pub(crate) audionimbus_sys::IPLSerializedObject);
 
 impl SerializedObject {
-    /// Creates a new empty serialized object for serialization purposes.
+    /// Creates a new empty serialized object for serialization purposes and returns a handle to it.
     ///
     /// # Errors
     ///
@@ -36,7 +41,8 @@ impl SerializedObject {
         Self::try_with_settings(context, serialized_object_settings)
     }
 
-    /// Creates a serialized object that wraps an existing byte buffer for deserialization.
+    /// Creates a serialized object that wraps an existing byte buffer for deserialization and
+    /// returns a handle to it.
     ///
     /// # Errors
     ///
@@ -64,7 +70,7 @@ impl SerializedObject {
         Self::try_with_settings(context, serialized_object_settings)
     }
 
-    /// Creates a serialized object with the given settings.
+    /// Creates a serialized object with the given settings and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -83,7 +83,7 @@ pub struct Pathing;
 ///     .with_direct(DirectSimulationSettings {
 ///         max_num_occlusion_samples: 4,
 ///     });
-/// let mut simulator = Simulator::try_new(&context, &settings)?;
+/// let mut simulator = Simulator::try_new(&context, settings)?;
 ///
 /// // Set up a scene.
 /// let scene = Scene::try_new(&context)?;
@@ -97,7 +97,7 @@ pub struct Pathing;
 /// let source_settings = SourceSettings {
 ///     flags: SimulationFlags::DIRECT,
 /// };
-/// let mut source = Source::try_new(&simulator, &source_settings)?;
+/// let mut source = Source::try_new(&simulator, source_settings)?;
 ///
 /// simulator.add_source(&source);
 ///
@@ -119,7 +119,7 @@ pub struct Pathing;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug)]
-pub struct Simulator<'a, T: RayTracer, D = (), R = (), P = ()> {
+pub struct Simulator<T: RayTracer, D = (), R = (), P = ()> {
     inner: audionimbus_sys::IPLSimulator,
     shared: Arc<Mutex<SimulatorShared>>,
 
@@ -141,9 +141,9 @@ pub struct Simulator<'a, T: RayTracer, D = (), R = (), P = ()> {
     /// Synchronization lock for pathing simulation operations.
     pathing_lock: Option<Arc<Mutex<()>>>,
 
-    _open_cl_device: Option<&'a OpenClDevice>,
-    _radeon_rays_device: Option<&'a RadeonRaysDevice>,
-    _true_audio_next_device: Option<&'a TrueAudioNextDevice>,
+    _open_cl_device: Option<OpenClDevice>,
+    _radeon_rays_device: Option<RadeonRaysDevice>,
+    _true_audio_next_device: Option<TrueAudioNextDevice>,
     _ray_tracer: PhantomData<T>,
     _direct: PhantomData<D>,
     _reflections: PhantomData<R>,
@@ -167,7 +167,7 @@ struct SimulatorShared {
     has_pending_scene: bool,
 }
 
-impl<'a, T, D, R, P> Simulator<'a, T, D, R, P>
+impl<T, D, R, P> Simulator<T, D, R, P>
 where
     T: RayTracer,
     D: 'static,
@@ -199,12 +199,12 @@ where
     ///     .with_pathing(PathingSimulationSettings {
     ///         num_visibility_samples: 4,
     ///     });
-    /// let simulator = Simulator::try_new(&context, &settings)?;
+    /// let simulator = Simulator::try_new(&context, settings)?;
     /// # Ok::<(), audionimbus::SteamAudioError>(())
     /// ```
     pub fn try_new(
         context: &Context,
-        settings: &SimulationSettings<'a, T, D, R, P>,
+        settings: SimulationSettings<T, D, R, P>,
     ) -> Result<Self, SteamAudioError> {
         let direct_lock = if std::any::TypeId::of::<D>() == std::any::TypeId::of::<Direct>() {
             Some(Arc::new(Mutex::new(())))
@@ -225,6 +225,8 @@ where
             None
         };
 
+        let mut ffi_settings = settings.to_ffi();
+
         let mut simulator = Self {
             inner: std::ptr::null_mut(),
             // Safety: thread safety is upheld by the `unsafe impl Send + Sync` on `Simulator`.
@@ -236,9 +238,9 @@ where
             direct_lock,
             reflections_lock,
             pathing_lock,
-            _open_cl_device: settings._open_cl_device,
-            _radeon_rays_device: settings._radeon_rays_device,
-            _true_audio_next_device: settings._true_audio_next_device,
+            _open_cl_device: settings.open_cl_device,
+            _radeon_rays_device: settings.radeon_rays_device,
+            _true_audio_next_device: settings.true_audio_next_device,
             _ray_tracer: PhantomData,
             _direct: PhantomData,
             _reflections: PhantomData,
@@ -248,7 +250,7 @@ where
         let status = unsafe {
             audionimbus_sys::iplSimulatorCreate(
                 context.raw_ptr(),
-                &mut settings.to_ffi(),
+                &mut ffi_settings,
                 simulator.raw_ptr_mut(),
             )
         };
@@ -469,7 +471,7 @@ where
     }
 }
 
-impl<T, R, P> Simulator<'_, T, Direct, R, P>
+impl<T, R, P> Simulator<T, Direct, R, P>
 where
     T: RayTracer,
     R: 'static,
@@ -497,7 +499,7 @@ where
     }
 }
 
-impl<T, D, P> Simulator<'_, T, D, Reflections, P>
+impl<T, D, P> Simulator<T, D, Reflections, P>
 where
     T: RayTracer,
     D: 'static,
@@ -538,7 +540,7 @@ where
     }
 }
 
-impl<T, D, R> Simulator<'_, T, D, R, Pathing>
+impl<T, D, R> Simulator<T, D, R, Pathing>
 where
     T: RayTracer,
     D: 'static,
@@ -579,16 +581,16 @@ where
     }
 }
 
-impl<T: RayTracer, D, R, P> Drop for Simulator<'_, T, D, R, P> {
+impl<T: RayTracer, D, R, P> Drop for Simulator<T, D, R, P> {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplSimulatorRelease(&raw mut self.inner) }
     }
 }
 
-unsafe impl<T: RayTracer, D, R, P> Send for Simulator<'_, T, D, R, P> {}
-unsafe impl<T: RayTracer, D, R, P> Sync for Simulator<'_, T, D, R, P> {}
+unsafe impl<T: RayTracer, D, R, P> Send for Simulator<T, D, R, P> {}
+unsafe impl<T: RayTracer, D, R, P> Sync for Simulator<T, D, R, P> {}
 
-impl<'a, T, D, R, P> Clone for Simulator<'a, T, D, R, P>
+impl<T, D, R, P> Clone for Simulator<T, D, R, P>
 where
     T: RayTracer,
     D: 'static,
@@ -609,9 +611,9 @@ where
             direct_lock: self.direct_lock.clone(),
             reflections_lock: self.reflections_lock.clone(),
             pathing_lock: self.pathing_lock.clone(),
-            _open_cl_device: self._open_cl_device,
-            _radeon_rays_device: self._radeon_rays_device,
-            _true_audio_next_device: self._true_audio_next_device,
+            _open_cl_device: self._open_cl_device.clone(),
+            _radeon_rays_device: self._radeon_rays_device.clone(),
+            _true_audio_next_device: self._true_audio_next_device.clone(),
             _ray_tracer: PhantomData,
             _direct: PhantomData,
             _reflections: PhantomData,
@@ -642,20 +644,19 @@ where
 ///     });
 /// # Ok::<(), audionimbus::SteamAudioError>(())
 /// ```
-#[derive(Debug)]
-pub struct SimulationSettings<'a, T: RayTracer, D = (), R = (), P = ()> {
+#[derive(Clone, Debug)]
+pub struct SimulationSettings<T: RayTracer, D = (), R = (), P = ()> {
     settings: audionimbus_sys::IPLSimulationSettings,
-    _open_cl_device: Option<&'a OpenClDevice>,
-    _radeon_rays_device: Option<&'a RadeonRaysDevice>,
-    _true_audio_next_device: Option<&'a TrueAudioNextDevice>,
+    open_cl_device: Option<OpenClDevice>,
+    radeon_rays_device: Option<RadeonRaysDevice>,
+    true_audio_next_device: Option<TrueAudioNextDevice>,
     _ray_tracer: PhantomData<T>,
     _direct: PhantomData<D>,
     _reflections: PhantomData<R>,
     _pathing: PhantomData<P>,
-    _lifetime: PhantomData<&'a ()>,
 }
 
-impl SimulationSettings<'_, DefaultRayTracer, (), (), ()> {
+impl SimulationSettings<DefaultRayTracer, (), (), ()> {
     /// Creates new simulation settings with all simulations disabled by default.
     pub const fn new(sampling_rate: u32, frame_size: u32, max_order: u32) -> Self {
         let settings = audionimbus_sys::IPLSimulationSettings {
@@ -681,40 +682,38 @@ impl SimulationSettings<'_, DefaultRayTracer, (), (), ()> {
 
         Self {
             settings,
-            _open_cl_device: None,
-            _radeon_rays_device: None,
-            _true_audio_next_device: None,
+            open_cl_device: None,
+            radeon_rays_device: None,
+            true_audio_next_device: None,
             _ray_tracer: PhantomData,
             _direct: PhantomData,
             _reflections: PhantomData,
             _pathing: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 }
 
-impl<'a, D, R, P> SimulationSettings<'a, DefaultRayTracer, D, R, P> {
+impl<D, R, P> SimulationSettings<DefaultRayTracer, D, R, P> {
     /// Switches to the Embree ray tracer.
-    pub fn with_embree(self) -> SimulationSettings<'a, Embree, (), (), ()> {
+    pub fn with_embree(self) -> SimulationSettings<Embree, (), (), ()> {
         let Self {
             mut settings,
-            _open_cl_device,
-            _radeon_rays_device,
-            _true_audio_next_device,
+            open_cl_device,
+            radeon_rays_device,
+            true_audio_next_device,
             ..
         } = self;
         settings.sceneType = Embree::scene_type();
 
         SimulationSettings {
             settings,
-            _open_cl_device,
-            _radeon_rays_device,
-            _true_audio_next_device,
+            open_cl_device,
+            radeon_rays_device,
+            true_audio_next_device,
             _ray_tracer: PhantomData,
             _direct: PhantomData,
             _reflections: PhantomData,
             _pathing: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 
@@ -726,12 +725,12 @@ impl<'a, D, R, P> SimulationSettings<'a, DefaultRayTracer, D, R, P> {
     /// - `radeon_rays_device`: The Radeon Rays device to use.
     pub fn with_radeon_rays(
         self,
-        open_cl_device: &'a OpenClDevice,
-        radeon_rays_device: &'a RadeonRaysDevice,
-    ) -> SimulationSettings<'a, RadeonRays, (), (), ()> {
+        open_cl_device: OpenClDevice,
+        radeon_rays_device: RadeonRaysDevice,
+    ) -> SimulationSettings<RadeonRays, (), (), ()> {
         let Self {
             mut settings,
-            _true_audio_next_device,
+            true_audio_next_device,
             ..
         } = self;
         settings.sceneType = RadeonRays::scene_type();
@@ -740,14 +739,13 @@ impl<'a, D, R, P> SimulationSettings<'a, DefaultRayTracer, D, R, P> {
 
         SimulationSettings {
             settings,
-            _open_cl_device: Some(open_cl_device),
-            _radeon_rays_device: Some(radeon_rays_device),
-            _true_audio_next_device,
+            open_cl_device: Some(open_cl_device),
+            radeon_rays_device: Some(radeon_rays_device),
+            true_audio_next_device,
             _ray_tracer: PhantomData,
             _direct: PhantomData,
             _reflections: PhantomData,
             _pathing: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 
@@ -759,12 +757,12 @@ impl<'a, D, R, P> SimulationSettings<'a, DefaultRayTracer, D, R, P> {
     pub fn with_custom_ray_tracer(
         self,
         ray_batch_size: u32,
-    ) -> SimulationSettings<'a, CustomRayTracer, (), (), ()> {
+    ) -> SimulationSettings<CustomRayTracer, (), (), ()> {
         let Self {
             mut settings,
-            _open_cl_device,
-            _radeon_rays_device,
-            _true_audio_next_device,
+            open_cl_device,
+            radeon_rays_device,
+            true_audio_next_device,
             ..
         } = self;
         settings.sceneType = CustomRayTracer::scene_type();
@@ -772,33 +770,31 @@ impl<'a, D, R, P> SimulationSettings<'a, DefaultRayTracer, D, R, P> {
 
         SimulationSettings {
             settings,
-            _open_cl_device,
-            _radeon_rays_device,
-            _true_audio_next_device,
+            open_cl_device,
+            radeon_rays_device,
+            true_audio_next_device,
             _ray_tracer: PhantomData,
             _direct: PhantomData,
             _reflections: PhantomData,
             _pathing: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 }
 
-impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
+impl<T: RayTracer, D, R, P> SimulationSettings<T, D, R, P> {
     /// Enables direct simulation.
     pub fn with_direct(
         self,
         direct_settings: DirectSimulationSettings,
-    ) -> SimulationSettings<'a, T, Direct, R, P> {
+    ) -> SimulationSettings<T, Direct, R, P> {
         let Self {
             mut settings,
-            _open_cl_device,
-            _radeon_rays_device,
-            _true_audio_next_device,
+            open_cl_device,
+            radeon_rays_device,
+            true_audio_next_device,
             _ray_tracer,
             _reflections,
             _pathing,
-            _lifetime,
             ..
         } = self;
 
@@ -807,31 +803,29 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
 
         SimulationSettings {
             settings,
-            _open_cl_device,
-            _radeon_rays_device,
-            _true_audio_next_device,
+            open_cl_device,
+            radeon_rays_device,
+            true_audio_next_device,
             _ray_tracer,
             _direct: PhantomData,
             _reflections,
             _pathing,
-            _lifetime,
         }
     }
 
     /// Enables reflections simulation.
     pub fn with_reflections(
         self,
-        reflections_settings: ReflectionsSimulationSettings<'static>,
-    ) -> SimulationSettings<'a, T, D, Reflections, P> {
+        reflections_settings: ReflectionsSimulationSettings,
+    ) -> SimulationSettings<T, D, Reflections, P> {
         let Self {
             mut settings,
-            mut _open_cl_device,
-            _radeon_rays_device,
-            mut _true_audio_next_device,
+            mut open_cl_device,
+            radeon_rays_device,
+            mut true_audio_next_device,
             _ray_tracer,
             _direct,
             _pathing,
-            _lifetime,
             ..
         } = self;
 
@@ -893,13 +887,13 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
                 max_duration,
                 max_num_sources,
                 num_threads,
-                open_cl_device,
-                true_audio_next_device,
+                open_cl_device: ocl_device,
+                true_audio_next_device: tan_device,
             } => {
-                settings.openCLDevice = open_cl_device.raw_ptr();
-                settings.tanDevice = true_audio_next_device.raw_ptr();
-                _open_cl_device = Some(open_cl_device);
-                _true_audio_next_device = Some(true_audio_next_device);
+                settings.openCLDevice = ocl_device.raw_ptr();
+                settings.tanDevice = tan_device.raw_ptr();
+                open_cl_device = Some(ocl_device);
+                true_audio_next_device = Some(tan_device);
 
                 (
                     audionimbus_sys::IPLReflectionEffectType::IPL_REFLECTIONEFFECTTYPE_TAN,
@@ -921,14 +915,13 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
 
         SimulationSettings {
             settings,
-            _open_cl_device,
-            _radeon_rays_device,
-            _true_audio_next_device,
+            open_cl_device,
+            radeon_rays_device,
+            true_audio_next_device,
             _ray_tracer,
             _direct,
             _reflections: PhantomData,
             _pathing,
-            _lifetime,
         }
     }
 
@@ -936,16 +929,15 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
     pub fn with_pathing(
         self,
         pathing_settings: PathingSimulationSettings,
-    ) -> SimulationSettings<'a, T, D, R, Pathing> {
+    ) -> SimulationSettings<T, D, R, Pathing> {
         let Self {
             mut settings,
-            _open_cl_device,
-            _radeon_rays_device,
-            _true_audio_next_device,
+            open_cl_device,
+            radeon_rays_device,
+            true_audio_next_device,
             _ray_tracer,
             _direct,
             _reflections,
-            _lifetime,
             ..
         } = self;
 
@@ -954,14 +946,13 @@ impl<'a, T: RayTracer, D, R, P> SimulationSettings<'a, T, D, R, P> {
 
         SimulationSettings {
             settings,
-            _open_cl_device,
-            _radeon_rays_device,
-            _true_audio_next_device,
+            open_cl_device,
+            radeon_rays_device,
+            true_audio_next_device,
             _ray_tracer,
             _direct,
             _reflections,
             _pathing: PhantomData,
-            _lifetime,
         }
     }
 
@@ -1016,8 +1007,8 @@ pub struct DirectSimulationSettings {
 }
 
 /// Settings used for reflections simulation.
-#[derive(Debug, Copy, Clone)]
-pub enum ReflectionsSimulationSettings<'a> {
+#[derive(Debug, Clone)]
+pub enum ReflectionsSimulationSettings {
     /// Multi-channel convolution reverb.
     Convolution {
         /// The maximum number of rays to trace from the listener when simulating reflections.
@@ -1110,10 +1101,10 @@ pub enum ReflectionsSimulationSettings<'a> {
         num_threads: u32,
 
         /// The OpenCL device being used.
-        open_cl_device: &'a OpenClDevice,
+        open_cl_device: OpenClDevice,
 
         /// The TrueAudio Next device being used.
-        true_audio_next_device: &'a TrueAudioNextDevice,
+        true_audio_next_device: TrueAudioNextDevice,
     },
 }
 
@@ -1231,6 +1222,10 @@ struct SourceShared {
     /// Stored deviation model to keep `callback` and `user_data` alive.
     /// Only used when pathing simulation is enabled.
     deviation_model: Option<DeviationModel>,
+
+    /// When pathing is enabled, a reference to the probe batch within which to find paths.
+    /// It keeps the probe batch alive as long as the source is alive.
+    _pathing_probes: Option<ProbeBatch>,
 }
 
 impl<D, R, P> Source<D, R, P>
@@ -1245,8 +1240,8 @@ where
     ///
     /// Returns [`SteamAudioError`] if creation fails.
     pub fn try_new<T, SimD, SimR, SimP>(
-        simulator: &Simulator<'_, T, SimD, SimR, SimP>,
-        source_settings: &SourceSettings,
+        simulator: &Simulator<T, SimD, SimR, SimP>,
+        source_settings: SourceSettings,
     ) -> Result<Self, SteamAudioError>
     where
         T: RayTracer,
@@ -1318,7 +1313,7 @@ where
     pub fn set_inputs(
         &mut self,
         simulation_flags: SimulationFlags,
-        inputs: SimulationInputs<'_, D, R, P>,
+        inputs: SimulationInputs<D, R, P>,
     ) -> Result<(), ParameterValidationError> {
         Self::validate_flags(simulation_flags);
 
@@ -1326,9 +1321,11 @@ where
 
         let mut ffi_inputs = inputs.to_ffi();
 
-        if let Some(pathing_params) = inputs.pathing_simulation {
-            self.shared.lock().unwrap().deviation_model = Some(pathing_params.deviation);
-        }
+        let mut shared = self.shared.lock().unwrap();
+        (shared.deviation_model, shared._pathing_probes) = inputs
+            .pathing_simulation
+            .map(|p| (Some(p.deviation), Some(p.pathing_probes)))
+            .unwrap_or_default();
 
         let _guards = self.acquire_locks_for_flags(simulation_flags);
 
@@ -1446,7 +1443,7 @@ where
     /// Validates simulation parameters against the limits set during simulator initialization.
     fn validate_inputs(
         &self,
-        inputs: &SimulationInputs<'_, D, R, P>,
+        inputs: &SimulationInputs<D, R, P>,
     ) -> Result<(), ParameterValidationError> {
         let Some(direct_params) = &inputs.direct_simulation else {
             return Ok(());
@@ -1528,14 +1525,14 @@ where
 }
 
 /// Settings used to create a source.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct SourceSettings {
     /// The types of simulation that may be run for this source.
     pub flags: SimulationFlags,
 }
 
-impl From<&SourceSettings> for audionimbus_sys::IPLSourceSettings {
-    fn from(settings: &SourceSettings) -> Self {
+impl From<SourceSettings> for audionimbus_sys::IPLSourceSettings {
+    fn from(settings: SourceSettings) -> Self {
         Self {
             flags: settings.flags.into(),
         }
@@ -1544,7 +1541,7 @@ impl From<&SourceSettings> for audionimbus_sys::IPLSourceSettings {
 
 /// Simulation parameters for a source.
 #[derive(Clone, Debug)]
-pub struct SimulationInputs<'a, D = (), R = (), P = ()> {
+pub struct SimulationInputs<D = (), R = (), P = ()> {
     /// The position and orientation of this source.
     source: CoordinateSystem,
 
@@ -1555,14 +1552,14 @@ pub struct SimulationInputs<'a, D = (), R = (), P = ()> {
     reflections_simulation: Option<ReflectionsSimulationParameters>,
 
     /// If `Some`, enables pathing simulation.
-    pathing_simulation: Option<PathingSimulationParameters<'a>>,
+    pathing_simulation: Option<PathingSimulationParameters>,
 
     _direct: PhantomData<D>,
     _reflections: PhantomData<R>,
     _pathing: PhantomData<P>,
 }
 
-impl SimulationInputs<'_> {
+impl SimulationInputs {
     /// Crates new [`SimulationInputs`] with all simulations disabled by default.
     pub fn new(source: CoordinateSystem) -> Self {
         Self {
@@ -1577,12 +1574,9 @@ impl SimulationInputs<'_> {
     }
 }
 
-impl<'a, D, R, P> SimulationInputs<'a, D, R, P> {
+impl<D, R, P> SimulationInputs<D, R, P> {
     /// Enables direct simulation with the specified parameters.
-    pub fn with_direct(
-        self,
-        params: DirectSimulationParameters,
-    ) -> SimulationInputs<'a, Direct, R, P> {
+    pub fn with_direct(self, params: DirectSimulationParameters) -> SimulationInputs<Direct, R, P> {
         let Self {
             source,
             reflections_simulation,
@@ -1607,7 +1601,7 @@ impl<'a, D, R, P> SimulationInputs<'a, D, R, P> {
     pub fn with_reflections(
         self,
         params: ReflectionsSimulationParameters,
-    ) -> SimulationInputs<'a, D, Reflections, P> {
+    ) -> SimulationInputs<D, Reflections, P> {
         let Self {
             source,
             direct_simulation,
@@ -1631,8 +1625,8 @@ impl<'a, D, R, P> SimulationInputs<'a, D, R, P> {
     /// Enables pathing simulation with the specified parameters.
     pub fn with_pathing(
         self,
-        params: PathingSimulationParameters<'a>,
-    ) -> SimulationInputs<'a, D, R, Pathing> {
+        params: PathingSimulationParameters,
+    ) -> SimulationInputs<D, R, Pathing> {
         let Self {
             source,
             direct_simulation,
@@ -1835,9 +1829,9 @@ pub enum ReflectionsSimulationParameters {
 
 /// Pathing simulation parameters for a source.
 #[derive(Clone, Debug)]
-pub struct PathingSimulationParameters<'a> {
+pub struct PathingSimulationParameters {
     /// The probe batch within which to find paths from this source to the listener.
-    pub pathing_probes: &'a ProbeBatch,
+    pub pathing_probes: ProbeBatch,
 
     /// When testing for mutual visibility between a pair of probes, each probe is treated as a sphere of this radius (in meters), and point samples are generated within this sphere.
     pub visibility_radius: f32,
@@ -2555,7 +2549,7 @@ mod tests {
                             max_num_occlusion_samples: 4,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -2564,7 +2558,7 @@ mod tests {
                     flags: SimulationFlags::DIRECT | SimulationFlags::REFLECTIONS,
                 };
                 let mut source =
-                    Source::<Direct, (), ()>::try_new(&simulator, &source_settings).unwrap();
+                    Source::<Direct, (), ()>::try_new(&simulator, source_settings).unwrap();
 
                 let simulation_inputs = SimulationInputs::new(CoordinateSystem {
                     right: Vector3::new(1.0, 0.0, 0.0),
@@ -2611,7 +2605,7 @@ mod tests {
                             max_num_occlusion_samples: 4,
                         },
                     );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+                let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
@@ -2619,7 +2613,7 @@ mod tests {
                 let source_settings = SourceSettings {
                     flags: SimulationFlags::DIRECT | SimulationFlags::REFLECTIONS,
                 };
-                let mut source = Source::try_new(&simulator, &source_settings).unwrap();
+                let mut source = Source::try_new(&simulator, source_settings).unwrap();
 
                 let simulation_inputs = SimulationInputs::new(CoordinateSystem {
                     right: Vector3::new(1.0, 0.0, 0.0),
@@ -2656,11 +2650,11 @@ mod tests {
             fn test_clone() {
                 let context = Context::default();
                 let simulator_settings = SimulationSettings::new(48_000, 1024, 1);
-                let simulator = Simulator::try_new(&context, &simulator_settings).unwrap();
+                let simulator = Simulator::try_new(&context, simulator_settings).unwrap();
                 let source_settings = SourceSettings {
                     flags: SimulationFlags::empty(),
                 };
-                let source = Source::<(), (), ()>::try_new(&simulator, &source_settings).unwrap();
+                let source = Source::<(), (), ()>::try_new(&simulator, source_settings).unwrap();
                 let clone = source.clone();
                 assert_eq!(source.raw_ptr(), clone.raw_ptr());
                 drop(source);
@@ -2676,7 +2670,7 @@ mod tests {
         fn test_simulator_clone() {
             let context = Context::default();
             let settings = SimulationSettings::new(48_000, 1024, 1);
-            let simulator = Simulator::try_new(&context, &settings).unwrap();
+            let simulator = Simulator::try_new(&context, settings).unwrap();
             let clone = simulator.clone();
             assert_eq!(simulator.raw_ptr(), clone.raw_ptr());
             drop(simulator);

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -1499,7 +1499,7 @@ impl<D, R, P> Drop for Source<D, R, P> {
 unsafe impl<D, R, P> Send for Source<D, R, P> {}
 unsafe impl<D, R, P> Sync for Source<D, R, P> {}
 
-impl<'a, D, R, P> Clone for Source<D, R, P>
+impl<D, R, P> Clone for Source<D, R, P>
 where
     D: 'static,
     R: 'static,

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -307,7 +307,7 @@ where
     /// Adds a source to the set of sources processed by a simulator in subsequent simulations.
     ///
     /// Call [`Self::commit`] after calling this function for the changes to take effect.
-    pub fn add_source<SrcD, SrcR, SrcP>(&self, source: &Source<'a, SrcD, SrcR, SrcP>)
+    pub fn add_source<SrcD, SrcR, SrcP>(&self, source: &Source<SrcD, SrcR, SrcP>)
     where
         SrcD: DirectCompatible<D> + 'static,
         SrcR: ReflectionsCompatible<R> + 'static,
@@ -321,7 +321,7 @@ where
     /// Removes a source from the set of sources processed by a simulator in subsequent simulations.
     ///
     /// Call [`Self::commit`] after calling this function for the changes to take effect.
-    pub fn remove_source<SrcD, SrcR, SrcP>(&self, source: &Source<'a, SrcD, SrcR, SrcP>)
+    pub fn remove_source<SrcD, SrcR, SrcP>(&self, source: &Source<SrcD, SrcR, SrcP>)
     where
         SrcD: DirectCompatible<D> + 'static,
         SrcR: ReflectionsCompatible<R> + 'static,
@@ -1194,7 +1194,7 @@ impl PathingCompatible<()> for () {}
 ///
 /// This object is used to specify various parameters for direct and indirect sound propagation simulation, and to retrieve the simulation results.
 #[derive(Debug)]
-pub struct Source<'a, D = (), R = (), P = ()> {
+pub struct Source<D = (), R = (), P = ()> {
     inner: audionimbus_sys::IPLSource,
     shared: Arc<Mutex<SourceShared>>,
 
@@ -1216,7 +1216,6 @@ pub struct Source<'a, D = (), R = (), P = ()> {
     _direct: PhantomData<D>,
     _reflections: PhantomData<R>,
     _pathing: PhantomData<P>,
-    _lifetime: PhantomData<&'a ()>,
 }
 
 /// Shared ownership of [`Source`] data across clones.
@@ -1227,7 +1226,7 @@ struct SourceShared {
     deviation_model: Option<DeviationModel>,
 }
 
-impl<'a, D, R, P> Source<'a, D, R, P>
+impl<D, R, P> Source<D, R, P>
 where
     D: 'static,
     R: 'static,
@@ -1239,7 +1238,7 @@ where
     ///
     /// Returns [`SteamAudioError`] if creation fails.
     pub fn try_new<T, SimD, SimR, SimP>(
-        simulator: &Simulator<'a, T, SimD, SimR, SimP>,
+        simulator: &Simulator<'_, T, SimD, SimR, SimP>,
         source_settings: &SourceSettings,
     ) -> Result<Self, SteamAudioError>
     where
@@ -1279,7 +1278,6 @@ where
             _direct: PhantomData,
             _reflections: PhantomData,
             _pathing: PhantomData,
-            _lifetime: PhantomData,
         };
 
         Ok(source)
@@ -1488,16 +1486,16 @@ where
     }
 }
 
-impl<D, R, P> Drop for Source<'_, D, R, P> {
+impl<D, R, P> Drop for Source<D, R, P> {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplSourceRelease(&raw mut self.inner) }
     }
 }
 
-unsafe impl<D, R, P> Send for Source<'_, D, R, P> {}
-unsafe impl<D, R, P> Sync for Source<'_, D, R, P> {}
+unsafe impl<D, R, P> Send for Source<D, R, P> {}
+unsafe impl<D, R, P> Sync for Source<D, R, P> {}
 
-impl<'a, D, R, P> Clone for Source<'a, D, R, P>
+impl<'a, D, R, P> Clone for Source<D, R, P>
 where
     D: 'static,
     R: 'static,
@@ -1518,7 +1516,6 @@ where
             _direct: PhantomData,
             _reflections: PhantomData,
             _pathing: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 }

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -62,6 +62,11 @@ pub struct Pathing;
 /// Your application will typically create one simulator object and use it to run simulations with different source and listener parameters between consecutive simulation runs.
 /// The simulator can also be reused across scene changes.
 ///
+/// `Simulator` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
+///
 /// # Examples
 ///
 /// Basic simulation workflow (shown with direct sound; reflections and pathing follow a similar pattern):
@@ -169,7 +174,7 @@ where
     R: 'static,
     P: 'static,
 {
-    /// Creates a new [`Simulator`].
+    /// Creates a new [`Simulator`] and returns a handle to it.
     ///
     /// # Errors
     ///
@@ -1190,6 +1195,11 @@ impl PathingCompatible<()> for () {}
 /// A sound source, for the purposes of simulation.
 ///
 /// This object is used to specify various parameters for direct and indirect sound propagation simulation, and to retrieve the simulation results.
+///
+/// `Source` is a reference-counted handle to an underlying Steam Audio object.
+/// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
+/// incrementing a reference count.
+/// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
 pub struct Source<D = (), R = (), P = ()> {
     inner: audionimbus_sys::IPLSource,
@@ -1229,7 +1239,7 @@ where
     R: 'static,
     P: 'static,
 {
-    /// Creates a new source.
+    /// Creates a new source and returns a handle to it.
     ///
     /// # Errors
     ///

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -143,7 +143,6 @@ pub struct Simulator<'a, T: RayTracer, D = (), R = (), P = ()> {
     _direct: PhantomData<D>,
     _reflections: PhantomData<R>,
     _pathing: PhantomData<P>,
-    _lifetime: PhantomData<&'a ()>,
 }
 
 /// Shared ownership of [`Simulator`] data across clones.
@@ -239,7 +238,6 @@ where
             _direct: PhantomData,
             _reflections: PhantomData,
             _pathing: PhantomData,
-            _lifetime: PhantomData,
         };
 
         let status = unsafe {
@@ -613,7 +611,6 @@ where
             _direct: PhantomData,
             _reflections: PhantomData,
             _pathing: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 }

--- a/audionimbus/tests/effect.rs
+++ b/audionimbus/tests/effect.rs
@@ -224,7 +224,7 @@ fn test_pathing() {
         .with_pathing(PathingSimulationSettings {
             num_visibility_samples: 4,
         });
-    let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+    let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
     let mut scene = Scene::try_new(&context).unwrap();
     let vertices = vec![
@@ -270,10 +270,10 @@ fn test_pathing() {
         },
     );
 
-    let mut probe_batch = ProbeBatch::try_new(&context).unwrap();
-    probe_batch.add_probe_array(&probe_array);
-    probe_batch.commit();
-    simulator.add_probe_batch(&probe_batch);
+    let mut pathing_probes = ProbeBatch::try_new(&context).unwrap();
+    pathing_probes.add_probe_array(&probe_array);
+    pathing_probes.commit();
+    simulator.add_probe_batch(&pathing_probes);
 
     let path_bake_params = PathBakeParams {
         identifier,
@@ -285,13 +285,13 @@ fn test_pathing() {
         threshold: 0.5,
     };
     PathBaker::new()
-        .bake(&context, &mut probe_batch, &scene, path_bake_params)
+        .bake(&context, &mut pathing_probes, &scene, path_bake_params)
         .unwrap();
 
     let source_settings = SourceSettings {
         flags: SimulationFlags::PATHING,
     };
-    let mut source = Source::try_new(&simulator, &source_settings).unwrap();
+    let mut source = Source::try_new(&simulator, source_settings).unwrap();
     let simulation_inputs = SimulationInputs::new(CoordinateSystem::default())
         .with_direct(
             DirectSimulationParameters::new()
@@ -310,7 +310,7 @@ fn test_pathing() {
             baked_data_identifier: None,
         })
         .with_pathing(PathingSimulationParameters {
-            pathing_probes: &probe_batch,
+            pathing_probes,
             visibility_radius: 1.0,
             visibility_threshold: 10.0,
             visibility_range: 10.0,

--- a/audionimbus/tests/scene.rs
+++ b/audionimbus/tests/scene.rs
@@ -200,7 +200,7 @@ pub fn test_baking() {
         .with_pathing(PathingSimulationSettings {
             num_visibility_samples: 4,
         });
-    let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+    let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
     let scene = Scene::try_new(&context).unwrap();
     simulator.set_scene(&scene);

--- a/audionimbus/tests/simulation.rs
+++ b/audionimbus/tests/simulation.rs
@@ -26,7 +26,7 @@ fn test_simulation() {
         .with_pathing(PathingSimulationSettings {
             num_visibility_samples: 4,
         });
-    let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+    let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
     let scene = Scene::try_new(&context).unwrap();
     simulator.set_scene(&scene);
@@ -34,7 +34,7 @@ fn test_simulation() {
     let source_settings = SourceSettings {
         flags: SimulationFlags::DIRECT | SimulationFlags::REFLECTIONS,
     };
-    let mut source = Source::try_new(&simulator, &source_settings).unwrap();
+    let mut source = Source::try_new(&simulator, source_settings).unwrap();
 
     let pathing_probes = ProbeBatch::try_new(&context).unwrap();
     let simulation_inputs = SimulationInputs::new(CoordinateSystem {
@@ -60,7 +60,7 @@ fn test_simulation() {
         baked_data_identifier: None,
     })
     .with_pathing(PathingSimulationParameters {
-        pathing_probes: &pathing_probes,
+        pathing_probes,
         visibility_radius: 1.0,
         visibility_threshold: 10.0,
         visibility_range: 10.0,
@@ -150,7 +150,7 @@ fn test_pathing_without_probes() {
         .with_pathing(PathingSimulationSettings {
             num_visibility_samples: 4,
         });
-    let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+    let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
     let mut scene = Scene::try_new(&context).unwrap();
     let vertices = vec![
@@ -196,11 +196,11 @@ fn test_pathing_without_probes() {
         },
     );
 
-    let mut probe_batch = ProbeBatch::try_new(&context).unwrap();
+    let mut pathing_probes = ProbeBatch::try_new(&context).unwrap();
     // Add a probe array without commit.
-    probe_batch.add_probe_array(&probe_array);
+    pathing_probes.add_probe_array(&probe_array);
     // Add the probe batch to the simulator without any probes in it.
-    simulator.add_probe_batch(&probe_batch);
+    simulator.add_probe_batch(&pathing_probes);
 
     let path_bake_params = PathBakeParams {
         identifier,
@@ -212,13 +212,13 @@ fn test_pathing_without_probes() {
         threshold: 0.5,
     };
     PathBaker::new()
-        .bake(&context, &mut probe_batch, &scene, path_bake_params)
+        .bake(&context, &mut pathing_probes, &scene, path_bake_params)
         .unwrap();
 
     let source_settings = SourceSettings {
         flags: SimulationFlags::PATHING,
     };
-    let mut source = Source::try_new(&simulator, &source_settings).unwrap();
+    let mut source = Source::try_new(&simulator, source_settings).unwrap();
     let simulation_inputs = SimulationInputs::new(CoordinateSystem::default())
         .with_direct(
             DirectSimulationParameters::new()
@@ -237,7 +237,7 @@ fn test_pathing_without_probes() {
             baked_data_identifier: None,
         })
         .with_pathing(PathingSimulationParameters {
-            pathing_probes: &probe_batch,
+            pathing_probes,
             visibility_radius: 1.0,
             visibility_threshold: 10.0,
             visibility_range: 10.0,
@@ -273,7 +273,7 @@ fn test_reflections_without_scene() {
             max_num_sources: 8,
             num_threads: 2,
         });
-    let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
+    let mut simulator = Simulator::try_new(&context, simulation_settings).unwrap();
 
     let simulation_shared_inputs = SimulationSharedInputs::new(CoordinateSystem::default())
         .with_reflections(ReflectionsSharedInputs {


### PR DESCRIPTION
Steam Audio objects are internally reference-counted via `Retain`/`Release`.
Following the recent addition of `Clone` and `Sync` to all handle types in https://github.com/MaxenceMaire/audionimbus/pull/52, they now behave like `Arc`; cloning is cheap, and the underlying object is kept alive as long as any handle exists.

This means handle types no longer need to be borrowed across other objects' lifetimes; they can simply be owned.
This PR takes advantage of that by removing lifetime parameters throughout.

### Changed

- `Simulator::try_new` now takes `SimulationSettings` by value instead of by reference.
- `Source::try_new` now takes `SourceSettings` by value instead of by reference.
- `Source::set_inputs` now takes `SimulationInputs` by value instead of by reference.
- `SimulationSettings::with_radeon_rays` now takes `OpenClDevice` and `RadeonRaysDevice` by value instead of by reference.
- `PathingSimulationParameters::pathing_probes` is now an owned `ProbeBatch` instead of `&ProbeBatch`.
- `ReflectionsSimulationSettings::TrueAudioNext` now owns its `OpenClDevice` and `TrueAudioNextDevice` fields instead of borrowing them. As a result, `ReflectionsSimulationSettings` no longer implements `Copy`.
- Lifetime parameters have been removed from `Simulator`, `SimulationSettings`, `SimulationInputs`, `PathingSimulationParameters`, and `ReflectionsSimulationSettings`.
- `Scene::try_with_embree`, `Scene::load_embree`, and `Scene::load_embree_with_progress` now take `EmbreeDevice` by value instead of by reference.
- `Scene::try_with_radeon_rays`, `Scene::load_radeon_rays`, and `Scene::load_radeon_rays_with_progress` now take `RadeonRaysDevice` by value instead of by reference.
- `Scene::try_with_custom`, `Scene::load_custom`, and `Scene::load_custom_with_progress` now take `CustomRayTracingCallbacks` by value instead of by reference.
- Lifetime parameters have been removed from `Scene`.

### Added

- Implement `Copy`, `Clone` for `AudioEffectState`.
- Implement `Copy`, `Clone` for `SourceSettings`.