### PR TITLE
Encode simulation flags in type parameters for Simulator and Source inputs

### DIFF
--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -40,7 +40,7 @@
 - Add `Source::get_direct_outputs`, `Source::get_reflection_outputs`, and `Source::get_pathing_outputs` as typed convenience methods that return effect parameters directly.
 - Add `Source::set_inputs_subset` to set a subset of simulation inputs, blocking only for the requested simulation types.
 - Add `Source::set_direct_inputs`, `Source::set_reflections_inputs`, and `Source::set_pathing_inputs` as typed convenience methods.
-- Add `Source::try_new_limited` to create a source that runs a subset of the simulations supported by its simulator.
+- Add `Source::try_new_subset` to create a source that runs a subset of the simulations supported by its simulator.
 - Add `SimulationFlagsProvider` trait, implemented for `Direct`, `Reflections`, `Pathing`, and `()`.
 
 ### Removed

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - All callback types (`DistanceAttenuationCallback`, `AirAbsorptionCallback`, `DirectivityCallback`, `DeviationCallback`, `PathingVisualizationCallback`, `ClosestHitCallback`, `AnyHitCallback`, `BatchedClosestHitCallback`, `BatchedAnyHitCallback`) now require `Fn + Send + Sync` instead of `FnMut + Send`. Closures that previously captured mutable state must now use interior mutability (e.g. `Mutex`, `RwLock`) instead.
-- `Source::try_new` now takes `SourceSettings` by value instead of by reference.
+- `Source::try_new` no longer takes `SourceSettings`. The simulation flags are now derived from the source's type parameters.
 - `Source::set_inputs` now takes `SimulationInputs` by reference instead of by value.
 - `SimulationSettings::with_radeon_rays` now takes `OpenClDevice` and `RadeonRaysDevice` by value instead of by reference.
 - `PathingSimulationParameters::pathing_probes` is now an owned `ProbeBatch` instead of `&ProbeBatch`.
@@ -20,6 +20,7 @@
 - `ReflectionParams<TrueAudioNext>::new` now takes `device` by value instead of by reference.
 - Methods `SimulationOutputs::direct`, `SimulationOutputs::reflections`, and `SimulationOutputs::pathing` now return their respective effect parameters directly instead of wrapped in `FFIWrapper`.
 - `Source::get_outputs` no longer takes a `SimulationFlags` argument. Simulation types are now encoded as type parameters, preventing invalid flag combinations at compile time instead of panicking at runtime.
+- `Source::set_inputs` no longer takes a `SimulationFlags` argument. Simulation types are now encoded as type parameters, preventing invalid flag combinations at compile time instead of panicking at runtime.
 - `ReflectionEffectParams` no longer has a lifetime parameter. It now bumps the reference count of the associated `Source` to keep the IR pointer valid.
 - `ReflectionEffectParams<Convolution>::new` and `ReflectionEffectParams<Hybrid>::new` are now `unsafe` since the caller must ensure the IR pointer remains valid.
 
@@ -29,7 +30,6 @@
 - Implement `Clone` for all models (`AirAbsorptionModel`, `DeviationModel`, `Directivity`, `DistanceAttenuationModel`).
 - Implement `Clone` for `SimulationInputs`, `DirectSimulationParameters`, `PathingSimulationParameters`.
 - Implement `Copy`, `Clone` for `AudioEffectState`.
-- Implement `Copy`, `Clone` for `SourceSettings`.
 - Add `SimulationInputs::set_source` to update the source position and orientation in place.
 - Add `SimulationInputs::set_direct_simulation_parameters`, `set_reflections_simulation_parameters`, and `set_pathing_simulation_parameters` to update simulation parameters in place without rebuilding the struct.
 - Implement `Copy`, `Clone` for `Direct`, `Reflections`, and `Pathing` marker types.
@@ -38,13 +38,18 @@
 - Add methods `set_listener`, `set_reflections_shared_inputs`, and `set_pathing_visualization_callback` for `SimulationSharedInputs`.
 - Add `Source::get_outputs_subset` to retrieve a subset of simulation results, blocking only for the requested simulation types.
 - Add `Source::get_direct_outputs`, `Source::get_reflection_outputs`, and `Source::get_pathing_outputs` as typed convenience methods that return effect parameters directly.
+- Add `Source::set_inputs_subset` to set a subset of simulation inputs, blocking only for the requested simulation types.
+- Add `Source::set_direct_inputs`, `Source::set_reflections_inputs`, and `Source::set_pathing_inputs` as typed convenience methods.
+- Add `Source::try_new_limited` to create a source that runs a subset of the simulations supported by its simulator.
 - Add `SimulationFlagsProvider` trait, implemented for `Direct`, `Reflections`, `Pathing`, and `()`.
 
 ### Removed
 
+- Remove `SourceSettings`. The simulation flags are now derived from the source's type parameters.
 - Remove `'static` bounds from `Clone` implementation for `Source`.
 - Remove lifetime from `SimulationOutputs`. `SimulationOutputs` now bumps the reference count of the associated `Source` instead.
 - Remove `Source::get_outputs` runtime panic on invalid flags. Invalid flag combinations are now rejected at compile time via type parameters.
+- Remove `Source::set_inputs` runtime panic on invalid flags. Invalid flag combinations are now rejected at compile time via type parameters.
 
 ## [0.13.0] - 2026-03-04
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `Source::set_inputs` no longer takes a `SimulationFlags` argument. Simulation types are now encoded as type parameters, preventing invalid flag combinations at compile time instead of panicking at runtime.
 - `ReflectionEffectParams` no longer has a lifetime parameter. It now bumps the reference count of the associated `Source` to keep the IR pointer valid.
 - `ReflectionEffectParams<Convolution>::new` and `ReflectionEffectParams<Hybrid>::new` are now `unsafe` since the caller must ensure the IR pointer remains valid.
+- `Simulator::set_shared_inputs` no longer takes a `SimulationFlags` argument. Simulation types are now encoded as type parameters, preventing invalid flag combinations at compile time instead of panicking at runtime.
 
 ### Added
 
@@ -42,6 +43,8 @@
 - Add `Source::set_direct_inputs`, `Source::set_reflections_inputs`, and `Source::set_pathing_inputs` as typed convenience methods.
 - Add `Source::try_new_subset` to create a source that runs a subset of the simulations supported by its simulator.
 - Add `SimulationFlagsProvider` trait, implemented for `Direct`, `Reflections`, `Pathing`, and `()`.
+- Add `Simulator::set_shared_inputs_subset` to set a subset of shared simulation inputs, blocking only for the requested simulation types.
+- Add `Simulator::set_shared_direct_inputs`, `Simulator::set_shared_reflections_inputs`, and `Simulator::set_shared_pathing_inputs` as typed convenience methods.
 
 ### Removed
 

--- a/audionimbus/src/effect/pathing.rs
+++ b/audionimbus/src/effect/pathing.rs
@@ -125,10 +125,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 ///     .bake(&context, &mut probe_batch, &scene, path_bake_params)
 ///     .unwrap();
 ///
-/// let source_settings = SourceSettings {
-///     flags: SimulationFlags::PATHING,
-/// };
-/// let mut source = Source::try_new(&simulator, source_settings)?;
+/// let mut source = Source::try_new(&simulator)?;
 /// let simulation_inputs = SimulationInputs::new(CoordinateSystem::default())
 ///     .with_direct(
 ///         DirectSimulationParameters::new()
@@ -156,7 +153,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 ///         find_alternate_paths: true,
 ///         deviation: DeviationModel::default(),
 ///     });
-/// source.set_inputs(SimulationFlags::PATHING, &simulation_inputs);
+/// source.set_pathing_inputs(&simulation_inputs);
 /// simulator.add_source(&source);
 ///
 /// simulator.commit();

--- a/audionimbus/src/effect/reflections.rs
+++ b/audionimbus/src/effect/reflections.rs
@@ -201,8 +201,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 /// );
 ///
 /// simulator.add_source(&source);
-/// simulator.set_shared_inputs(
-///     SimulationFlags::REFLECTIONS,
+/// simulator.set_shared_reflections_inputs(
 ///     &SimulationSharedInputs::new(CoordinateSystem::default()).with_reflections(
 ///         ReflectionsSharedInputs {
 ///             num_rays: 4096,
@@ -286,8 +285,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 /// );
 ///
 /// simulator.add_source(&reverb_source);
-/// simulator.set_shared_inputs(
-///     SimulationFlags::REFLECTIONS,
+/// simulator.set_shared_reflections_inputs(
 ///     &SimulationSharedInputs::new(CoordinateSystem::default()).with_reflections(
 ///         ReflectionsSharedInputs {
 ///             num_rays: 4096,
@@ -1150,7 +1148,7 @@ mod tests {
                     irradiance_min_distance: 1.0,
                 });
                 simulator
-                    .set_shared_inputs(SimulationFlags::REFLECTIONS, &simulation_shared_inputs)
+                    .set_shared_reflections_inputs(&simulation_shared_inputs)
                     .unwrap();
 
                 simulator.commit();
@@ -1226,7 +1224,7 @@ mod tests {
                     irradiance_min_distance: 1.0,
                 });
                 simulator
-                    .set_shared_inputs(SimulationFlags::REFLECTIONS, &simulation_shared_inputs)
+                    .set_shared_reflections_inputs(&simulation_shared_inputs)
                     .unwrap();
 
                 simulator.commit();
@@ -1314,7 +1312,7 @@ mod tests {
                     irradiance_min_distance: 1.0,
                 });
                 simulator
-                    .set_shared_inputs(SimulationFlags::REFLECTIONS, &simulation_shared_inputs)
+                    .set_shared_reflections_inputs(&simulation_shared_inputs)
                     .unwrap();
 
                 simulator.commit();
@@ -1401,7 +1399,7 @@ mod tests {
                     irradiance_min_distance: 1.0,
                 });
                 simulator
-                    .set_shared_inputs(SimulationFlags::REFLECTIONS, &simulation_shared_inputs)
+                    .set_shared_reflections_inputs(&simulation_shared_inputs)
                     .unwrap();
 
                 simulator.commit();
@@ -1489,7 +1487,7 @@ mod tests {
                     irradiance_min_distance: 1.0,
                 });
                 simulator
-                    .set_shared_inputs(SimulationFlags::REFLECTIONS, &simulation_shared_inputs)
+                    .set_shared_reflections_inputs(&simulation_shared_inputs)
                     .unwrap();
 
                 simulator.commit();
@@ -1585,7 +1583,7 @@ mod tests {
                     irradiance_min_distance: 1.0,
                 });
                 simulator
-                    .set_shared_inputs(SimulationFlags::REFLECTIONS, &simulation_shared_inputs)
+                    .set_shared_reflections_inputs(&simulation_shared_inputs)
                     .unwrap();
 
                 simulator.commit();
@@ -1870,7 +1868,7 @@ mod tests {
                     irradiance_min_distance: 1.0,
                 });
                 simulator
-                    .set_shared_inputs(SimulationFlags::REFLECTIONS, &simulation_shared_inputs)
+                    .set_shared_reflections_inputs(&simulation_shared_inputs)
                     .unwrap();
 
                 simulator.commit();
@@ -1943,7 +1941,7 @@ mod tests {
                     irradiance_min_distance: 1.0,
                 });
                 simulator
-                    .set_shared_inputs(SimulationFlags::REFLECTIONS, &simulation_shared_inputs)
+                    .set_shared_reflections_inputs(&simulation_shared_inputs)
                     .unwrap();
 
                 simulator.commit();
@@ -2020,7 +2018,7 @@ mod tests {
                     irradiance_min_distance: 1.0,
                 });
                 simulator
-                    .set_shared_inputs(SimulationFlags::REFLECTIONS, &simulation_shared_inputs)
+                    .set_shared_reflections_inputs(&simulation_shared_inputs)
                     .unwrap();
 
                 simulator.commit();
@@ -2093,7 +2091,7 @@ mod tests {
                     irradiance_min_distance: 1.0,
                 });
                 simulator
-                    .set_shared_inputs(SimulationFlags::REFLECTIONS, &simulation_shared_inputs)
+                    .set_shared_reflections_inputs(&simulation_shared_inputs)
                     .unwrap();
 
                 simulator.commit();

--- a/audionimbus/src/effect/reflections.rs
+++ b/audionimbus/src/effect/reflections.rs
@@ -190,15 +190,9 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 /// let scene = Scene::try_new(&context)?;
 /// simulator.set_scene(&scene);
 ///
-/// let mut source = Source::try_new(
-///     &simulator,
-///     SourceSettings {
-///         flags: SimulationFlags::REFLECTIONS,
-///     },
-/// )?;
+/// let mut source = Source::try_new(&simulator)?;
 ///
-/// source.set_inputs(
-///     SimulationFlags::REFLECTIONS,
+/// source.set_reflections_inputs(
 ///     &SimulationInputs::new(CoordinateSystem::default()).with_reflections(
 ///         ReflectionsSimulationParameters::Convolution {
 ///             baked_data_identifier: None,
@@ -276,12 +270,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 /// simulator.set_scene(&scene);
 ///
 /// // Create a reverb source positioned at the listener.
-/// let mut reverb_source = Source::try_new(
-///     &simulator,
-///     SourceSettings {
-///         flags: SimulationFlags::REFLECTIONS,
-///     },
-/// )?;
+/// let mut reverb_source = Source::try_new(&simulator)?;
 ///
 /// let listener_position = CoordinateSystem {
 ///     origin: Vector3::new(0.0, 1.5, 0.0), // Listener at head height
@@ -289,8 +278,7 @@ use crate::simulation::{SimulationOutputs, Simulator, Source};
 /// };
 ///
 /// // Set source position to match listener position.
-/// reverb_source.set_inputs(
-///     SimulationFlags::REFLECTIONS,
+/// reverb_source.set_reflections_inputs(
 ///     &SimulationInputs::new(listener_position) // Source at listener = reverb
 ///         .with_reflections(ReflectionsSimulationParameters::Convolution {
 ///             baked_data_identifier: None,
@@ -1148,11 +1136,7 @@ mod tests {
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
 
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::REFLECTIONS,
-                };
-                let source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
+                let source = Source::try_new(&simulator).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1228,11 +1212,7 @@ mod tests {
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
 
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::REFLECTIONS,
-                };
-                let source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
+                let source = Source::try_new(&simulator).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1320,11 +1300,7 @@ mod tests {
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
 
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::REFLECTIONS,
-                };
-                let source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
+                let source = Source::try_new(&simulator).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1411,11 +1387,7 @@ mod tests {
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
 
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::REFLECTIONS,
-                };
-                let source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
+                let source = Source::try_new(&simulator).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1503,11 +1475,7 @@ mod tests {
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
 
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::REFLECTIONS,
-                };
-                let source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
+                let source = Source::try_new(&simulator).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1603,11 +1571,7 @@ mod tests {
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
 
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::REFLECTIONS,
-                };
-                let source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
+                let source = Source::try_new(&simulator).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1892,11 +1856,7 @@ mod tests {
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
 
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::REFLECTIONS,
-                };
-                let source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
+                let source = Source::try_new(&simulator).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -1969,11 +1929,7 @@ mod tests {
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
 
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::REFLECTIONS,
-                };
-                let source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
+                let source = Source::try_new(&simulator).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -2050,11 +2006,7 @@ mod tests {
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
 
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::REFLECTIONS,
-                };
-                let source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
+                let source = Source::try_new(&simulator).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(
@@ -2127,11 +2079,7 @@ mod tests {
                 let scene = Scene::try_new(&context).unwrap();
                 simulator.set_scene(&scene);
 
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::REFLECTIONS,
-                };
-                let source =
-                    Source::<(), Reflections, ()>::try_new(&simulator, source_settings).unwrap();
+                let source = Source::try_new(&simulator).unwrap();
                 simulator.add_source(&source);
 
                 let simulation_shared_inputs = SimulationSharedInputs::new(

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -391,8 +391,6 @@ where
     ///
     /// Convenience method abstracting the more expressive [`Self::set_shared_inputs_subset`].
     ///
-    /// See the [module-level documentation](crate::simulation) for threading guidelines.
-    ///
     /// Also see:
     /// - [`Self::set_shared_direct_inputs`]
     /// - [`Self::set_shared_reflections_inputs`]
@@ -407,6 +405,8 @@ where
     /// It is safe to call this method concurrently with simulations of different types.
     /// For example, setting `DIRECT` shared inputs while a `REFLECTIONS` simulation is running
     /// will not block.
+    ///
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
     ///
     /// # Arguments
     ///
@@ -1477,8 +1477,6 @@ where
     ///
     /// Convenience method abstracting the more expressive [`Self::set_inputs_subset`].
     ///
-    /// See the [module-level documentation](crate::simulation) for threading guidelines.
-    ///
     /// Also see:
     /// - [`Self::set_direct_inputs`]
     /// - [`Self::set_reflections_inputs`]
@@ -1487,12 +1485,14 @@ where
     /// # Threading Considerations
     ///
     /// This method will block if a simulation is currently running for the
-    /// specified type(s). Call this from the same thread that runs the corresponding
-    /// simulation(s) to avoid blocking.
+    /// specified type(s).
+    /// Call this from the same thread that runs the corresponding simulation(s) to avoid blocking.
     ///
     /// It is safe to call this method concurrently with simulations of different types.
     /// For example, setting `DIRECT` inputs while a `REFLECTIONS` simulation is running
     /// will not block.
+    ///
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
     ///
     /// # Arguments
     ///

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -408,6 +408,33 @@ where
     ///
     /// See the [module-level documentation](crate::simulation) for threading guidelines.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// # let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    /// #     .with_direct(DirectSimulationSettings { max_num_occlusion_samples: 4 })
+    /// #     .with_reflections(ReflectionsSimulationSettings::Convolution {
+    /// #         max_num_rays: 4096,
+    /// #         num_diffuse_samples: 32,
+    /// #         max_duration: 2.0,
+    /// #         max_num_sources: 8,
+    /// #         num_threads: 2,
+    /// #     });
+    /// # let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    /// let shared_inputs = SimulationSharedInputs::new(CoordinateSystem::default())
+    ///     .with_reflections(ReflectionsSharedInputs {
+    ///         num_rays: 4096,
+    ///         num_bounces: 16,
+    ///         duration: 2.0,
+    ///         order: 1,
+    ///         irradiance_min_distance: 1.0,
+    ///     });
+    /// simulator.set_shared_inputs(&shared_inputs)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
     /// # Arguments
     ///
     /// - `shared_inputs`: the shared input parameters to set.
@@ -442,6 +469,38 @@ where
     ///
     /// MUST NOT be called from a real-time audio thread.
     /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// # let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    /// #     .with_direct(DirectSimulationSettings { max_num_occlusion_samples: 4 })
+    /// #     .with_reflections(ReflectionsSimulationSettings::Convolution {
+    /// #         max_num_rays: 4096,
+    /// #         num_diffuse_samples: 32,
+    /// #         max_duration: 2.0,
+    /// #         max_num_sources: 8,
+    /// #         num_threads: 2,
+    /// #     });
+    /// # let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    /// let shared_inputs = SimulationSharedInputs::new(CoordinateSystem::default())
+    ///     .with_reflections(ReflectionsSharedInputs {
+    ///         num_rays: 4096,
+    ///         num_bounces: 16,
+    ///         duration: 2.0,
+    ///         order: 1,
+    ///         irradiance_min_distance: 1.0,
+    ///     });
+    ///
+    /// // Direct simulation thread...
+    /// simulator.set_shared_inputs_subset::<Direct, (), (), _, _, _>(&shared_inputs)?;
+    ///
+    /// // Reflections simulation thread... Does not block the direct thread.
+    /// simulator.set_shared_inputs_subset::<(), Reflections, (), _, _, _>(&shared_inputs)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     ///
     /// # Arguments
     ///
@@ -573,6 +632,21 @@ where
     /// Convenience method abstracting the more expressive [`Self::set_shared_inputs_subset`].
     /// See the [module-level documentation](crate::simulation) for threading guidelines.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// # let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    /// #     .with_direct(DirectSimulationSettings {
+    /// #         max_num_occlusion_samples: 4,
+    /// #     });
+    /// # let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    /// let shared_inputs = SimulationSharedInputs::new(CoordinateSystem::default());
+    /// simulator.set_shared_direct_inputs(&shared_inputs)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
     /// # Arguments
     ///
     /// - `shared_inputs`: the shared input parameters to set.
@@ -627,6 +701,32 @@ where
     ///
     /// Convenience method abstracting the more expressive [`Self::set_shared_inputs_subset`].
     /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// # let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    /// #     .with_reflections(ReflectionsSimulationSettings::Convolution {
+    /// #         max_num_rays: 4096,
+    /// #         num_diffuse_samples: 32,
+    /// #         max_duration: 2.0,
+    /// #         max_num_sources: 8,
+    /// #         num_threads: 1,
+    /// #     });
+    /// # let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    /// let shared_inputs = SimulationSharedInputs::new(CoordinateSystem::default())
+    ///     .with_reflections(ReflectionsSharedInputs {
+    ///         num_rays: 4096,
+    ///         num_bounces: 16,
+    ///         duration: 2.0,
+    ///         order: 1,
+    ///         irradiance_min_distance: 1.0,
+    ///     });
+    /// simulator.set_shared_reflections_inputs(&shared_inputs)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     ///
     /// # Arguments
     ///
@@ -694,6 +794,21 @@ where
     ///
     /// Convenience method abstracting the more expressive [`Self::set_shared_inputs_subset`].
     /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// # let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    /// #     .with_pathing(PathingSimulationSettings {
+    /// #         num_visibility_samples: 4,
+    /// #     });
+    /// # let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    /// let shared_inputs = SimulationSharedInputs::new(CoordinateSystem::default());
+    /// simulator.set_shared_pathing_inputs(&shared_inputs)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     ///
     /// # Arguments
     ///
@@ -1411,6 +1526,19 @@ where
     ///
     /// Convenience method abstracting the more expressive [`Self::try_new_subset`].
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// # let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    /// #     .with_direct(DirectSimulationSettings { max_num_occlusion_samples: 4 });
+    /// # let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    /// // The source's type parameters determine which simulations may be run.
+    /// let source = Source::<Direct, (), ()>::try_new(&simulator)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns [`SteamAudioError`] if creation fails.
@@ -1427,6 +1555,28 @@ where
     /// Creates a new source and returns a handle to it.
     ///
     /// Generics specify which types of simulation may be run for this source.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    ///     .with_direct(DirectSimulationSettings { max_num_occlusion_samples: 4 })
+    ///     .with_reflections(ReflectionsSimulationSettings::Convolution {
+    ///         max_num_rays: 4096,
+    ///         num_diffuse_samples: 32,
+    ///         max_duration: 2.0,
+    ///         max_num_sources: 8,
+    ///         num_threads: 1,
+    ///     });
+    /// let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    ///
+    /// // The simulator supports both direct and reflections, but this source
+    /// // only participates in direct simulation.
+    /// let source = Source::<Direct, (), ()>::try_new_subset(&simulator)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     ///
     /// # Errors
     ///
@@ -1501,6 +1651,22 @@ where
     ///
     /// See the [module-level documentation](crate::simulation) for threading guidelines.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// # let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    /// #     .with_direct(DirectSimulationSettings { max_num_occlusion_samples: 4 });
+    /// # let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    /// let source = Source::try_new(&simulator)?;
+    /// let inputs = SimulationInputs::new(CoordinateSystem::default())
+    ///     .with_direct(DirectSimulationParameters::new()
+    ///         .with_distance_attenuation(DistanceAttenuationModel::default()));
+    /// source.set_inputs(&inputs)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
     /// # Arguments
     ///
     /// - `inputs`: the input parameters to set.
@@ -1535,6 +1701,36 @@ where
     ///
     /// MUST NOT be called from a real-time audio thread.
     /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// # let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    /// #     .with_direct(DirectSimulationSettings { max_num_occlusion_samples: 4 })
+    /// #     .with_reflections(ReflectionsSimulationSettings::Convolution {
+    /// #         max_num_rays: 4096,
+    /// #         num_diffuse_samples: 32,
+    /// #         max_duration: 2.0,
+    /// #         max_num_sources: 8,
+    /// #         num_threads: 1,
+    /// #     });
+    /// # let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    /// # let source = Source::try_new(&simulator)?;
+    /// # let inputs = SimulationInputs::new(CoordinateSystem::default())
+    /// #     .with_direct(DirectSimulationParameters::new()
+    /// #         .with_distance_attenuation(DistanceAttenuationModel::default()))
+    /// #     .with_reflections(ReflectionsSimulationParameters::Convolution {
+    /// #         baked_data_identifier: None,
+    /// #     });
+    /// // Direct simulation thread...
+    /// source.set_inputs_subset::<Direct, (), (), _, _, _>(&inputs)?;
+    ///
+    /// // Reflections simulation thread... Does not block the direct thread.
+    /// source.set_inputs_subset::<(), Reflections, (), _, _, _>(&inputs)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     ///
     /// # Arguments
     ///
@@ -1739,6 +1935,22 @@ where
     /// Convenience method abstracting the more expressive [`Self::set_inputs_subset`].
     /// See the [module-level documentation](crate::simulation) for threading guidelines.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// # let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    /// #     .with_direct(DirectSimulationSettings { max_num_occlusion_samples: 4 });
+    /// # let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    /// # let source = Source::try_new(&simulator)?;
+    /// let inputs = SimulationInputs::new(CoordinateSystem::default())
+    ///     .with_direct(DirectSimulationParameters::new()
+    ///         .with_distance_attenuation(DistanceAttenuationModel::default()));
+    /// source.set_direct_inputs(&inputs)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
     /// # Arguments
     ///
     /// - `inputs`: the input parameters to set.
@@ -1786,6 +1998,29 @@ where
     ///
     /// Convenience method abstracting the more expressive [`Self::set_inputs_subset`].
     /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// # let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    /// #     .with_reflections(ReflectionsSimulationSettings::Convolution {
+    /// #         max_num_rays: 4096,
+    /// #         num_diffuse_samples: 32,
+    /// #         max_duration: 2.0,
+    /// #         max_num_sources: 8,
+    /// #         num_threads: 2,
+    /// #     });
+    /// # let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    /// # let source = Source::try_new(&simulator)?;
+    /// let inputs = SimulationInputs::new(CoordinateSystem::default())
+    ///     .with_reflections(ReflectionsSimulationParameters::Convolution {
+    ///         baked_data_identifier: None,
+    ///     });
+    /// source.set_reflections_inputs(&inputs)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     ///
     /// # Arguments
     ///
@@ -1837,6 +2072,33 @@ where
     ///
     /// Convenience method abstracting the more expressive [`Self::set_inputs_subset`].
     /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use audionimbus::*;
+    /// # let context = Context::default();
+    /// # let simulation_settings = SimulationSettings::new(48_000, 1024, 1)
+    /// #     .with_pathing(PathingSimulationSettings {
+    /// #         num_visibility_samples: 4,
+    /// #     });
+    /// # let simulator = Simulator::try_new(&context, &simulation_settings)?;
+    /// # let source = Source::try_new(&simulator)?;
+    /// # let pathing_probes = ProbeBatch::try_new(&context).unwrap();
+    /// let inputs = SimulationInputs::new(CoordinateSystem::default())
+    ///     .with_pathing(PathingSimulationParameters {
+    ///         pathing_probes,
+    ///         visibility_radius: 1.0,
+    ///         visibility_threshold: 10.0,
+    ///         visibility_range: 10.0,
+    ///         pathing_order: 1,
+    ///         enable_validation: true,
+    ///         find_alternate_paths: true,
+    ///         deviation: DeviationModel::default(),
+    ///     });
+    /// source.set_pathing_inputs(&inputs)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     ///
     /// # Arguments
     ///

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -133,7 +133,7 @@ impl SimulationFlagsProvider for () {
 ///
 /// // Set shared parameters.
 /// let shared_inputs = SimulationSharedInputs::new(CoordinateSystem::default());
-/// simulator.set_shared_inputs(SimulationFlags::DIRECT, &shared_inputs);
+/// simulator.set_shared_direct_inputs(&shared_inputs);
 ///
 /// // Run the simulation.
 /// simulator.run_direct();

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -389,26 +389,83 @@ where
 
     /// Specifies simulation parameters that are not associated with any particular source.
     ///
+    /// Convenience method abstracting the more expressive [`Self::set_shared_inputs_subset`].
+    ///
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// Also see:
+    /// - [`Self::set_shared_direct_inputs`]
+    /// - [`Self::set_shared_reflections_inputs`]
+    /// - [`Self::set_shared_pathing_inputs`]
+    ///
+    /// # Threading Considerations
+    ///
+    /// This method will block if a simulation is currently running for the
+    /// specified type(s).
+    /// Call this from the same thread that runs the corresponding simulation(s) to avoid blocking.
+    ///
+    /// It is safe to call this method concurrently with simulations of different types.
+    /// For example, setting `DIRECT` shared inputs while a `REFLECTIONS` simulation is running
+    /// will not block.
+    ///
     /// # Arguments
     ///
-    /// - `flags`: the types of simulation for which to specify shared inputs. If, for example, direct and reflections simulations are being run on separate threads, you can call this function on the direct simulation thread with [`SimulationFlags::DIRECT`], and on the reflections simulation thread with [`SimulationFlags::REFLECTIONS`], without requiring any synchronization between the calls.
     /// - `shared_inputs`: the shared input parameters to set.
     ///
     /// # Errors
     ///
     /// Returns [`ParameterValidationError`] if any parameters exceed the maximums set during
     /// simulator initialization.
-    pub fn set_shared_inputs<_D, _P>(
+    pub fn set_shared_inputs<InD, InR, InP>(
         &self,
-        simulation_flags: SimulationFlags,
-        // `_D` and `_P` are intentionally unconstrained here.
-        // `SimulationSharedInputs` does not contain any Direct- or Pathing-specific data.
-        // Allowing arbitrary `_D` and `_P` avoids forcing callers to construct a value via
-        // `SimulationSharedInputs::with_direct` and `SimulationSharedInputs::with_pathing`, which
-        // would add unnecessary boilerplate with no semantic benefit.
-        shared_inputs: &SimulationSharedInputs<_D, R, _P>,
-    ) -> Result<(), ParameterValidationError> {
+        shared_inputs: &SimulationSharedInputs<InD, InR, InP>,
+    ) -> Result<(), ParameterValidationError>
+    where
+        D: DirectCompatible<D> + DirectCompatible<InD> + SimulationFlagsProvider,
+        R: ReflectionsCompatible<R> + ReflectionsCompatible<InR> + SimulationFlagsProvider,
+        P: PathingCompatible<P> + PathingCompatible<InP> + SimulationFlagsProvider,
+        InD: DirectCompatible<D> + SimulationFlagsProvider,
+        InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        InP: PathingCompatible<P> + SimulationFlagsProvider,
+    {
+        self.set_shared_inputs_subset::<D, R, P, InD, InR, InP>(shared_inputs)
+    }
+
+    /// Specifies simulation parameters that are not associated with any particular source.
+    ///
+    /// Only blocks for the requested simulation types, allowing concurrent setting of shared
+    /// parameters across simulation threads.
+    ///
+    /// For example, `set_shared_inputs_subset::<Direct, (), ()>()` and
+    /// `set_shared_inputs_subset::<(), Reflections, ()>()` can be called simultaneously without
+    /// blocking each other.
+    ///
+    /// MUST NOT be called from a real-time audio thread.
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Arguments
+    ///
+    /// - `shared_inputs`: the shared input parameters to set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParameterValidationError`] if any parameters exceed the maximums set during
+    /// simulator initialization.
+    pub fn set_shared_inputs_subset<SubD, SubR, SubP, InD, InR, InP>(
+        &self,
+        shared_inputs: &SimulationSharedInputs<InD, InR, InP>,
+    ) -> Result<(), ParameterValidationError>
+    where
+        SubD: DirectCompatible<D> + DirectCompatible<InD> + SimulationFlagsProvider,
+        SubR: ReflectionsCompatible<R> + ReflectionsCompatible<InR> + SimulationFlagsProvider,
+        SubP: PathingCompatible<P> + PathingCompatible<InP> + SimulationFlagsProvider,
+        InD: DirectCompatible<D> + SimulationFlagsProvider,
+        InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        InP: PathingCompatible<P> + SimulationFlagsProvider,
+    {
         self.validate_shared_inputs(shared_inputs)?;
+
+        let simulation_flags = SubD::flags() | SubR::flags() | SubP::flags();
 
         let _guards = self.acquire_locks_for_flags(simulation_flags);
 
@@ -449,10 +506,15 @@ where
     }
 
     /// Validates shared simulation inputs against the limits set during initialization.
-    fn validate_shared_inputs<_D, _P>(
+    fn validate_shared_inputs<InD, InR, InP>(
         &self,
-        shared_inputs: &SimulationSharedInputs<_D, R, _P>,
-    ) -> Result<(), ParameterValidationError> {
+        shared_inputs: &SimulationSharedInputs<InD, InR, InP>,
+    ) -> Result<(), ParameterValidationError>
+    where
+        InD: DirectCompatible<D>,
+        InR: ReflectionsCompatible<R>,
+        InP: PathingCompatible<P>,
+    {
         let Some(reflections_inputs) = &shared_inputs.reflections_shared_inputs else {
             return Ok(());
         };
@@ -501,6 +563,32 @@ where
     R: 'static,
     P: 'static,
 {
+    /// Specifies direct simulation parameters that are not associated with any particular source.
+    ///
+    /// Convenience method abstracting the more expressive [`Self::set_shared_inputs_subset`].
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Arguments
+    ///
+    /// - `shared_inputs`: the shared input parameters to set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParameterValidationError`] if any parameters exceed the maximums set during
+    /// simulator initialization.
+    pub fn set_shared_direct_inputs<InR, InP>(
+        &self,
+        shared_inputs: &SimulationSharedInputs<Direct, InR, InP>,
+    ) -> Result<(), ParameterValidationError>
+    where
+        InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        InP: PathingCompatible<P> + SimulationFlagsProvider,
+        (): ReflectionsCompatible<R> + ReflectionsCompatible<InR>,
+        (): PathingCompatible<P> + PathingCompatible<InP>,
+    {
+        self.set_shared_inputs_subset::<Direct, (), (), Direct, InR, InP>(shared_inputs)
+    }
+
     /// Runs a direct simulation for all sources added to the simulator.
     ///
     /// This may include distance attenuation, air absorption, directivity, occlusion, and transmission.
@@ -529,6 +617,32 @@ where
     D: 'static,
     P: 'static,
 {
+    /// Specifies reflections simulation parameters that are not associated with any particular source.
+    ///
+    /// Convenience method abstracting the more expressive [`Self::set_shared_inputs_subset`].
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Arguments
+    ///
+    /// - `shared_inputs`: the shared input parameters to set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParameterValidationError`] if any parameters exceed the maximums set during
+    /// simulator initialization.
+    pub fn set_shared_reflections_inputs<InD, InP>(
+        &self,
+        shared_inputs: &SimulationSharedInputs<InD, Reflections, InP>,
+    ) -> Result<(), ParameterValidationError>
+    where
+        InD: DirectCompatible<D> + SimulationFlagsProvider,
+        InP: PathingCompatible<P> + SimulationFlagsProvider,
+        (): DirectCompatible<D> + DirectCompatible<InD>,
+        (): PathingCompatible<P> + PathingCompatible<InP>,
+    {
+        self.set_shared_inputs_subset::<(), Reflections, (), InD, Reflections, InP>(shared_inputs)
+    }
+
     /// Runs a reflections simulation for all sources added to the simulator.
     ///
     /// # Performance Considerations
@@ -570,6 +684,32 @@ where
     D: 'static,
     R: 'static,
 {
+    /// Specifies pathing simulation parameters that are not associated with any particular source.
+    ///
+    /// Convenience method abstracting the more expressive [`Self::set_shared_inputs_subset`].
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Arguments
+    ///
+    /// - `shared_inputs`: the shared input parameters to set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParameterValidationError`] if any parameters exceed the maximums set during
+    /// simulator initialization.
+    pub fn set_shared_pathing_inputs<InD, InR>(
+        &self,
+        shared_inputs: &SimulationSharedInputs<InD, InR, Pathing>,
+    ) -> Result<(), ParameterValidationError>
+    where
+        InD: DirectCompatible<D> + SimulationFlagsProvider,
+        InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        (): DirectCompatible<D> + DirectCompatible<InD>,
+        (): ReflectionsCompatible<R> + ReflectionsCompatible<InR>,
+    {
+        self.set_shared_inputs_subset::<(), (), Pathing, InD, InR, Pathing>(shared_inputs)
+    }
+
     /// Runs a pathing simulation for all sources added to the simulator.
     ///
     /// # Performance Considerations
@@ -1362,16 +1502,19 @@ where
     ///
     /// Returns [`ParameterValidationError`] if any parameters exceed the maximums
     /// set during simulator initialization.
-    pub fn set_inputs(
+    pub fn set_inputs<InD, InR, InP>(
         &self,
-        inputs: &SimulationInputs<D, R, P>,
+        inputs: &SimulationInputs<InD, InR, InP>,
     ) -> Result<(), ParameterValidationError>
     where
-        D: DirectCompatible<D> + SimulationFlagsProvider,
-        R: ReflectionsCompatible<R> + SimulationFlagsProvider,
-        P: PathingCompatible<P> + SimulationFlagsProvider,
+        D: DirectCompatible<D> + DirectCompatible<InD> + SimulationFlagsProvider,
+        R: ReflectionsCompatible<R> + ReflectionsCompatible<InR> + SimulationFlagsProvider,
+        P: PathingCompatible<P> + PathingCompatible<InP> + SimulationFlagsProvider,
+        InD: DirectCompatible<D> + SimulationFlagsProvider,
+        InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        InP: PathingCompatible<P> + SimulationFlagsProvider,
     {
-        self.set_inputs_subset::<D, R, P>(inputs)
+        self.set_inputs_subset::<D, R, P, InD, InR, InP>(inputs)
     }
 
     /// Specifies parts or all of the simulation parameters for a source.
@@ -1394,18 +1537,21 @@ where
     ///
     /// Returns [`ParameterValidationError`] if any parameters exceed the maximums
     /// set during simulator initialization.
-    pub fn set_inputs_subset<InD, InR, InP>(
+    pub fn set_inputs_subset<SubD, SubR, SubP, InD, InR, InP>(
         &self,
         inputs: &SimulationInputs<InD, InR, InP>,
     ) -> Result<(), ParameterValidationError>
     where
+        SubD: DirectCompatible<D> + DirectCompatible<InD> + SimulationFlagsProvider,
+        SubR: ReflectionsCompatible<R> + ReflectionsCompatible<InR> + SimulationFlagsProvider,
+        SubP: PathingCompatible<P> + PathingCompatible<InP> + SimulationFlagsProvider,
         InD: DirectCompatible<D> + SimulationFlagsProvider,
         InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
         InP: PathingCompatible<P> + SimulationFlagsProvider,
     {
         self.validate_inputs(inputs)?;
 
-        let simulation_flags = InD::flags() | InR::flags() | InP::flags();
+        let simulation_flags = SubD::flags() | SubR::flags() | SubP::flags();
 
         let mut ffi_inputs = inputs.to_ffi();
 
@@ -1601,8 +1747,10 @@ where
     where
         InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
         InP: PathingCompatible<P> + SimulationFlagsProvider,
+        (): ReflectionsCompatible<InR>,
+        (): PathingCompatible<InP>,
     {
-        self.set_inputs_subset::<Direct, InR, InP>(inputs)
+        self.set_inputs_subset::<Direct, (), (), Direct, InR, InP>(inputs)
     }
 
     /// Retrieves direct simulation results for a source.
@@ -1647,8 +1795,10 @@ where
     where
         InD: DirectCompatible<D> + SimulationFlagsProvider,
         InP: PathingCompatible<P> + SimulationFlagsProvider,
+        (): DirectCompatible<InD>,
+        (): PathingCompatible<InP>,
     {
-        self.set_inputs_subset::<InD, Reflections, InP>(inputs)
+        self.set_inputs_subset::<(), Reflections, (), InD, Reflections, InP>(inputs)
     }
 
     /// Retrieves reflections simulation results for a source.
@@ -1696,8 +1846,10 @@ where
     where
         InD: DirectCompatible<D> + SimulationFlagsProvider,
         InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        (): DirectCompatible<InD>,
+        (): ReflectionsCompatible<InR>,
     {
-        self.set_inputs_subset::<InD, InR, Pathing>(inputs)
+        self.set_inputs_subset::<(), (), Pathing, InD, InR, Pathing>(inputs)
     }
 
     /// Retrieves pathing simulation results for a source.

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -1262,7 +1262,7 @@ where
 {
     /// Creates a new source and returns a handle to it.
     ///
-    /// Convenience method abstracting the more expressive [`Self::try_new_limited`].
+    /// Convenience method abstracting the more expressive [`Self::try_new_subset`].
     ///
     /// # Errors
     ///
@@ -1274,7 +1274,7 @@ where
         R: 'static + ReflectionsCompatible<R> + SimulationFlagsProvider,
         P: 'static + PathingCompatible<P> + SimulationFlagsProvider,
     {
-        Self::try_new_limited::<T, D, R, P>(simulator)
+        Self::try_new_subset::<T, D, R, P>(simulator)
     }
 
     /// Creates a new source and returns a handle to it.
@@ -1284,7 +1284,7 @@ where
     /// # Errors
     ///
     /// Returns [`SteamAudioError`] if creation fails.
-    pub fn try_new_limited<T, SimD, SimR, SimP>(
+    pub fn try_new_subset<T, SimD, SimR, SimP>(
         simulator: &Simulator<T, SimD, SimR, SimP>,
     ) -> Result<Self, SteamAudioError>
     where

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -102,7 +102,7 @@ impl SimulationFlagsProvider for () {
 ///
 /// ```
 /// # use audionimbus::{
-/// #     Context, Simulator, Scene, Source, SourceSettings, SimulationFlags,
+/// #     Context, Simulator, Scene, Source, SimulationFlags,
 /// #     DirectSimulationSettings, SimulationSettings, SimulationInputs, SimulationSharedInputs,
 /// #     CoordinateSystem, DirectSimulationParameters, ReflectionsSharedInputs, DistanceAttenuationModel,
 /// # };
@@ -122,19 +122,14 @@ impl SimulationFlagsProvider for () {
 /// simulator.set_scene(&scene);
 /// simulator.commit();
 ///
-/// // Create and add a source.
-/// let source_settings = SourceSettings {
-///     flags: SimulationFlags::DIRECT,
-/// };
-/// let mut source = Source::try_new(&simulator, source_settings)?;
-///
+/// let mut source = Source::try_new(&simulator)?;
 /// simulator.add_source(&source);
 ///
 /// // Configure simulation parameters.
 /// let simulation_inputs = SimulationInputs::new(CoordinateSystem::default())
 ///     .with_direct(DirectSimulationParameters::new()
 ///         .with_distance_attenuation(DistanceAttenuationModel::default()));
-/// source.set_inputs(SimulationFlags::DIRECT, &simulation_inputs);
+/// source.set_direct_inputs(&simulation_inputs);
 ///
 /// // Set shared parameters.
 /// let shared_inputs = SimulationSharedInputs::new(CoordinateSystem::default());
@@ -1220,6 +1215,8 @@ impl PathingCompatible<()> for () {}
 /// Cloning it is cheap; it produces a new handle pointing to the same underlying object, while
 /// incrementing a reference count.
 /// The underlying object is destroyed when all handles are dropped.
+///
+/// Generic over the types of simulation that may be run for this source.
 #[derive(Debug)]
 pub struct Source<D = (), R = (), P = ()> {
     inner: audionimbus_sys::IPLSource,
@@ -1265,28 +1262,50 @@ where
 {
     /// Creates a new source and returns a handle to it.
     ///
+    /// Convenience method abstracting the more expressive [`Self::try_new_limited`].
+    ///
     /// # Errors
     ///
     /// Returns [`SteamAudioError`] if creation fails.
-    pub fn try_new<T, SimD, SimR, SimP>(
+    pub fn try_new<T>(simulator: &Simulator<T, D, R, P>) -> Result<Self, SteamAudioError>
+    where
+        T: RayTracer,
+        D: 'static + DirectCompatible<D> + SimulationFlagsProvider,
+        R: 'static + ReflectionsCompatible<R> + SimulationFlagsProvider,
+        P: 'static + PathingCompatible<P> + SimulationFlagsProvider,
+    {
+        Self::try_new_limited::<T, D, R, P>(simulator)
+    }
+
+    /// Creates a new source and returns a handle to it.
+    ///
+    /// Generics specify which types of simulation may be run for this source.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SteamAudioError`] if creation fails.
+    pub fn try_new_limited<T, SimD, SimR, SimP>(
         simulator: &Simulator<T, SimD, SimR, SimP>,
-        source_settings: SourceSettings,
     ) -> Result<Self, SteamAudioError>
     where
         T: RayTracer,
         SimD: 'static,
         SimR: 'static,
         SimP: 'static,
-        D: DirectCompatible<SimD> + 'static,
-        R: ReflectionsCompatible<SimR> + 'static,
-        P: PathingCompatible<SimP> + 'static,
+        D: 'static + DirectCompatible<SimD> + SimulationFlagsProvider,
+        R: 'static + ReflectionsCompatible<SimR> + SimulationFlagsProvider,
+        P: 'static + PathingCompatible<SimP> + SimulationFlagsProvider,
     {
         let mut inner = std::ptr::null_mut();
+
+        let simulation_flags = D::flags() | R::flags() | P::flags();
 
         let status = unsafe {
             audionimbus_sys::iplSourceCreate(
                 simulator.raw_ptr(),
-                &mut audionimbus_sys::IPLSourceSettings::from(source_settings),
+                &mut audionimbus_sys::IPLSourceSettings {
+                    flags: simulation_flags.into(),
+                },
                 &mut inner,
             )
         };
@@ -1316,6 +1335,15 @@ where
 
     /// Specifies simulation parameters for a source.
     ///
+    /// Convenience method abstracting the more expressive [`Self::set_inputs_subset`].
+    ///
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// Also see:
+    /// - [`Self::set_direct_inputs`]
+    /// - [`Self::set_reflections_inputs`]
+    /// - [`Self::set_pathing_inputs`]
+    ///
     /// # Threading Considerations
     ///
     /// This method will block if a simulation is currently running for the
@@ -1328,25 +1356,56 @@ where
     ///
     /// # Arguments
     ///
-    /// - `flags`: the types of simulation for which to specify inputs. If, for example, direct and reflections simulations are being run on separate threads, you can call this function on the direct simulation thread with [`SimulationFlags::DIRECT`], and on the reflections simulation thread with [`SimulationFlags::REFLECTIONS`], without requiring any synchronization between the calls.
     /// - `inputs`: the input parameters to set.
     ///
     /// # Errors
     ///
     /// Returns [`ParameterValidationError`] if any parameters exceed the maximums
     /// set during simulator initialization.
-    ///
-    /// # Panics
-    ///
-    /// Panics if some of the `simulation_flags` are disabled on this [`Source`].
     pub fn set_inputs(
         &self,
-        simulation_flags: SimulationFlags,
         inputs: &SimulationInputs<D, R, P>,
-    ) -> Result<(), ParameterValidationError> {
-        Self::validate_flags(simulation_flags);
+    ) -> Result<(), ParameterValidationError>
+    where
+        D: DirectCompatible<D> + SimulationFlagsProvider,
+        R: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        P: PathingCompatible<P> + SimulationFlagsProvider,
+    {
+        self.set_inputs_subset::<D, R, P>(inputs)
+    }
 
+    /// Specifies parts or all of the simulation parameters for a source.
+    ///
+    /// Only blocks for the requested simulation types, allowing concurrent setting of parameters
+    /// across simulation threads.
+    ///
+    /// For example, `set_inputs_subset::<Direct, (), ()>()` and
+    /// `set_inputs_subset::<(), Reflections, ()>()` can be called simultaneously without blocking
+    /// each other.
+    ///
+    /// MUST NOT be called from a real-time audio thread.
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Arguments
+    ///
+    /// - `inputs`: the input parameters to set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParameterValidationError`] if any parameters exceed the maximums
+    /// set during simulator initialization.
+    pub fn set_inputs_subset<InD, InR, InP>(
+        &self,
+        inputs: &SimulationInputs<InD, InR, InP>,
+    ) -> Result<(), ParameterValidationError>
+    where
+        InD: DirectCompatible<D> + SimulationFlagsProvider,
+        InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        InP: PathingCompatible<P> + SimulationFlagsProvider,
+    {
         self.validate_inputs(inputs)?;
+
+        let simulation_flags = InD::flags() | InR::flags() | InP::flags();
 
         let mut ffi_inputs = inputs.to_ffi();
 
@@ -1460,37 +1519,16 @@ where
         guards
     }
 
-    /// Asserts whether flags are enabled on this [`Source`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if some `flags` are disabled on this [`Source`].
-    fn validate_flags(flags: SimulationFlags) {
-        let mut valid_flags = SimulationFlags::empty();
-
-        if std::any::TypeId::of::<D>() == std::any::TypeId::of::<Direct>() {
-            valid_flags |= SimulationFlags::DIRECT;
-        }
-        if std::any::TypeId::of::<R>() == std::any::TypeId::of::<Reflections>() {
-            valid_flags |= SimulationFlags::REFLECTIONS;
-        }
-        if std::any::TypeId::of::<P>() == std::any::TypeId::of::<Pathing>() {
-            valid_flags |= SimulationFlags::PATHING;
-        }
-
-        assert!(
-            valid_flags.contains(flags),
-            "requested simulation flags {:?} are not enabled on this source (valid flags: {:?})",
-            flags,
-            valid_flags
-        );
-    }
-
     /// Validates simulation parameters against the limits set during simulator initialization.
-    fn validate_inputs(
+    fn validate_inputs<InD, InR, InP>(
         &self,
-        inputs: &SimulationInputs<D, R, P>,
-    ) -> Result<(), ParameterValidationError> {
+        inputs: &SimulationInputs<InD, InR, InP>,
+    ) -> Result<(), ParameterValidationError>
+    where
+        InD: DirectCompatible<D>,
+        InR: ReflectionsCompatible<R>,
+        InP: PathingCompatible<P>,
+    {
         let Some(direct_params) = &inputs.direct_simulation else {
             return Ok(());
         };
@@ -1543,6 +1581,30 @@ where
     (): ReflectionsCompatible<R>,
     (): PathingCompatible<P>,
 {
+    /// Specifies direct simulation parameters for a source.
+    ///
+    /// Convenience method abstracting the more expressive [`Self::set_inputs_subset`].
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Arguments
+    ///
+    /// - `inputs`: the input parameters to set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParameterValidationError`] if any parameters exceed the maximums
+    /// set during simulator initialization.
+    pub fn set_direct_inputs<InR, InP>(
+        &self,
+        inputs: &SimulationInputs<Direct, InR, InP>,
+    ) -> Result<(), ParameterValidationError>
+    where
+        InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        InP: PathingCompatible<P> + SimulationFlagsProvider,
+    {
+        self.set_inputs_subset::<Direct, InR, InP>(inputs)
+    }
+
     /// Retrieves direct simulation results for a source.
     ///
     /// Convenience method abstracting the more expressive [`Self::get_outputs_subset`].
@@ -1565,6 +1627,30 @@ where
     (): DirectCompatible<D>,
     (): PathingCompatible<P>,
 {
+    /// Specifies reflections simulation parameters for a source.
+    ///
+    /// Convenience method abstracting the more expressive [`Self::set_inputs_subset`].
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Arguments
+    ///
+    /// - `inputs`: the input parameters to set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParameterValidationError`] if any parameters exceed the maximums
+    /// set during simulator initialization.
+    pub fn set_reflections_inputs<InD, InP>(
+        &self,
+        inputs: &SimulationInputs<InD, Reflections, InP>,
+    ) -> Result<(), ParameterValidationError>
+    where
+        InD: DirectCompatible<D> + SimulationFlagsProvider,
+        InP: PathingCompatible<P> + SimulationFlagsProvider,
+    {
+        self.set_inputs_subset::<InD, Reflections, InP>(inputs)
+    }
+
     /// Retrieves reflections simulation results for a source.
     ///
     /// Convenience method abstracting the more expressive [`Self::get_outputs_subset`].
@@ -1590,6 +1676,30 @@ where
     (): DirectCompatible<D>,
     (): ReflectionsCompatible<R>,
 {
+    /// Specifies pathing simulation parameters for a source.
+    ///
+    /// Convenience method abstracting the more expressive [`Self::set_inputs_subset`].
+    /// See the [module-level documentation](crate::simulation) for threading guidelines.
+    ///
+    /// # Arguments
+    ///
+    /// - `inputs`: the input parameters to set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParameterValidationError`] if any parameters exceed the maximums
+    /// set during simulator initialization.
+    pub fn set_pathing_inputs<InD, InR>(
+        &self,
+        inputs: &SimulationInputs<InD, InR, Pathing>,
+    ) -> Result<(), ParameterValidationError>
+    where
+        InD: DirectCompatible<D> + SimulationFlagsProvider,
+        InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
+    {
+        self.set_inputs_subset::<InD, InR, Pathing>(inputs)
+    }
+
     /// Retrieves pathing simulation results for a source.
     ///
     /// Convenience method abstracting the more expressive [`Self::get_outputs_subset`].
@@ -1630,21 +1740,6 @@ impl<D, R, P> Clone for Source<D, R, P> {
             _direct: PhantomData,
             _reflections: PhantomData,
             _pathing: PhantomData,
-        }
-    }
-}
-
-/// Settings used to create a source.
-#[derive(Copy, Clone, Debug)]
-pub struct SourceSettings {
-    /// The types of simulation that may be run for this source.
-    pub flags: SimulationFlags,
-}
-
-impl From<SourceSettings> for audionimbus_sys::IPLSourceSettings {
-    fn from(settings: SourceSettings) -> Self {
-        Self {
-            flags: settings.flags.into(),
         }
     }
 }
@@ -2705,62 +2800,6 @@ mod tests {
     mod source {
         use super::*;
 
-        mod set_inputs {
-            use super::*;
-
-            #[test]
-            #[should_panic(
-                expected = "requested simulation flags SimulationFlags(REFLECTIONS) are not enabled on this source (valid flags: SimulationFlags(DIRECT))"
-            )]
-            fn panic_on_invalid_flags() {
-                let context = Context::default();
-
-                const SAMPLING_RATE: u32 = 48_000;
-                const FRAME_SIZE: u32 = 1024;
-                const MAX_ORDER: u32 = 1;
-
-                let simulation_settings =
-                    SimulationSettings::new(SAMPLING_RATE, FRAME_SIZE, MAX_ORDER).with_direct(
-                        DirectSimulationSettings {
-                            max_num_occlusion_samples: 4,
-                        },
-                    );
-                let mut simulator = Simulator::try_new(&context, &simulation_settings).unwrap();
-
-                let scene = Scene::try_new(&context).unwrap();
-                simulator.set_scene(&scene);
-
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::DIRECT | SimulationFlags::REFLECTIONS,
-                };
-                let source =
-                    Source::<Direct, (), ()>::try_new(&simulator, source_settings).unwrap();
-
-                let simulation_inputs = SimulationInputs::new(CoordinateSystem {
-                    right: Vector3::new(1.0, 0.0, 0.0),
-                    up: Vector3::new(0.0, 1.0, 0.0),
-                    ahead: Vector3::new(0.0, 0.0, 1.0),
-                    origin: Vector3::new(0.0, 0.0, 0.0),
-                })
-                .with_direct(
-                    DirectSimulationParameters::new()
-                        .with_distance_attenuation(DistanceAttenuationModel::default())
-                        .with_air_absorption(AirAbsorptionModel::default())
-                        .with_directivity(Directivity::default())
-                        .with_occlusion(
-                            Occlusion::new(OcclusionAlgorithm::Raycast).with_transmission(
-                                TransmissionParameters {
-                                    num_transmission_rays: 1,
-                                },
-                            ),
-                        ),
-                );
-                source
-                    .set_inputs(SimulationFlags::REFLECTIONS, &simulation_inputs)
-                    .unwrap();
-            }
-        }
-
         mod clone {
             use super::*;
 
@@ -2769,10 +2808,7 @@ mod tests {
                 let context = Context::default();
                 let simulator_settings = SimulationSettings::new(48_000, 1024, 1);
                 let simulator = Simulator::try_new(&context, &simulator_settings).unwrap();
-                let source_settings = SourceSettings {
-                    flags: SimulationFlags::empty(),
-                };
-                let source = Source::<(), (), ()>::try_new(&simulator, source_settings).unwrap();
+                let source = Source::try_new(&simulator).unwrap();
                 let clone = source.clone();
                 assert_eq!(source.raw_ptr(), clone.raw_ptr());
                 drop(source);

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -463,11 +463,24 @@ where
     /// Only blocks for the requested simulation types, allowing concurrent setting of shared
     /// parameters across simulation threads.
     ///
-    /// For example, `set_shared_inputs_subset::<Direct, (), ()>()` and
-    /// `set_shared_inputs_subset::<(), Reflections, ()>()` can be called simultaneously without
-    /// blocking each other.
+    /// The last three generic parameters `InD`, `InR`, and `InP` can be inferred from the
+    /// `shared_inputs` argument using `_`.
     ///
-    /// MUST NOT be called from a real-time audio thread.
+    /// Also see:
+    /// - [`Self::set_shared_direct_inputs`]
+    /// - [`Self::set_shared_reflections_inputs`]
+    /// - [`Self::set_shared_pathing_inputs`]
+    ///
+    /// # Threading Considerations
+    ///
+    /// This method will block if a simulation is currently running for the
+    /// specified type(s).
+    /// Call this from the same thread that runs the corresponding simulation(s) to avoid blocking.
+    ///
+    /// It is safe to call this method concurrently with simulations of different types.
+    /// For example, setting `DIRECT` shared inputs while a `REFLECTIONS` simulation is running
+    /// will not block.
+    ///
     /// See the [module-level documentation](crate::simulation) for threading guidelines.
     ///
     /// # Examples

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -421,9 +421,9 @@ where
         shared_inputs: &SimulationSharedInputs<InD, InR, InP>,
     ) -> Result<(), ParameterValidationError>
     where
-        D: DirectCompatible<D> + DirectCompatible<InD> + SimulationFlagsProvider,
+        D: DirectCompatible<D> + SimulationFlagsProvider,
         R: ReflectionsCompatible<R> + ReflectionsCompatible<InR> + SimulationFlagsProvider,
-        P: PathingCompatible<P> + PathingCompatible<InP> + SimulationFlagsProvider,
+        P: PathingCompatible<P> + SimulationFlagsProvider,
         InD: DirectCompatible<D> + SimulationFlagsProvider,
         InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
         InP: PathingCompatible<P> + SimulationFlagsProvider,
@@ -453,12 +453,17 @@ where
     /// simulator initialization.
     pub fn set_shared_inputs_subset<SubD, SubR, SubP, InD, InR, InP>(
         &self,
+        // `InD` and `InP` are intentionally loosely constrained here.
+        // `SimulationSharedInputs` does not contain any Direct- or Pathing-specific data.
+        // Allowing arbitrary `InD` and `InP` avoids forcing callers to construct a value via
+        // `SimulationSharedInputs::with_direct` and `SimulationSharedInputs::with_pathing`, which
+        // would add unnecessary boilerplate with no semantic benefit.
         shared_inputs: &SimulationSharedInputs<InD, InR, InP>,
     ) -> Result<(), ParameterValidationError>
     where
-        SubD: DirectCompatible<D> + DirectCompatible<InD> + SimulationFlagsProvider,
+        SubD: DirectCompatible<D> + SimulationFlagsProvider,
         SubR: ReflectionsCompatible<R> + ReflectionsCompatible<InR> + SimulationFlagsProvider,
-        SubP: PathingCompatible<P> + PathingCompatible<InP> + SimulationFlagsProvider,
+        SubP: PathingCompatible<P> + SimulationFlagsProvider,
         InD: DirectCompatible<D> + SimulationFlagsProvider,
         InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
         InP: PathingCompatible<P> + SimulationFlagsProvider,
@@ -576,17 +581,18 @@ where
     ///
     /// Returns [`ParameterValidationError`] if any parameters exceed the maximums set during
     /// simulator initialization.
-    pub fn set_shared_direct_inputs<InR, InP>(
+    pub fn set_shared_direct_inputs<InD, InR, InP>(
         &self,
-        shared_inputs: &SimulationSharedInputs<Direct, InR, InP>,
+        shared_inputs: &SimulationSharedInputs<InD, InR, InP>,
     ) -> Result<(), ParameterValidationError>
     where
+        InD: DirectCompatible<Direct> + SimulationFlagsProvider,
         InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
         InP: PathingCompatible<P> + SimulationFlagsProvider,
         (): ReflectionsCompatible<R> + ReflectionsCompatible<InR>,
         (): PathingCompatible<P> + PathingCompatible<InP>,
     {
-        self.set_shared_inputs_subset::<Direct, (), (), Direct, InR, InP>(shared_inputs)
+        self.set_shared_inputs_subset::<Direct, (), (), InD, InR, InP>(shared_inputs)
     }
 
     /// Runs a direct simulation for all sources added to the simulator.
@@ -697,17 +703,18 @@ where
     ///
     /// Returns [`ParameterValidationError`] if any parameters exceed the maximums set during
     /// simulator initialization.
-    pub fn set_shared_pathing_inputs<InD, InR>(
+    pub fn set_shared_pathing_inputs<InD, InR, InP>(
         &self,
-        shared_inputs: &SimulationSharedInputs<InD, InR, Pathing>,
+        shared_inputs: &SimulationSharedInputs<InD, InR, InP>,
     ) -> Result<(), ParameterValidationError>
     where
         InD: DirectCompatible<D> + SimulationFlagsProvider,
         InR: ReflectionsCompatible<R> + SimulationFlagsProvider,
+        InP: PathingCompatible<Pathing> + SimulationFlagsProvider,
         (): DirectCompatible<D> + DirectCompatible<InD>,
         (): ReflectionsCompatible<R> + ReflectionsCompatible<InR>,
     {
-        self.set_shared_inputs_subset::<(), (), Pathing, InD, InR, Pathing>(shared_inputs)
+        self.set_shared_inputs_subset::<(), (), Pathing, InD, InR, InP>(shared_inputs)
     }
 
     /// Runs a pathing simulation for all sources added to the simulator.

--- a/audionimbus/tests/effect.rs
+++ b/audionimbus/tests/effect.rs
@@ -288,10 +288,7 @@ fn test_pathing() {
         .bake(&context, &mut pathing_probes, &scene, path_bake_params)
         .unwrap();
 
-    let source_settings = SourceSettings {
-        flags: SimulationFlags::PATHING,
-    };
-    let source = Source::try_new(&simulator, source_settings).unwrap();
+    let source = Source::try_new(&simulator).unwrap();
     let simulation_inputs = SimulationInputs::new(CoordinateSystem::default())
         .with_direct(
             DirectSimulationParameters::new()
@@ -319,9 +316,7 @@ fn test_pathing() {
             find_alternate_paths: true,
             deviation: DeviationModel::default(),
         });
-    source
-        .set_inputs(SimulationFlags::PATHING, &simulation_inputs)
-        .unwrap();
+    source.set_pathing_inputs(&simulation_inputs).unwrap();
     simulator.add_source(&source);
 
     simulator.commit();

--- a/audionimbus/tests/simulation.rs
+++ b/audionimbus/tests/simulation.rs
@@ -31,10 +31,7 @@ fn test_simulation() {
     let scene = Scene::try_new(&context).unwrap();
     simulator.set_scene(&scene);
 
-    let source_settings = SourceSettings {
-        flags: SimulationFlags::DIRECT | SimulationFlags::REFLECTIONS,
-    };
-    let source = Source::try_new(&simulator, source_settings).unwrap();
+    let source = Source::try_new(&simulator).unwrap();
 
     let pathing_probes = ProbeBatch::try_new(&context).unwrap();
     let simulation_inputs = SimulationInputs::new(CoordinateSystem {
@@ -69,9 +66,7 @@ fn test_simulation() {
         find_alternate_paths: true,
         deviation: DeviationModel::default(),
     });
-    source
-        .set_inputs(SimulationFlags::DIRECT, &simulation_inputs)
-        .unwrap();
+    source.set_direct_inputs(&simulation_inputs).unwrap();
 
     simulator.add_source(&source);
 
@@ -215,10 +210,7 @@ fn test_pathing_without_probes() {
         .bake(&context, &mut pathing_probes, &scene, path_bake_params)
         .unwrap();
 
-    let source_settings = SourceSettings {
-        flags: SimulationFlags::PATHING,
-    };
-    let source = Source::try_new(&simulator, source_settings).unwrap();
+    let source = Source::try_new(&simulator).unwrap();
     let simulation_inputs = SimulationInputs::new(CoordinateSystem::default())
         .with_direct(
             DirectSimulationParameters::new()
@@ -246,9 +238,7 @@ fn test_pathing_without_probes() {
             find_alternate_paths: true,
             deviation: DeviationModel::default(),
         });
-    source
-        .set_inputs(SimulationFlags::PATHING, &simulation_inputs)
-        .unwrap();
+    source.set_pathing_inputs(&simulation_inputs).unwrap();
     simulator.add_source(&source);
 
     simulator.commit();

--- a/audionimbus/tests/simulation.rs
+++ b/audionimbus/tests/simulation.rs
@@ -79,10 +79,7 @@ fn test_simulation() {
             irradiance_min_distance: 1.0,
         });
     simulator
-        .set_shared_inputs(
-            SimulationFlags::DIRECT | SimulationFlags::REFLECTIONS,
-            &simulation_shared_inputs,
-        )
+        .set_shared_inputs(&simulation_shared_inputs)
         .unwrap();
 
     simulator.commit();
@@ -274,7 +271,7 @@ fn test_reflections_without_scene() {
             irradiance_min_distance: 1.0,
         });
     simulator
-        .set_shared_inputs(SimulationFlags::REFLECTIONS, &simulation_shared_inputs)
+        .set_shared_reflections_inputs(&simulation_shared_inputs)
         .unwrap();
 
     simulator.commit();


### PR DESCRIPTION
Following #55, this PR applies the same pattern to the remaining APIs that still took `SimulationFlags` at runtime.

`Source::set_inputs` and `Simulator::set_shared_inputs` no longer take a `SimulationFlags` argument. The flags are derived from the type parameters. `set_shared_inputs_subset` allow acquiring locks for only the requested simulation types, enabling inputs to be set from separate threads without blocking each other.

`Source::try_new` no longer takes `SourceSettings`. The simulation flags are derived from the source's type parameters. For instance, constructing a `SourceSettings { flags: SimulationFlags::REFLECTIONS }` that disagrees with `Source<(), Reflections, ()>` is no longer possible.

#### Added

- `Source::set_inputs_subset`, `set_direct_inputs`, `set_reflections_inputs`, `set_pathing_inputs`
- `Simulator::set_shared_inputs_subset`, `set_shared_direct_inputs`, `set_shared_reflections_inputs`, `set_shared_pathing_inputs`
- `Source::try_new_subset` for creating a source that runs a subset of its simulator's simulations

#### Removed

- `SourceSettings`: flags are now derived from type parameters
- Removed the runtime panic in `Source::set_inputs` on invalid flags