### PR TITLE
Prevent concurrent scene commit and simulations across scene hierarchies

### DIFF
--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `SpeakerLayout::Custom` FFI conversion: speaker directions are now guaranteed to remain valid for the duration of any FFI call.
+- `Simulator::set_scene`, `add_probe_batch`, `remove_probe_batch`, and `commit` now acquire all active simulation locks before mutating simulator state.
 
 ### Changed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -79,6 +79,7 @@
 - Implement `Copy`, `Clone` for `SimulationError`.
 - Implement `Copy` for `ParameterValidationError`.
 - Implement `Clone` for `Spatialization`, `PathEffectSettings`, `VirtualSurroundEffectSettings`, `VirtualSurroundEffectParams`, `AmbisonicsBinauralEffectSettings`, `AmbisonicsBinauralEffectParams`, `AmbisonicsDecodeEffectSettings`, `AmbisonicsDecodeEffectParams` and `ReconstructorInputs`.
+- Implement `PartialEq`, `Eq` for `Scene`.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -79,7 +79,7 @@
 - Implement `Copy`, `Clone` for `SimulationError`.
 - Implement `Copy` for `ParameterValidationError`.
 - Implement `Clone` for `Spatialization`, `PathEffectSettings`, `VirtualSurroundEffectSettings`, `VirtualSurroundEffectParams`, `AmbisonicsBinauralEffectSettings`, `AmbisonicsBinauralEffectParams`, `AmbisonicsDecodeEffectSettings`, `AmbisonicsDecodeEffectParams` and `ReconstructorInputs`.
-- Implement `PartialEq`, `Eq` for `Scene`.
+- Implement `PartialEq`, `Eq` and `Hash` for `Scene`.
 
 ### Removed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `SpeakerLayout::Custom` FFI conversion: speaker directions are now guaranteed to remain valid for the duration of any FFI call.
 - `Simulator::set_scene`, `add_probe_batch`, `remove_probe_batch`, and `commit` now acquire all active simulation locks before mutating simulator state.
+- `InstancedMesh` now retains its sub-scene handle, keeping the sub-scene alive for the lifetime of the instanced mesh.
 
 ### Changed
 

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - `SpeakerLayout::Custom` FFI conversion: speaker directions are now guaranteed to remain valid for the duration of any FFI call.
 - `Simulator::set_scene`, `add_probe_batch`, `remove_probe_batch`, and `commit` now acquire all active simulation locks before mutating simulator state.
+- Scene commit locking now propagates across instanced sub-scene hierarchies, and removed sub-scenes remain registered with simulators until `Scene::commit` completes.
+- `Simulator::set_scene` now tracks pending and committed scenes separately, keeping the previous scene's simulator registrations alive until `Simulator::commit` and treating redundant scene assignments as no-ops.
 - `InstancedMesh` now retains its sub-scene handle, keeping the sub-scene alive for the lifetime of the instanced mesh.
 
 ### Changed

--- a/audionimbus/CHANGELOG.md
+++ b/audionimbus/CHANGELOG.md
@@ -81,7 +81,7 @@
 - Implement `Copy`, `Clone` for `SimulationError`.
 - Implement `Copy` for `ParameterValidationError`.
 - Implement `Clone` for `Spatialization`, `PathEffectSettings`, `VirtualSurroundEffectSettings`, `VirtualSurroundEffectParams`, `AmbisonicsBinauralEffectSettings`, `AmbisonicsBinauralEffectParams`, `AmbisonicsDecodeEffectSettings`, `AmbisonicsDecodeEffectParams` and `ReconstructorInputs`.
-- Implement `PartialEq`, `Eq` and `Hash` for `Scene`.
+- Implement `PartialEq`, `Eq` and `Hash` for `Scene` and `Simulator`.
 
 ### Removed
 

--- a/audionimbus/src/geometry/instanced_mesh.rs
+++ b/audionimbus/src/geometry/instanced_mesh.rs
@@ -15,8 +15,9 @@ use std::marker::PhantomData;
 /// incrementing a reference count.
 /// The underlying object is destroyed when all handles are dropped.
 #[derive(Debug)]
-pub struct InstancedMesh<T> {
+pub struct InstancedMesh<T: RayTracer = DefaultRayTracer> {
     inner: audionimbus_sys::IPLInstancedMesh,
+    pub(crate) sub_scene: Scene<T>,
     _marker: PhantomData<T>,
 }
 
@@ -51,6 +52,7 @@ impl<T: RayTracer> InstancedMesh<T> {
 
         let instanced_mesh = Self {
             inner,
+            sub_scene: settings.sub_scene.clone(),
             _marker: PhantomData,
         };
 
@@ -72,7 +74,7 @@ impl<T: RayTracer> InstancedMesh<T> {
     }
 }
 
-impl<T> Drop for InstancedMesh<T> {
+impl<T: RayTracer> Drop for InstancedMesh<T> {
     fn drop(&mut self) {
         unsafe { audionimbus_sys::iplInstancedMeshRelease(&raw mut self.inner) }
     }
@@ -89,6 +91,7 @@ impl<T: RayTracer> Clone for InstancedMesh<T> {
         // SAFETY: The instanced mesh will not be destroyed until all references are released.
         Self {
             inner: unsafe { audionimbus_sys::iplInstancedMeshRetain(self.inner) },
+            sub_scene: self.sub_scene.clone(),
             _marker: PhantomData,
         }
     }

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -853,6 +853,14 @@ impl<T: RayTracer> Clone for Scene<T> {
     }
 }
 
+impl<T: RayTracer> PartialEq for Scene<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw_ptr() == other.raw_ptr()
+    }
+}
+
+impl Eq for Scene {}
+
 /// Calculates the relative direction from the listener to a sound source.
 ///
 /// The returned direction vector is expressed in the listener’s coordinate system.

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -12,7 +12,7 @@ use crate::ray_tracing::{
 use crate::serialized_object::SerializedObject;
 use slotmap::{DefaultKey, SlotMap};
 use std::marker::PhantomData;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 /// Marker trait for scenes that can use `save()`.
 pub trait SaveableAsSerialized: Sealed {}
@@ -36,13 +36,13 @@ impl SaveableAsObj for Embree {}
 #[derive(Debug)]
 pub struct Scene<T: RayTracer = DefaultRayTracer> {
     inner: audionimbus_sys::IPLScene,
-    shared: Arc<Mutex<SceneShared<T>>>,
+    pub(crate) shared: Arc<Mutex<SceneShared<T>>>,
     _marker: PhantomData<T>,
 }
 
 /// Shared ownership of [`Scene`] data across clones.
 #[derive(Debug)]
-struct SceneShared<T: RayTracer> {
+pub(crate) struct SceneShared<T: RayTracer> {
     /// Used to keep static meshes alive for the lifetime of the scene.
     static_meshes: SlotMap<DefaultKey, StaticMesh<T>>,
 
@@ -54,6 +54,9 @@ struct SceneShared<T: RayTracer> {
 
     /// Instanced meshes to be dropped by the next call to [`Self::commit`].
     instanced_meshes_to_remove: Vec<InstancedMesh<T>>,
+
+    /// Locks aquired during [`Scene::commit`] to prevent concurrent simulation access.
+    pub(crate) simulation_locks: Vec<Arc<Mutex<()>>>,
 
     /// Keeps the device alive for the lifetime of the scene.
     _device: T::Device,
@@ -69,6 +72,7 @@ impl<T: RayTracer> SceneShared<T> {
             instanced_meshes: SlotMap::new(),
             static_meshes_to_remove: Vec::new(),
             instanced_meshes_to_remove: Vec::new(),
+            simulation_locks: Vec::new(),
             _device: device,
             _callback_user_data: callback_user_data,
         }
@@ -759,11 +763,20 @@ impl<T: RayTracer> Scene<T> {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn commit(&mut self) {
+        let mut shared = self.shared.lock().unwrap();
+
+        let _guards: Vec<MutexGuard<'_, ()>> = shared
+            .simulation_locks
+            .iter()
+            .map(|lock| lock.lock().unwrap())
+            .collect();
+
         unsafe {
             audionimbus_sys::iplSceneCommit(self.raw_ptr());
         }
 
-        let mut shared = self.shared.lock().unwrap();
+        drop(_guards);
+
         shared.static_meshes_to_remove.clear();
         shared.instanced_meshes_to_remove.clear();
     }

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -11,6 +11,7 @@ use crate::ray_tracing::{
 };
 use crate::serialized_object::SerializedObject;
 use slotmap::{DefaultKey, SlotMap};
+use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -860,6 +861,12 @@ impl<T: RayTracer> PartialEq for Scene<T> {
 }
 
 impl Eq for Scene {}
+
+impl<T: RayTracer> Hash for Scene<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::ptr::hash(self.raw_ptr(), state);
+    }
+}
 
 /// Calculates the relative direction from the listener to a sound source.
 ///

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -853,7 +853,8 @@ impl<T: RayTracer> Scene<T> {
     ///
     /// For best performance, call this function once after all changes have been made for a given frame.
     ///
-    /// This function cannot be called concurrently with any simulation functions.
+    /// This function cannot be called while any simulation that uses this scene hierarchy is
+    /// running. Either will block until the other finishes.
     ///
     /// # Example
     ///

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -1,19 +1,19 @@
-use super::{InstancedMesh, Matrix, StaticMesh};
 use crate::Sealed;
 use crate::callback::{CustomRayTracingCallbacks, ProgressCallback};
 use crate::context::Context;
 use crate::device::embree::EmbreeDevice;
 use crate::device::radeon_rays::RadeonRaysDevice;
 use crate::error::{SteamAudioError, to_option_error};
-use crate::geometry::{Direction, Point};
+use crate::geometry::{Direction, InstancedMesh, Matrix, Point, StaticMesh};
 use crate::ray_tracing::{
     CustomCallbackUserData, CustomRayTracer, DefaultRayTracer, Embree, RadeonRays, RayTracer,
 };
 use crate::serialized_object::SerializedObject;
 use slotmap::{DefaultKey, SlotMap};
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
 
 /// Marker trait for scenes that can use `save()`.
 pub trait SaveableAsSerialized: Sealed {}
@@ -41,6 +41,16 @@ pub struct Scene<T: RayTracer = DefaultRayTracer> {
     _marker: PhantomData<T>,
 }
 
+/// Simulator-specific registration state for a scene hierarchy.
+#[derive(Clone, Debug)]
+pub(crate) struct SceneSimulationRegistration {
+    /// The simulation locks that must be held while committing this scene.
+    pub(crate) locks: Vec<Arc<Mutex<()>>>,
+
+    /// Number of references from this simulator into this scene subtree.
+    pub(crate) ref_count: usize,
+}
+
 /// Shared ownership of [`Scene`] data across clones.
 #[derive(Debug)]
 pub(crate) struct SceneShared<T: RayTracer> {
@@ -56,8 +66,8 @@ pub(crate) struct SceneShared<T: RayTracer> {
     /// Instanced meshes to be dropped by the next call to [`Self::commit`].
     instanced_meshes_to_remove: Vec<InstancedMesh<T>>,
 
-    /// Locks aquired during [`Scene::commit`] to prevent concurrent simulation access.
-    pub(crate) simulation_locks: Vec<Arc<Mutex<()>>>,
+    /// Simulator registrations that currently require this scene to block commits.
+    simulation_registrations: HashMap<audionimbus_sys::IPLSimulator, SceneSimulationRegistration>,
 
     /// Keeps the device alive for the lifetime of the scene.
     _device: T::Device,
@@ -67,16 +77,54 @@ pub(crate) struct SceneShared<T: RayTracer> {
 }
 
 impl<T: RayTracer> SceneShared<T> {
+    /// Creates empty shared scene state.
     fn new(device: T::Device, callback_user_data: T::CallbackUserData) -> Self {
         Self {
             static_meshes: SlotMap::new(),
             instanced_meshes: SlotMap::new(),
             static_meshes_to_remove: Vec::new(),
             instanced_meshes_to_remove: Vec::new(),
-            simulation_locks: Vec::new(),
+            simulation_registrations: HashMap::new(),
             _device: device,
             _callback_user_data: callback_user_data,
         }
+    }
+
+    /// Returns handles to all sub-scenes reachable from this scene.
+    ///
+    /// Scenes from pending removals are included.
+    fn sub_scenes(&self) -> Vec<Scene<T>> {
+        self.instanced_meshes
+            .values()
+            .map(|mesh| mesh.sub_scene.clone())
+            .chain(
+                self.instanced_meshes_to_remove
+                    .iter()
+                    .map(|mesh| mesh.sub_scene.clone()),
+            )
+            .collect()
+    }
+
+    /// Returns clones of the simulator registrations for this scene.
+    fn registration_snapshots(
+        &self,
+    ) -> Vec<(audionimbus_sys::IPLSimulator, SceneSimulationRegistration)> {
+        self.simulation_registrations
+            .iter()
+            .map(|(simulator, registration)| (*simulator, registration.clone()))
+            .collect()
+    }
+
+    /// Collects all registered simulation locks, sorted and deduplicated by pointer.
+    fn simulation_locks(&self) -> Vec<Arc<Mutex<()>>> {
+        let mut locks: Vec<_> = self
+            .simulation_registrations
+            .values()
+            .flat_map(|registration| registration.locks.iter().cloned())
+            .collect();
+        locks.sort_unstable_by_key(|lock| Arc::as_ptr(lock) as usize);
+        locks.dedup_by_key(|lock| Arc::as_ptr(lock) as usize);
+        locks
     }
 }
 
@@ -147,6 +195,65 @@ impl<T: RayTracer> Scene<T> {
         }
 
         Ok(scene)
+    }
+
+    /// Registers a simulator with this scene and all reachable sub-scenes.
+    pub(crate) fn register_simulator(
+        &self,
+        simulator: audionimbus_sys::IPLSimulator,
+        locks: &[Arc<Mutex<()>>],
+        count: usize,
+    ) {
+        if count == 0 {
+            return;
+        }
+
+        let sub_scenes = {
+            let mut shared = self.shared.lock().unwrap();
+            shared
+                .simulation_registrations
+                .entry(simulator)
+                .and_modify(|registration| registration.ref_count += count)
+                .or_insert_with(|| SceneSimulationRegistration {
+                    locks: locks.to_vec(),
+                    ref_count: count,
+                });
+            shared.sub_scenes()
+        };
+
+        for sub_scene in sub_scenes {
+            sub_scene.register_simulator(simulator, locks, count);
+        }
+    }
+
+    /// Unregisters a simulator from this scene and all reachable sub-scenes.
+    pub(crate) fn unregister_simulator(
+        &self,
+        simulator: audionimbus_sys::IPLSimulator,
+        count: usize,
+    ) {
+        if count == 0 {
+            return;
+        }
+
+        let sub_scenes = {
+            let mut shared = self.shared.lock().unwrap();
+            let Some(registration) = shared.simulation_registrations.get_mut(&simulator) else {
+                return;
+            };
+
+            if registration.ref_count <= count {
+                shared.simulation_registrations.remove(&simulator);
+            } else {
+                registration.ref_count -= count;
+            }
+
+            shared.sub_scenes()
+        };
+
+        for sub_scene in sub_scenes {
+            sub_scene.unregister_simulator(simulator, count);
+        }
     }
 }
 
@@ -586,8 +693,17 @@ impl<T: RayTracer> Scene<T> {
             audionimbus_sys::iplInstancedMeshAdd(instanced_mesh.raw_ptr(), self.raw_ptr());
         }
 
-        let mut shared = self.shared.lock().unwrap();
-        let key = shared.instanced_meshes.insert(instanced_mesh);
+        let sub_scene = instanced_mesh.sub_scene.clone();
+        let (key, registrations) = {
+            let mut shared = self.shared.lock().unwrap();
+            let key = shared.instanced_meshes.insert(instanced_mesh);
+            (key, shared.registration_snapshots())
+        };
+
+        for (simulator, registration) in registrations {
+            sub_scene.register_simulator(simulator, &registration.locks, registration.ref_count);
+        }
+
         InstancedMeshHandle(key)
     }
 
@@ -764,22 +880,38 @@ impl<T: RayTracer> Scene<T> {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn commit(&mut self) {
-        let mut shared = self.shared.lock().unwrap();
+        let locks = {
+            let shared = self.shared.lock().unwrap();
+            shared.simulation_locks()
+        };
 
-        let _guards: Vec<MutexGuard<'_, ()>> = shared
-            .simulation_locks
+        let _guards = locks
             .iter()
             .map(|lock| lock.lock().unwrap())
-            .collect();
+            .collect::<Vec<_>>();
 
         unsafe {
             audionimbus_sys::iplSceneCommit(self.raw_ptr());
         }
 
-        drop(_guards);
+        let (removed_sub_scenes, registrations) = {
+            let mut shared = self.shared.lock().unwrap();
+            let removed_sub_scenes = shared
+                .instanced_meshes_to_remove
+                .iter()
+                .map(|mesh| mesh.sub_scene.clone())
+                .collect::<Vec<_>>();
+            let registrations = shared.registration_snapshots();
+            shared.static_meshes_to_remove.clear();
+            shared.instanced_meshes_to_remove.clear();
+            (removed_sub_scenes, registrations)
+        };
 
-        shared.static_meshes_to_remove.clear();
-        shared.instanced_meshes_to_remove.clear();
+        for removed_sub_scene in removed_sub_scenes {
+            for (simulator, registration) in &registrations {
+                removed_sub_scene.unregister_simulator(*simulator, registration.ref_count);
+            }
+        }
     }
 
     /// Returns the raw FFI pointer to the underlying scene.
@@ -996,9 +1128,29 @@ pub struct InstancedMeshHandle(DefaultKey);
 mod tests {
     use super::*;
     use crate::{
-        AnyHitCallback, BatchedAnyHitCallback, BatchedClosestHitCallback, ClosestHitCallback,
-        CustomRayTracingCallbacks, Vector3,
+        AnyHitCallback, AudioSettings, BatchedAnyHitCallback, BatchedClosestHitCallback,
+        ClosestHitCallback, CustomRayTracingCallbacks, Direct, DirectSimulationSettings,
+        InstancedMesh, InstancedMeshSettings, Matrix4, SimulationSettings, Simulator, Vector3,
     };
+
+    fn registration_ref_count<D, R, P, RE>(
+        scene: &Scene<DefaultRayTracer>,
+        simulator: &Simulator<DefaultRayTracer, D, R, P, RE>,
+    ) -> usize
+    where
+        D: 'static,
+        R: 'static,
+        P: 'static,
+        RE: 'static,
+    {
+        scene
+            .shared
+            .lock()
+            .unwrap()
+            .simulation_registrations
+            .get(&simulator.raw_ptr())
+            .map_or(0, |registration| registration.ref_count)
+    }
 
     #[test]
     fn test_default_scene() {
@@ -1065,5 +1217,143 @@ mod tests {
         assert_eq!(scene.raw_ptr(), clone.raw_ptr());
         drop(scene);
         assert!(!clone.raw_ptr().is_null());
+    }
+
+    #[test]
+    fn test_add_instanced_mesh_propagates_existing_simulator_registration() {
+        let context = Context::default();
+        let audio_settings = AudioSettings::default();
+        let settings =
+            SimulationSettings::new(&audio_settings).with_direct(DirectSimulationSettings {
+                max_num_occlusion_samples: 4,
+            });
+        let mut simulator: Simulator<DefaultRayTracer, Direct, (), (), ()> =
+            Simulator::try_new(&context, &settings).unwrap();
+        let mut root_scene = Scene::try_new(&context).unwrap();
+        let sub_scene = Scene::try_new(&context).unwrap();
+
+        simulator.set_scene(&root_scene);
+        simulator.commit();
+
+        let instanced_mesh = InstancedMesh::try_new(
+            &root_scene,
+            &InstancedMeshSettings {
+                sub_scene: sub_scene.clone(),
+                transform: Matrix4::IDENTITY,
+            },
+        )
+        .unwrap();
+        root_scene.add_instanced_mesh(instanced_mesh);
+
+        assert_eq!(registration_ref_count(&sub_scene, &simulator), 1);
+    }
+
+    #[test]
+    fn test_shared_sub_scene_registration_ref_count_tracks_instances() {
+        let context = Context::default();
+        let audio_settings = AudioSettings::default();
+        let settings =
+            SimulationSettings::new(&audio_settings).with_direct(DirectSimulationSettings {
+                max_num_occlusion_samples: 4,
+            });
+        let mut simulator: Simulator<DefaultRayTracer, Direct, (), (), ()> =
+            Simulator::try_new(&context, &settings).unwrap();
+        let mut root_scene = Scene::try_new(&context).unwrap();
+        let shared_sub_scene = Scene::try_new(&context).unwrap();
+
+        let first_mesh = InstancedMesh::try_new(
+            &root_scene,
+            &InstancedMeshSettings {
+                sub_scene: shared_sub_scene.clone(),
+                transform: Matrix4::IDENTITY,
+            },
+        )
+        .unwrap();
+        let first_handle = root_scene.add_instanced_mesh(first_mesh);
+
+        let second_mesh = InstancedMesh::try_new(
+            &root_scene,
+            &InstancedMeshSettings {
+                sub_scene: shared_sub_scene.clone(),
+                transform: Matrix4::IDENTITY,
+            },
+        )
+        .unwrap();
+        let second_handle = root_scene.add_instanced_mesh(second_mesh);
+
+        root_scene.commit();
+
+        simulator.set_scene(&root_scene);
+        simulator.commit();
+
+        assert_eq!(registration_ref_count(&shared_sub_scene, &simulator), 2);
+
+        assert!(root_scene.remove_instanced_mesh(first_handle));
+        assert_eq!(registration_ref_count(&shared_sub_scene, &simulator), 2);
+
+        root_scene.commit();
+        assert_eq!(registration_ref_count(&shared_sub_scene, &simulator), 1);
+
+        assert!(root_scene.remove_instanced_mesh(second_handle));
+        root_scene.commit();
+        assert_eq!(registration_ref_count(&shared_sub_scene, &simulator), 0);
+    }
+
+    #[test]
+    fn test_simulator_commit_switches_scene_registrations_across_sub_scene_hierarchies() {
+        let context = Context::default();
+        let audio_settings = AudioSettings::default();
+        let settings =
+            SimulationSettings::new(&audio_settings).with_direct(DirectSimulationSettings {
+                max_num_occlusion_samples: 4,
+            });
+        let mut simulator: Simulator<DefaultRayTracer, Direct, (), (), ()> =
+            Simulator::try_new(&context, &settings).unwrap();
+
+        let mut old_root_scene = Scene::try_new(&context).unwrap();
+        let old_sub_scene = Scene::try_new(&context).unwrap();
+        let old_instanced_mesh = InstancedMesh::try_new(
+            &old_root_scene,
+            &InstancedMeshSettings {
+                sub_scene: old_sub_scene.clone(),
+                transform: Matrix4::IDENTITY,
+            },
+        )
+        .unwrap();
+        old_root_scene.add_instanced_mesh(old_instanced_mesh);
+        old_root_scene.commit();
+
+        let mut new_root_scene = Scene::try_new(&context).unwrap();
+        let new_sub_scene = Scene::try_new(&context).unwrap();
+        let new_instanced_mesh = InstancedMesh::try_new(
+            &new_root_scene,
+            &InstancedMeshSettings {
+                sub_scene: new_sub_scene.clone(),
+                transform: Matrix4::IDENTITY,
+            },
+        )
+        .unwrap();
+        new_root_scene.add_instanced_mesh(new_instanced_mesh);
+        new_root_scene.commit();
+
+        simulator.set_scene(&old_root_scene);
+        assert_eq!(registration_ref_count(&old_root_scene, &simulator), 1);
+        assert_eq!(registration_ref_count(&old_sub_scene, &simulator), 1);
+
+        simulator.commit();
+        assert_eq!(registration_ref_count(&old_root_scene, &simulator), 1);
+        assert_eq!(registration_ref_count(&old_sub_scene, &simulator), 1);
+
+        simulator.set_scene(&new_root_scene);
+        assert_eq!(registration_ref_count(&old_root_scene, &simulator), 1);
+        assert_eq!(registration_ref_count(&old_sub_scene, &simulator), 1);
+        assert_eq!(registration_ref_count(&new_root_scene, &simulator), 1);
+        assert_eq!(registration_ref_count(&new_sub_scene, &simulator), 1);
+
+        simulator.commit();
+        assert_eq!(registration_ref_count(&old_root_scene, &simulator), 0);
+        assert_eq!(registration_ref_count(&old_sub_scene, &simulator), 0);
+        assert_eq!(registration_ref_count(&new_root_scene, &simulator), 1);
+        assert_eq!(registration_ref_count(&new_sub_scene, &simulator), 1);
     }
 }

--- a/audionimbus/src/geometry/scene.rs
+++ b/audionimbus/src/geometry/scene.rs
@@ -860,7 +860,7 @@ impl<T: RayTracer> PartialEq for Scene<T> {
     }
 }
 
-impl Eq for Scene {}
+impl<T: RayTracer> Eq for Scene<T> {}
 
 impl<T: RayTracer> Hash for Scene<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -56,6 +56,7 @@ use crate::model::distance_attenuation::DistanceAttenuationModel;
 use crate::probe::ProbeBatch;
 use crate::ray_tracing::{CustomRayTracer, DefaultRayTracer, Embree, RadeonRays, RayTracer};
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -978,6 +979,42 @@ where
             _pathing: PhantomData,
             _reflection_effect: PhantomData,
         }
+    }
+}
+
+impl<T, D, R, P, RE> PartialEq for Simulator<T, D, R, P, RE>
+where
+    T: RayTracer,
+    D: 'static,
+    R: 'static,
+    P: 'static,
+    RE: 'static,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.raw_ptr() == other.raw_ptr()
+    }
+}
+
+impl<T, D, R, P, RE> Eq for Simulator<T, D, R, P, RE>
+where
+    T: RayTracer,
+    D: 'static,
+    R: 'static,
+    P: 'static,
+    RE: 'static,
+{
+}
+
+impl<T, D, R, P, RE> Hash for Simulator<T, D, R, P, RE>
+where
+    T: RayTracer,
+    D: 'static,
+    R: 'static,
+    P: 'static,
+    RE: 'static,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::ptr::hash(self.raw_ptr(), state);
     }
 }
 

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -323,7 +323,8 @@ where
     ///
     /// Call [`Self::commit`] after calling this function for the changes to take effect.
     ///
-    /// This function cannot be called while any simulation is running.
+    /// This function cannot be called while any simulation is running. Either will block until the
+    /// other finishes.
     pub fn set_scene(&mut self, scene: &Scene<T>) {
         let _guards = self.acquire_all_locks();
 
@@ -357,7 +358,8 @@ where
     ///
     /// Call [`Self::commit`] after calling this function for the changes to take effect.
     ///
-    /// This function cannot be called while any simulation is running.
+    /// This function cannot be called while any simulation is running. Either will block until the
+    /// other finishes.
     pub fn add_probe_batch(&mut self, probe_batch: &ProbeBatch) {
         let _guards = self.acquire_all_locks();
         let raw_ptr = probe_batch.raw_ptr();
@@ -377,7 +379,8 @@ where
     ///
     /// Call [`Self::commit`] after calling this function for the changes to take effect.
     ///
-    /// This function cannot be called while any simulation is running.
+    /// This function cannot be called while any simulation is running. Either will block until the
+    /// other finishes.
     pub fn remove_probe_batch(&mut self, probe_batch: &ProbeBatch) {
         let _guards = self.acquire_all_locks();
         let raw_ptr = probe_batch.raw_ptr();
@@ -424,7 +427,8 @@ where
     ///
     /// Call this function after calling [`Self::set_scene`], [`Self::add_probe_batch`], or [`Self::remove_probe_batch`] for the changes to take effect.
     ///
-    /// This function cannot be called while any simulation is running.
+    /// This function cannot be called while any simulation is running. Either will block until the
+    /// other finishes.
     pub fn commit(&mut self) {
         let _guards = self.acquire_all_locks();
         let simulator = self.raw_ptr();

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -314,8 +314,22 @@ where
     /// This function cannot be called while any simulation is running.
     pub fn set_scene(&mut self, scene: &Scene<T>) {
         unsafe { audionimbus_sys::iplSimulatorSetScene(self.raw_ptr(), scene.raw_ptr()) }
-        let mut shared = self.shared.lock().unwrap();
-        shared.has_pending_scene = true;
+
+        let mut scene_shared = scene.shared.lock().unwrap();
+        scene_shared.simulation_locks.clear();
+        for lock in [
+            &self.direct_lock,
+            &self.reflections_lock,
+            &self.pathing_lock,
+        ]
+        .iter()
+        .filter_map(|lock| lock.as_ref())
+        {
+            scene_shared.simulation_locks.push(Arc::clone(lock));
+        }
+
+        let mut simulation_shared = self.shared.lock().unwrap();
+        simulation_shared.has_pending_scene = true;
     }
 
     /// Adds a probe batch for use in subsequent simulations.

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -313,6 +313,8 @@ where
     ///
     /// This function cannot be called while any simulation is running.
     pub fn set_scene(&mut self, scene: &Scene<T>) {
+        let _guards = self.acquire_all_simulation_locks();
+
         unsafe { audionimbus_sys::iplSimulatorSetScene(self.raw_ptr(), scene.raw_ptr()) }
 
         let mut scene_shared = scene.shared.lock().unwrap();
@@ -339,6 +341,7 @@ where
     ///
     /// This function cannot be called while any simulation is running.
     pub fn add_probe_batch(&mut self, probe_batch: &ProbeBatch) {
+        let _guards = self.acquire_all_simulation_locks();
         let raw_ptr = probe_batch.raw_ptr();
 
         unsafe {
@@ -358,6 +361,7 @@ where
     ///
     /// This function cannot be called while any simulation is running.
     pub fn remove_probe_batch(&mut self, probe_batch: &ProbeBatch) {
+        let _guards = self.acquire_all_simulation_locks();
         let raw_ptr = probe_batch.raw_ptr();
 
         unsafe {
@@ -404,14 +408,7 @@ where
     ///
     /// This function cannot be called while any simulation is running.
     pub fn commit(&mut self) {
-        let _guards: Vec<_> = [
-            self.direct_lock.as_ref(),
-            self.reflections_lock.as_ref(),
-            self.pathing_lock.as_ref(),
-        ]
-        .iter()
-        .filter_map(|lock| lock.as_ref().map(|l| l.lock().unwrap()))
-        .collect();
+        let _guards = self.acquire_all_simulation_locks();
 
         unsafe { audionimbus_sys::iplSimulatorCommit(self.raw_ptr()) }
 
@@ -621,6 +618,19 @@ where
         }
 
         guards
+    }
+
+    /// Acquires locks for all simulation types enabled on this simulator.
+    fn acquire_all_simulation_locks(&self) -> Vec<MutexGuard<'_, ()>> {
+        [
+            self.direct_lock.as_ref(),
+            self.reflections_lock.as_ref(),
+            self.pathing_lock.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .map(|lock| lock.lock().unwrap())
+        .collect()
     }
 
     /// Validates shared simulation inputs against the limits set during initialization.

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -162,7 +162,7 @@ impl SimulationFlagsProvider for () {
 #[derive(Debug)]
 pub struct Simulator<T: RayTracer, D = (), R = (), P = (), RE = ()> {
     inner: audionimbus_sys::IPLSimulator,
-    shared: Arc<Mutex<SimulatorShared>>,
+    shared: Arc<Mutex<SimulatorShared<T>>>,
 
     /// The maximum number of occlusion samples specified during creation.
     max_num_occlusion_samples: Option<u32>,
@@ -193,8 +193,8 @@ pub struct Simulator<T: RayTracer, D = (), R = (), P = (), RE = ()> {
 }
 
 /// Shared ownership of [`Simulator`] data across clones.
-#[derive(Default, Debug)]
-struct SimulatorShared {
+#[derive(Debug)]
+struct SimulatorShared<T: RayTracer> {
     /// Number of probes after the last commit.
     /// Used to ensure the simulator has probes before running pathing.
     committed_num_probes: usize,
@@ -202,11 +202,22 @@ struct SimulatorShared {
     /// Pending probe batches to be committed.
     pending_probe_batches: HashMap<audionimbus_sys::IPLProbeBatch, usize>,
 
-    /// Whether a scene has been set and committed.
-    has_committed_scene: bool,
+    /// The scene currently visible to simulation after the last simulator commit.
+    committed_scene: Option<Scene<T>>,
 
-    /// Whether a scene is pending commit.
-    has_pending_scene: bool,
+    /// The next scene to become visible after the next simulator commit.
+    pending_scene: Option<Scene<T>>,
+}
+
+impl<T: RayTracer> Default for SimulatorShared<T> {
+    fn default() -> Self {
+        Self {
+            committed_num_probes: 0,
+            pending_probe_batches: HashMap::new(),
+            committed_scene: None,
+            pending_scene: None,
+        }
+    }
 }
 
 impl<T, D, R, P, RE> Simulator<T, D, R, P, RE>
@@ -314,25 +325,31 @@ where
     ///
     /// This function cannot be called while any simulation is running.
     pub fn set_scene(&mut self, scene: &Scene<T>) {
-        let _guards = self.acquire_all_simulation_locks();
+        let _guards = self.acquire_all_locks();
 
-        unsafe { audionimbus_sys::iplSimulatorSetScene(self.raw_ptr(), scene.raw_ptr()) }
+        let previous_pending_scene = {
+            let mut shared = self.shared.lock().unwrap();
+            let is_noop = shared.pending_scene.as_ref() == Some(scene)
+                || (shared.pending_scene.is_none()
+                    && shared.committed_scene.as_ref() == Some(scene));
 
-        let mut scene_shared = scene.shared.lock().unwrap();
-        scene_shared.simulation_locks.clear();
-        for lock in [
-            &self.direct_lock,
-            &self.reflections_lock,
-            &self.pathing_lock,
-        ]
-        .iter()
-        .filter_map(|lock| lock.as_ref())
-        {
-            scene_shared.simulation_locks.push(Arc::clone(lock));
+            if is_noop {
+                return;
+            }
+
+            shared.pending_scene.replace(scene.clone())
+        };
+
+        let simulator = self.raw_ptr();
+        let lock_handles = self.lock_handles();
+
+        if let Some(previous_pending_scene) = previous_pending_scene {
+            previous_pending_scene.unregister_simulator(simulator, 1);
         }
 
-        let mut simulation_shared = self.shared.lock().unwrap();
-        simulation_shared.has_pending_scene = true;
+        scene.register_simulator(simulator, &lock_handles, 1);
+
+        unsafe { audionimbus_sys::iplSimulatorSetScene(self.raw_ptr(), scene.raw_ptr()) }
     }
 
     /// Adds a probe batch for use in subsequent simulations.
@@ -342,7 +359,7 @@ where
     ///
     /// This function cannot be called while any simulation is running.
     pub fn add_probe_batch(&mut self, probe_batch: &ProbeBatch) {
-        let _guards = self.acquire_all_simulation_locks();
+        let _guards = self.acquire_all_locks();
         let raw_ptr = probe_batch.raw_ptr();
 
         unsafe {
@@ -362,7 +379,7 @@ where
     ///
     /// This function cannot be called while any simulation is running.
     pub fn remove_probe_batch(&mut self, probe_batch: &ProbeBatch) {
-        let _guards = self.acquire_all_simulation_locks();
+        let _guards = self.acquire_all_locks();
         let raw_ptr = probe_batch.raw_ptr();
 
         unsafe {
@@ -409,16 +426,24 @@ where
     ///
     /// This function cannot be called while any simulation is running.
     pub fn commit(&mut self) {
-        let _guards = self.acquire_all_simulation_locks();
+        let _guards = self.acquire_all_locks();
+        let simulator = self.raw_ptr();
 
         unsafe { audionimbus_sys::iplSimulatorCommit(self.raw_ptr()) }
 
-        let mut shared = self.shared.lock().unwrap();
-        shared.committed_num_probes = shared.pending_probe_batches.values().sum();
+        let previous_committed_scene = {
+            let mut shared = self.shared.lock().unwrap();
+            shared.committed_num_probes = shared.pending_probe_batches.values().sum();
 
-        if shared.has_pending_scene {
-            shared.has_committed_scene = true;
-            shared.has_pending_scene = false;
+            if let Some(pending_scene) = shared.pending_scene.take() {
+                shared.committed_scene.replace(pending_scene)
+            } else {
+                None
+            }
+        };
+
+        if let Some(previous_committed_scene) = previous_committed_scene {
+            previous_committed_scene.unregister_simulator(simulator, 1);
         }
     }
 
@@ -598,40 +623,59 @@ where
 
     /// Acquires locks for the simulation types specified in the given flags.
     fn acquire_locks_for_flags(&self, flags: SimulationFlags) -> Vec<MutexGuard<'_, ()>> {
-        let mut guards = Vec::new();
+        let mut locks = Vec::new();
 
         if flags.contains(SimulationFlags::DIRECT)
             && let Some(lock) = &self.direct_lock
         {
-            guards.push(lock.lock().unwrap());
+            locks.push(lock);
         }
 
         if flags.contains(SimulationFlags::REFLECTIONS)
             && let Some(lock) = &self.reflections_lock
         {
-            guards.push(lock.lock().unwrap());
+            locks.push(lock);
         }
 
         if flags.contains(SimulationFlags::PATHING)
             && let Some(lock) = &self.pathing_lock
         {
-            guards.push(lock.lock().unwrap());
+            locks.push(lock);
         }
 
-        guards
+        // Match scene commit lock ordering to avoid deadlocks.
+        locks.sort_unstable_by_key(|lock| Arc::as_ptr(lock) as usize);
+        locks.into_iter().map(|lock| lock.lock().unwrap()).collect()
     }
 
     /// Acquires locks for all simulation types enabled on this simulator.
-    fn acquire_all_simulation_locks(&self) -> Vec<MutexGuard<'_, ()>> {
-        [
+    fn acquire_all_locks(&self) -> Vec<MutexGuard<'_, ()>> {
+        let mut locks: Vec<_> = [
             self.direct_lock.as_ref(),
             self.reflections_lock.as_ref(),
             self.pathing_lock.as_ref(),
         ]
         .into_iter()
         .flatten()
-        .map(|lock| lock.lock().unwrap())
-        .collect()
+        .collect();
+        // Match scene commit lock ordering to avoid deadlocks.
+        locks.sort_unstable_by_key(|lock| Arc::as_ptr(lock) as usize);
+        locks.into_iter().map(|lock| lock.lock().unwrap()).collect()
+    }
+
+    /// Returns this simulator's simulation locks in a stable order.
+    fn lock_handles(&self) -> Vec<Arc<Mutex<()>>> {
+        let mut locks: Vec<_> = [
+            self.direct_lock.as_ref(),
+            self.reflections_lock.as_ref(),
+            self.pathing_lock.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .cloned()
+        .collect();
+        locks.sort_unstable_by_key(|lock| Arc::as_ptr(lock) as usize);
+        locks
     }
 
     /// Validates shared simulation inputs against the limits set during initialization.
@@ -842,7 +886,7 @@ where
             .unwrap();
 
         let shared = self.shared.lock().unwrap();
-        if !shared.has_committed_scene {
+        if shared.committed_scene.is_none() {
             return Err(SimulationError::ReflectionsWithoutScene);
         }
 
@@ -3635,6 +3679,30 @@ mod tests {
             assert_eq!(simulator.raw_ptr(), clone.raw_ptr());
             drop(simulator);
             assert!(!clone.raw_ptr().is_null());
+        }
+
+        #[test]
+        fn test_set_scene_is_noop_when_scene_is_already_committed() {
+            let context = Context::default();
+            let audio_settings = AudioSettings::default();
+            let settings = SimulationSettings::new(&audio_settings);
+            let mut simulator = Simulator::try_new(&context, &settings).unwrap();
+            let scene = Scene::try_new(&context).unwrap();
+
+            simulator.set_scene(&scene);
+            simulator.commit();
+
+            {
+                let shared = simulator.shared.lock().unwrap();
+                assert!(shared.pending_scene.is_none());
+                assert_eq!(shared.committed_scene.as_ref(), Some(&scene));
+            }
+
+            simulator.set_scene(&scene);
+
+            let shared = simulator.shared.lock().unwrap();
+            assert!(shared.pending_scene.is_none());
+            assert_eq!(shared.committed_scene.as_ref(), Some(&scene));
         }
     }
 }

--- a/audionimbus/src/simulation.rs
+++ b/audionimbus/src/simulation.rs
@@ -326,8 +326,6 @@ where
     /// This function cannot be called while any simulation is running. Either will block until the
     /// other finishes.
     pub fn set_scene(&mut self, scene: &Scene<T>) {
-        let _guards = self.acquire_all_locks();
-
         let previous_pending_scene = {
             let mut shared = self.shared.lock().unwrap();
             let is_noop = shared.pending_scene.as_ref() == Some(scene)
@@ -341,6 +339,7 @@ where
             shared.pending_scene.replace(scene.clone())
         };
 
+        let _guards = self.acquire_all_locks();
         let simulator = self.raw_ptr();
         let lock_handles = self.lock_handles();
 


### PR DESCRIPTION
The Steam Audio documentation states that [`iplSceneCommit` cannot be called concurrently with any simulation function](https://valvesoftware.github.io/steam-audio/doc/capi/scene.html#_CPPv414iplSceneCommit8IPLScene). This was previously unenforced.

This PR introduces a registration system that propagates mutex locks from simulators down through scene hierarchies. When a simulator is set on a scene via `Simulator::set_scene`, the simulator's simulation locks are registered with that scene and all reachable sub-scenes transitively. `Scene::commit` then acquires all registered locks before calling `iplSceneCommit`, blocking until simulations finish (and preventing new ones from starting until the commit completes).

Sub-scenes reachable via multiple instanced meshes from the same simulator track a reference count, so locks are only released when the last path to the sub-scene is removed.
Pending-removal sub-scenes remain registered until `Scene::commit` completes, since they are still live from Steam Audio's perspective until then.