### PR TITLE
Type-safe simulation output retrieval

### DIFF
--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - All callback types (`DistanceAttenuationCallback`, `AirAbsorptionCallback`, `DirectivityCallback`, `DeviationCallback`, `PathingVisualizationCallback`, `ClosestHitCallback`, `AnyHitCallback`, `BatchedClosestHitCallback`, `BatchedAnyHitCallback`) now require `Fn + Send + Sync` instead of `FnMut + Send`. Closures that previously captured mutable state must now use interior mutability (e.g. `Mutex`, `RwLock`) instead.
 - `Source::try_new` now takes `SourceSettings` by value instead of by reference.
+- `Source::set_inputs` now takes `SimulationInputs` by reference instead of by value.
 - `SimulationSettings::with_radeon_rays` now takes `OpenClDevice` and `RadeonRaysDevice` by value instead of by reference.
 - `PathingSimulationParameters::pathing_probes` is now an owned `ProbeBatch` instead of `&ProbeBatch`.
 - `ReflectionsSimulationSettings::TrueAudioNext` now owns its `OpenClDevice` and `TrueAudioNextDevice` fields instead of borrowing them. As a result, `ReflectionsSimulationSettings` no longer implements `Copy`.
@@ -14,10 +15,13 @@
 - `Scene::try_with_radeon_rays`, `Scene::load_radeon_rays`, and `Scene::load_radeon_rays_with_progress` now take `RadeonRaysDevice` by value instead of by reference.
 - `Scene::try_with_custom`, `Scene::load_custom`, and `Scene::load_custom_with_progress` now take `CustomRayTracingCallbacks` by value instead of by reference.
 - Lifetime parameters have been removed from `Scene`.
-- Implement `set_source` method for `Source<D, R, P>` instead of `Source`.
-- Take `&self` instead of `&mut self` in `Source::set_inputs` and `Source::get_outputs`.
+- `SimulationInputs::set_source` is now implemented for `Source<D, R, P>` instead of `Source`.
+- `Source::set_inputs` and `Source::get_outputs` now take `&self` instead of `&mut self`.
 - `ReflectionParams<TrueAudioNext>::new` now takes `device` by value instead of by reference.
-- Methods `direct`, `reflections`, and `pathing` now return their respective effect parameters directly instead of being wrapped inside `FFIWrapper`.
+- Methods `SimulationOutputs::direct`, `SimulationOutputs::reflections`, and `SimulationOutputs::pathing` now return their respective effect parameters directly instead of wrapped in `FFIWrapper`.
+- `Source::get_outputs` no longer takes a `SimulationFlags` argument. Simulation types are now encoded as type parameters, preventing invalid flag combinations at compile time instead of panicking at runtime.
+- `ReflectionEffectParams` no longer has a lifetime parameter. It now bumps the reference count of the associated `Source` to keep the IR pointer valid.
+- `ReflectionEffectParams<Convolution>::new` and `ReflectionEffectParams<Hybrid>::new` are now `unsafe` since the caller must ensure the IR pointer remains valid.
 
 ### Added
 
@@ -28,15 +32,19 @@
 - Implement `Copy`, `Clone` for `SourceSettings`.
 - Add `SimulationInputs::set_source` to update the source position and orientation in place.
 - Add `SimulationInputs::set_direct_simulation_parameters`, `set_reflections_simulation_parameters`, and `set_pathing_simulation_parameters` to update simulation parameters in place without rebuilding the struct.
-- Implement `Copy`, `Clone` for `Direct`, `Reflections` and `Pathing` marker types.
+- Implement `Copy`, `Clone` for `Direct`, `Reflections`, and `Pathing` marker types.
 - Implement `Default` for `Direct`, `Reflections`, `Pathing`.
 - Implement `Default`, `Clone` for `SimulationSharedInputs`.
 - Add methods `set_listener`, `set_reflections_shared_inputs`, and `set_pathing_visualization_callback` for `SimulationSharedInputs`.
+- Add `Source::get_outputs_subset` to retrieve a subset of simulation results, blocking only for the requested simulation types.
+- Add `Source::get_direct_outputs`, `Source::get_reflection_outputs`, and `Source::get_pathing_outputs` as typed convenience methods that return effect parameters directly.
+- Add `SimulationFlagsProvider` trait, implemented for `Direct`, `Reflections`, `Pathing`, and `()`.
 
 ### Removed
 
 - Remove `'static` bounds from `Clone` implementation for `Source`.
 - Remove lifetime from `SimulationOutputs`. `SimulationOutputs` now bumps the reference count of the associated `Source` instead.
+- Remove `Source::get_outputs` runtime panic on invalid flags. Invalid flag combinations are now rejected at compile time via type parameters.
 
 ## [0.13.0] - 2026-03-04
 

--- a/audionimbus/src/effect/pathing.rs
+++ b/audionimbus/src/effect/pathing.rs
@@ -180,8 +180,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 ///     AudioBufferSettings::with_num_channels(NUM_CHANNELS),
 /// )?;
 ///
-/// let simulation_outputs = source.get_outputs(SimulationFlags::PATHING)?;
-/// let path_effect_params = simulation_outputs.pathing();
+/// let path_effect_params = source.get_pathing_outputs()?;
 /// let _ = path_effect.apply(&path_effect_params, &input_buffer, &output_buffer);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```

--- a/audionimbus/src/effect/reflections.rs
+++ b/audionimbus/src/effect/reflections.rs
@@ -222,7 +222,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 /// simulator.commit();
 ///
 /// simulator.run_reflections();
-/// let outputs = source.get_outputs(SimulationFlags::REFLECTIONS)?;
+/// let params = source.get_reflection_outputs()?;
 ///
 /// const NUM_CHANNELS: u32 = num_ambisonics_channels(1); // 1st order ambisonics
 /// let mut effect = ReflectionEffect::<Convolution>::try_new(
@@ -242,7 +242,6 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 ///     AudioBufferSettings::with_num_channels(NUM_CHANNELS),
 /// )?;
 ///
-/// let params = outputs.reflections();
 /// let _ = effect.apply(&params, &input_buffer, &output_buffer);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -315,8 +314,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 ///
 /// // Run simulation.
 /// simulator.run_reflections();
-/// let reverb_outputs = reverb_source.get_outputs(SimulationFlags::REFLECTIONS)?;
-/// let reverb_params = reverb_outputs.reflections();
+/// let reverb_params = reverb_source.get_reflection_outputs()?;
 ///
 /// const NUM_CHANNELS: u32 = num_ambisonics_channels(1); // 1st order ambisonics
 /// let mut reverb_effect = ReflectionEffect::<Convolution>::try_new(
@@ -663,7 +661,7 @@ pub struct ReflectionEffectSettings {
 
 /// Parameters for applying a reflection effect to an audio buffer.
 #[derive(Debug, PartialEq)]
-pub struct ReflectionEffectParams<'a, T: ReflectionEffectType> {
+pub struct ReflectionEffectParams<T: ReflectionEffectType> {
     /// The impulse response.
     impulse_response: ReflectionEffectIR,
 
@@ -697,13 +695,13 @@ pub struct ReflectionEffectParams<'a, T: ReflectionEffectType> {
     /// The slot identifies the IR to use.
     true_audio_next_slot: u32,
 
-    /// Safety marker to tie the `ReflectioEffectIR` pointer to the lifetime.
-    _lifetime: PhantomData<&'a ()>,
+    /// Retained source pointer, keeping the IR pointer valid.
+    _source: audionimbus_sys::IPLSource,
 
     _marker: PhantomData<T>,
 }
 
-impl ReflectionEffectParams<'_, Convolution> {
+impl ReflectionEffectParams<Convolution> {
     /// Constructs multi-channel convolution reverb params.
     ///
     /// # Arguments
@@ -711,7 +709,19 @@ impl ReflectionEffectParams<'_, Convolution> {
     /// - `impulse_response`: the impulse response.
     /// - `num_channels`: number of IR channels to process. May be less than the number of channels specified when creating the effect, in which case CPU usage will be reduced.
     /// - `impulse_response_size`: number of IR samples per channel to process. May be less than the number of samples specified when creating the effect, in which case CPU usage will be reduced.
-    pub fn new(
+    ///
+    /// # Safety
+    ///
+    /// `impulse_response` is a pointer managed internally by Steam Audio.
+    /// The caller must ensure the type that owns this IR remains valid for the lifetime of these
+    /// params.
+    ///
+    /// # Safety
+    ///
+    /// `impulse_response` is a pointer managed internally by Steam Audio.
+    /// The caller must ensure the type that owns this IR remains valid for the lifetime of these
+    /// params.
+    pub unsafe fn new(
         impulse_response: audionimbus_sys::IPLReflectionEffectIR,
         num_channels: u32,
         impulse_response_size: u32,
@@ -727,13 +737,13 @@ impl ReflectionEffectParams<'_, Convolution> {
             max_impulse_response_size: impulse_response_size,
             true_audio_next_device: None,
             true_audio_next_slot: 0,
+            _source: std::ptr::null_mut(),
             _marker: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 }
 
-impl ReflectionEffectParams<'_, Parametric> {
+impl ReflectionEffectParams<Parametric> {
     /// Constructs parametric (or artificial) reverb params.
     ///
     /// # Arguments
@@ -753,13 +763,13 @@ impl ReflectionEffectParams<'_, Parametric> {
             max_impulse_response_size: impulse_response_size,
             true_audio_next_device: None,
             true_audio_next_slot: 0,
+            _source: std::ptr::null_mut(),
             _marker: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 }
 
-impl ReflectionEffectParams<'_, Hybrid> {
+impl ReflectionEffectParams<Hybrid> {
     /// Constructs params for a hybrid of convolution and parametric reverb.
     ///
     /// # Arguments
@@ -770,7 +780,13 @@ impl ReflectionEffectParams<'_, Hybrid> {
     /// - `delay`: samples after which parametric part starts.
     /// - `num_channels`: number of IR channels to process. May be less than the number of channels specified when creating the effect, in which case CPU usage will be reduced.
     /// - `impulse_response_size`: number of IR samples per channel to process. May be less than the number of samples specified when creating the effect, in which case CPU usage will be reduced.
-    pub const fn new(
+    ///
+    /// # Safety
+    ///
+    /// `impulse_response` is a pointer managed internally by Steam Audio.
+    /// The caller must ensure the type that owns this IR remains valid for the lifetime of these
+    /// params.
+    pub const unsafe fn new(
         impulse_response: audionimbus_sys::IPLReflectionEffectIR,
         reverb_times: [f32; 3],
         equalizer: Equalizer<3>,
@@ -789,13 +805,13 @@ impl ReflectionEffectParams<'_, Hybrid> {
             max_impulse_response_size: impulse_response_size,
             true_audio_next_device: None,
             true_audio_next_slot: 0,
+            _source: std::ptr::null_mut(),
             _marker: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 }
 
-impl<'a> ReflectionEffectParams<'a, TrueAudioNext> {
+impl ReflectionEffectParams<TrueAudioNext> {
     /// Constructs multi-channel convolution reverb (using AMD TrueAudio Next for GPU acceleration)
     /// params.
     ///
@@ -822,13 +838,13 @@ impl<'a> ReflectionEffectParams<'a, TrueAudioNext> {
             max_impulse_response_size: impulse_response_size,
             true_audio_next_device: Some(device),
             true_audio_next_slot: slot,
+            _source: std::ptr::null_mut(),
             _marker: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 }
 
-impl<T: ReflectionEffectType> ReflectionEffectParams<'_, T> {
+impl<T: ReflectionEffectType> ReflectionEffectParams<T> {
     /// Sets the number of impulse response channels to process.
     ///
     /// May be less than the number of channels specified when creating the effect.
@@ -882,6 +898,7 @@ impl<T: ReflectionEffectType> ReflectionEffectParams<'_, T> {
     /// The `ir` pointer in `params` must remain valid for the lifetime of the params.
     pub(crate) unsafe fn from_ffi_unchecked(
         params: audionimbus_sys::IPLReflectionEffectParams,
+        source: audionimbus_sys::IPLSource,
     ) -> Self {
         let device = if params.tanDevice.is_null() {
             None
@@ -890,6 +907,8 @@ impl<T: ReflectionEffectType> ReflectionEffectParams<'_, T> {
                 audionimbus_sys::iplTrueAudioNextDeviceRetain(params.tanDevice),
             ))
         };
+
+        let source = audionimbus_sys::iplSourceRetain(source);
 
         let num_channels = params.numChannels as u32;
         let impulse_response_size = params.irSize as u32;
@@ -905,13 +924,21 @@ impl<T: ReflectionEffectType> ReflectionEffectParams<'_, T> {
             max_impulse_response_size: impulse_response_size,
             true_audio_next_device: device,
             true_audio_next_slot: params.tanSlot as u32,
+            _source: source,
             _marker: PhantomData,
-            _lifetime: PhantomData,
         }
     }
 }
 
-unsafe impl<T: ReflectionEffectType> Send for ReflectionEffectParams<'_, T> {}
+unsafe impl<T: ReflectionEffectType> Send for ReflectionEffectParams<T> {}
+
+impl<T: ReflectionEffectType> Drop for ReflectionEffectParams<T> {
+    fn drop(&mut self) {
+        if !self._source.is_null() {
+            unsafe { audionimbus_sys::iplSourceRelease(&mut self._source) };
+        }
+    }
+}
 
 /// The impulse response of [`ReflectionEffectParams`].
 #[derive(Debug, Eq, PartialEq)]
@@ -919,7 +946,7 @@ pub struct ReflectionEffectIR(pub audionimbus_sys::IPLReflectionEffectIR);
 
 unsafe impl Send for ReflectionEffectIR {}
 
-impl<'a, T: ReflectionEffectType> ReflectionEffectParams<'a, T> {
+impl<T: ReflectionEffectType> ReflectionEffectParams<T> {
     pub(crate) fn as_ffi(
         &self,
     ) -> FFIWrapper<'_, audionimbus_sys::IPLReflectionEffectParams, Self> {
@@ -1145,7 +1172,7 @@ mod tests {
                 simulator.commit();
 
                 assert!(simulator.run_reflections().is_ok());
-                let simulation_outputs = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
+                let reflection_effect_params = source.get_reflection_outputs().unwrap();
 
                 let num_output_channels = num_ambisonics_channels(1);
                 let reflection_effect_settings = ReflectionEffectSettings {
@@ -1170,7 +1197,6 @@ mod tests {
                 )
                 .unwrap();
 
-                let reflection_effect_params = simulation_outputs.reflections();
                 assert!(reflection_effect
                     .apply(&reflection_effect_params, &input_buffer, &output_buffer)
                     .is_ok());
@@ -1226,7 +1252,7 @@ mod tests {
                 simulator.commit();
 
                 assert!(simulator.run_reflections().is_ok());
-                let simulation_outputs = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
+                let reflection_effect_params = source.get_reflection_outputs().unwrap();
 
                 let num_output_channels = num_ambisonics_channels(1);
                 let reflection_effect_settings = ReflectionEffectSettings {
@@ -1255,7 +1281,6 @@ mod tests {
                 )
                 .unwrap();
 
-                let reflection_effect_params = simulation_outputs.reflections();
                 assert_eq!(
                     reflection_effect.apply(
                         &reflection_effect_params,
@@ -1319,7 +1344,7 @@ mod tests {
                 simulator.commit();
 
                 assert!(simulator.run_reflections().is_ok());
-                let simulation_outputs = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
+                let reflection_effect_params = source.get_reflection_outputs().unwrap();
 
                 let num_output_channels = num_ambisonics_channels(1);
                 let reflection_effect_settings = ReflectionEffectSettings {
@@ -1343,7 +1368,6 @@ mod tests {
                 )
                 .unwrap();
 
-                let reflection_effect_params = simulation_outputs.reflections();
                 assert_eq!(
                     reflection_effect.apply(
                         &reflection_effect_params,
@@ -1411,7 +1435,7 @@ mod tests {
                 simulator.commit();
 
                 assert!(simulator.run_reflections().is_ok());
-                let simulation_outputs = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
+                let reflection_effect_params = source.get_reflection_outputs().unwrap();
 
                 let num_output_channels = num_ambisonics_channels(1);
                 let reflection_effect_settings = ReflectionEffectSettings {
@@ -1443,7 +1467,6 @@ mod tests {
                 )
                 .unwrap();
 
-                let reflection_effect_params = simulation_outputs.reflections();
                 assert!(reflection_effect
                     .apply_into_mixer(
                         &reflection_effect_params,
@@ -1504,7 +1527,7 @@ mod tests {
                 simulator.commit();
 
                 assert!(simulator.run_reflections().is_ok());
-                let simulation_outputs = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
+                let reflection_effect_params = source.get_reflection_outputs().unwrap();
 
                 let num_output_channels = num_ambisonics_channels(1);
                 let reflection_effect_settings = ReflectionEffectSettings {
@@ -1540,7 +1563,6 @@ mod tests {
                 )
                 .unwrap();
 
-                let reflection_effect_params = simulation_outputs.reflections();
                 assert_eq!(
                     reflection_effect.apply_into_mixer(
                         &reflection_effect_params,
@@ -1605,7 +1627,7 @@ mod tests {
                 simulator.commit();
 
                 assert!(simulator.run_reflections().is_ok());
-                let simulation_outputs = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
+                let reflection_effect_params = source.get_reflection_outputs().unwrap();
 
                 let num_output_channels = num_ambisonics_channels(1);
                 let reflection_effect_settings = ReflectionEffectSettings {
@@ -1636,7 +1658,6 @@ mod tests {
                 )
                 .unwrap();
 
-                let reflection_effect_params = simulation_outputs.reflections();
                 assert_eq!(
                     reflection_effect.apply_into_mixer(
                         &reflection_effect_params,
@@ -1895,7 +1916,7 @@ mod tests {
                 simulator.commit();
 
                 assert!(simulator.run_reflections().is_ok());
-                let simulation_outputs = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
+                let mut reflection_effect_params = source.get_reflection_outputs().unwrap();
 
                 let num_output_channels = num_ambisonics_channels(1);
                 let reflection_effect_settings = ReflectionEffectSettings {
@@ -1917,7 +1938,6 @@ mod tests {
                 )
                 .unwrap();
 
-                let mut reflection_effect_params = simulation_outputs.reflections();
                 assert!(mixer
                     .apply(&mut reflection_effect_params, &output_buffer)
                     .is_ok());
@@ -1973,7 +1993,7 @@ mod tests {
                 simulator.commit();
 
                 assert!(simulator.run_reflections().is_ok());
-                let simulation_outputs = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
+                let mut reflection_effect_params = source.get_reflection_outputs().unwrap();
 
                 let num_output_channels = num_ambisonics_channels(1);
                 let reflection_effect_settings = ReflectionEffectSettings {
@@ -1995,7 +2015,6 @@ mod tests {
                 )
                 .unwrap();
 
-                let mut reflection_effect_params = simulation_outputs.reflections();
                 assert_eq!(
                     mixer.apply(&mut reflection_effect_params, &output_buffer),
                     Err(EffectError::InvalidOutputChannels {
@@ -2055,7 +2074,7 @@ mod tests {
                 simulator.commit();
 
                 assert!(simulator.run_reflections().is_ok());
-                let simulation_outputs = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
+                let mut reflection_effect_params = source.get_reflection_outputs().unwrap();
 
                 let num_output_channels = num_ambisonics_channels(1);
                 let reflection_effect_settings = ReflectionEffectSettings {
@@ -2077,7 +2096,6 @@ mod tests {
                 )
                 .unwrap();
 
-                let mut reflection_effect_params = simulation_outputs.reflections();
                 assert!(mixer
                     .apply(&mut reflection_effect_params, &output_buffer)
                     .is_ok());
@@ -2133,7 +2151,7 @@ mod tests {
                 simulator.commit();
 
                 assert!(simulator.run_reflections().is_ok());
-                let simulation_outputs = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
+                let mut reflection_effect_params = source.get_reflection_outputs().unwrap();
 
                 let num_output_channels = num_ambisonics_channels(1);
                 let reflection_effect_settings = ReflectionEffectSettings {
@@ -2152,7 +2170,6 @@ mod tests {
                 let mut output_container = vec![0.0; FRAME_SIZE as usize];
                 let output_buffer = AudioBuffer::try_with_data(&mut output_container).unwrap();
 
-                let mut reflection_effect_params = simulation_outputs.reflections();
                 assert!(mixer
                     .apply(&mut reflection_effect_params, &output_buffer)
                     .is_ok());

--- a/audionimbus/src/ffi_wrapper.rs
+++ b/audionimbus/src/ffi_wrapper.rs
@@ -13,11 +13,6 @@ impl<T, Owner> FFIWrapper<'_, T, Owner> {
             _marker: std::marker::PhantomData,
         }
     }
-
-    /// Consumes the wrapper and returns the inner FFI object.
-    pub fn into_inner(self) -> T {
-        self.ffi_object
-    }
 }
 
 impl<T, Owner> std::ops::Deref for FFIWrapper<'_, T, Owner> {

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -19,7 +19,7 @@
 //!
 //! ## Important Rules
 //!
-//! - Never call [`Source::get_outputs`] from an audio thread - it will block and cause audio glitches
+//! - Never call [`Source::get_outputs`] or [`Source::get_outputs_subset`] from an audio thread as it will block and cause audio glitches
 //! - Use lock-free communication to pass results from simulation to audio threads
 //! - Different simulation types can run in parallel
 
@@ -55,6 +55,36 @@ pub struct Reflections;
 /// Marker type indicating that pathing simulation is enabled.
 #[derive(Default, Copy, Clone, Debug)]
 pub struct Pathing;
+
+/// Provider of [`SimulationFlags`].
+pub trait SimulationFlagsProvider {
+    /// Returns the simulation flags associated with this type.
+    fn flags() -> SimulationFlags;
+}
+
+impl SimulationFlagsProvider for Direct {
+    fn flags() -> SimulationFlags {
+        SimulationFlags::DIRECT
+    }
+}
+
+impl SimulationFlagsProvider for Reflections {
+    fn flags() -> SimulationFlags {
+        SimulationFlags::REFLECTIONS
+    }
+}
+
+impl SimulationFlagsProvider for Pathing {
+    fn flags() -> SimulationFlags {
+        SimulationFlags::PATHING
+    }
+}
+
+impl SimulationFlagsProvider for () {
+    fn flags() -> SimulationFlags {
+        SimulationFlags::empty()
+    }
+}
 
 /// Manages direct and indirect sound propagation simulation for multiple sources.
 ///
@@ -114,7 +144,7 @@ pub struct Pathing;
 /// simulator.run_direct();
 ///
 /// // Get results.
-/// let outputs = source.get_outputs(SimulationFlags::DIRECT)?;
+/// let outputs = source.get_outputs()?;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug)]
@@ -1342,41 +1372,57 @@ where
 
     /// Retrieves simulation results for a source.
     ///
-    /// # ⚠️ Critical Threading Considerations
+    /// Convenience method abstracting the more expressive [`Self::get_outputs_subset`].
     ///
-    /// This method MUST NOT be called from a real-time audio thread!
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
     ///
-    /// This method will block while a simulation is running for the specified type(s).
-    /// Since simulations can take 50-500ms to complete, calling this from an audio thread
-    /// will likely cause audio dropouts, glitches, and severe performance problems.
-    ///
-    /// Recommended multi-threading pattern:
-    /// - Simulation thread: run simulation, then call `get_outputs()` to retrieve results
-    /// - Communication layer: send results to audio thread via non-blocking mechanism (e.g.,
-    ///   triple buffering or lock-free queue)
-    /// - Audio thread: receive results and apply effects
-    ///
-    /// # Arguments
-    ///
-    /// - `flags`: the types of simulation for which to retrieve results.
+    /// Also see:
+    /// - [`Self::get_direct_outputs`]
+    /// - [`Self::get_reflection_outputs`]
+    /// - [`Self::get_pathing_outputs`]
     ///
     /// # Errors
     ///
     /// Returns a [`SteamAudioError`] on failure to allocate sufficient memory for the
     /// [`SimulationOutputs`].
+    pub fn get_outputs(&self) -> Result<SimulationOutputs<D, R, P>, SteamAudioError>
+    where
+        D: DirectCompatible<D> + SimulationFlagsProvider,
+        R: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        P: PathingCompatible<P> + SimulationFlagsProvider,
+    {
+        self.get_outputs_subset::<D, R, P>()
+    }
+
+    /// Retrieves parts or all of the simulation results for a source.
     ///
-    /// # Panics
+    /// Only blocks for the requested simulation types, allowing concurrent retrieval across
+    /// simulation threads.
     ///
-    /// Panics if some of the `simulation_flags` are disabled on this [`Source`].
-    pub fn get_outputs(
+    /// For example, `get_outputs_subset::<Direct, (), ()>()` and
+    /// `get_outputs_subset::<(), Reflections, ()>()` can be called simultaneously without blocking
+    /// each other.
+    ///
+    /// MUST NOT be called from a real-time audio thread.
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SteamAudioError`] on failure to allocate sufficient memory for the
+    /// [`SimulationOutputs`].
+    pub fn get_outputs_subset<OutD, OutR, OutP>(
         &self,
-        simulation_flags: SimulationFlags,
-    ) -> Result<SimulationOutputs<D, R, P>, SteamAudioError> {
-        Self::validate_flags(simulation_flags);
+    ) -> Result<SimulationOutputs<OutD, OutR, OutP>, SteamAudioError>
+    where
+        OutD: DirectCompatible<D> + SimulationFlagsProvider,
+        OutR: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        OutP: PathingCompatible<P> + SimulationFlagsProvider,
+    {
+        let simulation_flags = OutD::flags() | OutR::flags() | OutP::flags();
 
         let _guards = self.acquire_locks_for_flags(simulation_flags);
 
-        let simulation_outputs = SimulationOutputs::try_allocate(self.clone())?;
+        let simulation_outputs = SimulationOutputs::try_allocate(self)?;
 
         unsafe {
             audionimbus_sys::iplSourceGetOutputs(
@@ -1487,6 +1533,75 @@ where
     /// This is intended for internal use and advanced scenarios.
     pub const fn raw_ptr_mut(&mut self) -> &mut audionimbus_sys::IPLSource {
         &mut self.inner
+    }
+}
+
+impl<R, P> Source<Direct, R, P>
+where
+    R: 'static,
+    P: 'static,
+    (): ReflectionsCompatible<R>,
+    (): PathingCompatible<P>,
+{
+    /// Retrieves direct simulation results for a source.
+    ///
+    /// Convenience method abstracting the more expressive [`Self::get_outputs_subset`].
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SteamAudioError`] on failure to allocate sufficient memory for the
+    /// [`SimulationOutputs`].
+    pub fn get_direct_outputs(&self) -> Result<DirectEffectParams, SteamAudioError> {
+        self.get_outputs_subset::<Direct, (), ()>()
+            .map(|outputs| outputs.direct())
+    }
+}
+
+impl<D, P> Source<D, Reflections, P>
+where
+    D: 'static,
+    P: 'static,
+    (): DirectCompatible<D>,
+    (): PathingCompatible<P>,
+{
+    /// Retrieves reflections simulation results for a source.
+    ///
+    /// Convenience method abstracting the more expressive [`Self::get_outputs_subset`].
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SteamAudioError`] on failure to allocate sufficient memory for the
+    /// [`SimulationOutputs`].
+    pub fn get_reflection_outputs<T>(&self) -> Result<ReflectionEffectParams<T>, SteamAudioError>
+    where
+        T: ReflectionEffectType,
+    {
+        self.get_outputs_subset::<(), Reflections, ()>()
+            .map(|outputs| outputs.reflections())
+    }
+}
+
+impl<D, R> Source<D, R, Pathing>
+where
+    D: 'static,
+    R: 'static,
+    (): DirectCompatible<D>,
+    (): ReflectionsCompatible<R>,
+{
+    /// Retrieves pathing simulation results for a source.
+    ///
+    /// Convenience method abstracting the more expressive [`Self::get_outputs_subset`].
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SteamAudioError`] on failure to allocate sufficient memory for the
+    /// [`SimulationOutputs`].
+    pub fn get_pathing_outputs(&self) -> Result<PathEffectParams, SteamAudioError> {
+        self.get_outputs_subset::<(), (), Pathing>()
+            .map(|outputs| outputs.pathing())
     }
 }
 
@@ -2408,8 +2523,9 @@ pub struct ReflectionsSharedInputs {
 pub struct SimulationOutputs<D, R, P> {
     inner: *mut audionimbus_sys::IPLSimulationOutputs,
 
-    /// Holds a reference to the [`Source`] [`SimulationOutputs`] originated from.
-    _source: Source<D, R, P>,
+    /// Retained pointer of the [`Source`] it originated from, to ensure the IR pointer remains
+    /// valid.
+    _source: audionimbus_sys::IPLSource,
 
     _direct: PhantomData<D>,
     _reflections: PhantomData<R>,
@@ -2417,7 +2533,17 @@ pub struct SimulationOutputs<D, R, P> {
 }
 
 impl<D, R, P> SimulationOutputs<D, R, P> {
-    fn try_allocate(source: Source<D, R, P>) -> Result<Self, SteamAudioError> {
+    fn try_allocate<SourceD, SourceR, SourceP>(
+        source: &Source<SourceD, SourceR, SourceP>,
+    ) -> Result<Self, SteamAudioError>
+    where
+        D: DirectCompatible<SourceD>,
+        R: ReflectionsCompatible<SourceR>,
+        P: PathingCompatible<SourceP>,
+        SourceD: 'static,
+        SourceR: 'static,
+        SourceP: 'static,
+    {
         let ptr = unsafe {
             let layout = std::alloc::Layout::new::<audionimbus_sys::IPLSimulationOutputs>();
             let ptr = std::alloc::alloc(layout).cast::<audionimbus_sys::IPLSimulationOutputs>();
@@ -2427,6 +2553,8 @@ impl<D, R, P> SimulationOutputs<D, R, P> {
             std::ptr::write(ptr, std::mem::zeroed());
             ptr
         };
+
+        let source = unsafe { audionimbus_sys::iplSourceRetain(source.raw_ptr()) };
 
         Ok(Self {
             inner: ptr,
@@ -2453,8 +2581,10 @@ impl<R, P> SimulationOutputs<Direct, R, P> {
 }
 
 impl<D, P> SimulationOutputs<D, Reflections, P> {
-    pub fn reflections<T: ReflectionEffectType>(&self) -> ReflectionEffectParams<'_, T> {
-        unsafe { ReflectionEffectParams::from_ffi_unchecked((*self.inner).reflections) }
+    pub fn reflections<T: ReflectionEffectType>(&self) -> ReflectionEffectParams<T> {
+        unsafe {
+            ReflectionEffectParams::from_ffi_unchecked((*self.inner).reflections, self._source)
+        }
     }
 }
 
@@ -2471,6 +2601,8 @@ impl<D, R, P> Drop for SimulationOutputs<D, R, P> {
         unsafe {
             let layout = std::alloc::Layout::new::<audionimbus_sys::IPLSimulationOutputs>();
             std::alloc::dealloc(self.inner.cast::<u8>(), layout);
+
+            audionimbus_sys::iplSourceRelease(&mut self._source);
         }
     }
 }
@@ -2626,64 +2758,6 @@ mod tests {
                 source
                     .set_inputs(SimulationFlags::REFLECTIONS, &simulation_inputs)
                     .unwrap();
-            }
-        }
-
-        mod get_outputs {
-            use super::*;
-
-            #[test]
-            #[should_panic(
-                expected = "requested simulation flags SimulationFlags(REFLECTIONS) are not enabled on this source (valid flags: SimulationFlags(DIRECT))"
-            )]
-            fn panic_on_invalid_flags() {
-                let context = Context::default();
-
-                const SAMPLING_RATE: u32 = 48_000;
-                const FRAME_SIZE: u32 = 1024;
-                const MAX_ORDER: u32 = 1;
-
-                let simulation_settings =
-                    SimulationSettings::new(SAMPLING_RATE, FRAME_SIZE, MAX_ORDER).with_direct(
-                        DirectSimulationSettings {
-                            max_num_occlusion_samples: 4,
-                        },
-                    );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
-
-                let scene = Scene::try_new(&context).unwrap();
-                simulator.set_scene(&scene);
-
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::DIRECT | SimulationFlags::REFLECTIONS,
-                };
-                let source = Source::try_new(&simulator, source_settings).unwrap();
-
-                let simulation_inputs = SimulationInputs::new(CoordinateSystem {
-                    right: Vector3::new(1.0, 0.0, 0.0),
-                    up: Vector3::new(0.0, 1.0, 0.0),
-                    ahead: Vector3::new(0.0, 0.0, 1.0),
-                    origin: Vector3::new(0.0, 0.0, 0.0),
-                })
-                .with_direct(
-                    DirectSimulationParameters::new()
-                        .with_distance_attenuation(DistanceAttenuationModel::default())
-                        .with_air_absorption(AirAbsorptionModel::default())
-                        .with_directivity(Directivity::default())
-                        .with_occlusion(
-                            Occlusion::new(OcclusionAlgorithm::Raycast).with_transmission(
-                                TransmissionParameters {
-                                    num_transmission_rays: 1,
-                                },
-                            ),
-                        ),
-                );
-                source
-                    .set_inputs(SimulationFlags::DIRECT, &simulation_inputs)
-                    .unwrap();
-
-                simulator.run_direct();
-                let _ = source.get_outputs(SimulationFlags::REFLECTIONS).unwrap();
             }
         }
 

--- a/audionimbus/tests/effect.rs
+++ b/audionimbus/tests/effect.rs
@@ -346,7 +346,6 @@ fn test_pathing() {
     )
     .unwrap();
 
-    let simulation_outputs = source.get_outputs(SimulationFlags::PATHING).unwrap();
-    let path_effect_params = simulation_outputs.pathing();
+    let path_effect_params = source.get_pathing_outputs().unwrap();
     let _ = path_effect.apply(&path_effect_params, &input_buffer, &output_buffer);
 }

--- a/audionimbus/tests/simulation.rs
+++ b/audionimbus/tests/simulation.rs
@@ -95,7 +95,7 @@ fn test_simulation() {
     simulator.run_direct();
     assert!(simulator.run_reflections().is_ok());
     let simulation_outputs = source
-        .get_outputs(SimulationFlags::DIRECT | SimulationFlags::REFLECTIONS)
+        .get_outputs_subset::<Direct, Reflections, ()>()
         .unwrap();
 
     let reflection_effect_settings = ReflectionEffectSettings {


### PR DESCRIPTION
`Source::get_outputs` previously took `SimulationFlags` at runtime and panicked when requesting flags not enabled on the source. The flags are now encoded in the source's type parameters, so invalid combinations are rejected at compile time.

`get_outputs` is now a thin wrapper around the new `get_outputs_subset<D, R, P>`, which only acquires locks for the requested simulation types.

Three convenience methods skip the intermediate `SimulationOutputs` entirely:
- `Source<Direct, R, P>::get_direct_outputs() -> DirectEffectParams`
- `Source<D, Reflections, P>::get_reflection_outputs<T>() -> ReflectionEffectParams<T>`
- `Source<D, R, Pathing>::get_pathing_outputs() -> PathEffectParams`

The lifetime is also removed from `ReflectionEffectParams`. Like `SimulationOutputs`, it now retains the source pointer directly and releases it on drop.