### PR TITLE
Add scene commit support to Simulation

### DIFF
--- a/audionimbus/src/wiring/mod.rs
+++ b/audionimbus/src/wiring/mod.rs
@@ -65,7 +65,7 @@
 //! let mut simulation = Simulation::new::<u32>(simulator);
 //!
 //! // Commit is required after adding sources so the simulator picks them up.
-//! simulation.request_commit();
+//! simulation.request_simulator_commit();
 //!
 //! // Spawn one thread per simulation type.
 //! // Each thread shares the same list of sources that the game thread writes every frame.

--- a/audionimbus/src/wiring/runner/mod.rs
+++ b/audionimbus/src/wiring/runner/mod.rs
@@ -10,8 +10,11 @@
 
 use super::simulation::SourceWithInputs;
 use super::step::SimulationStep;
+use crate::geometry::Scene;
+use crate::ray_tracing::RayTracer;
 use arc_swap::ArcSwap;
 use object_pool::{Pool, ReusableOwned};
+use std::collections::HashSet;
 use std::sync::{
     Arc, Condvar, Mutex,
     atomic::{AtomicBool, Ordering},
@@ -27,19 +30,21 @@ mod reflections_reverb;
 pub use reflections_reverb::*;
 
 /// Drives a [`SimulationStep`] on a dedicated thread.
-pub struct SimulationRunner<I, O> {
+pub struct SimulationRunner<I, O, T: RayTracer> {
     input: Arc<ArcSwap<I>>,
     output: Arc<ArcSwap<ReusableOwned<O>>>,
     commit_needed: Arc<AtomicBool>,
     on_commit: Box<dyn FnMut() + Send + 'static>,
+    pending_scene_commits: Arc<ArcSwap<HashSet<Scene<T>>>>,
     shutdown: Arc<AtomicBool>,
     paused: Arc<(Mutex<bool>, Condvar)>,
 }
 
-impl<I, O> SimulationRunner<I, O>
+impl<I, O, T> SimulationRunner<I, O, T>
 where
     I: Send + Sync + 'static,
     O: Send + Sync + 'static + Default + Clear + Shrink,
+    T: RayTracer + 'static,
 {
     /// Creates a new simulation runner.
     ///
@@ -49,6 +54,7 @@ where
     /// - `output`: shared output written after each simulation run.
     /// - `commit_needed`: set to `true` to trigger a simulator commit on the next run.
     /// - `on_commit`: called when the commit flag is set to `true`.
+    /// - `pending_scene_commits`: scenes pending a commit.
     /// - `shutdown`: set to `true` to stop the thread after its current iteration.
     /// - `paused`: set to `true` to pause the thread after its current iteration.
     pub fn new(
@@ -56,6 +62,7 @@ where
         output: Arc<ArcSwap<ReusableOwned<O>>>,
         commit_needed: Arc<AtomicBool>,
         on_commit: impl FnMut() + Send + 'static,
+        pending_scene_commits: Arc<ArcSwap<HashSet<Scene<T>>>>,
         shutdown: Arc<AtomicBool>,
         paused: Arc<(Mutex<bool>, Condvar)>,
     ) -> Self {
@@ -64,6 +71,7 @@ where
             output,
             commit_needed,
             on_commit: Box::new(on_commit),
+            pending_scene_commits,
             shutdown,
             paused,
         }
@@ -87,12 +95,14 @@ where
             output,
             commit_needed,
             mut on_commit,
+            pending_scene_commits,
             shutdown,
             paused,
         } = self;
 
         std::thread::spawn(move || {
             let pool = Arc::new(Pool::new(4, O::default));
+            let empty_scene_commits = Arc::new(HashSet::new());
 
             loop {
                 if shutdown.load(Ordering::Relaxed) {
@@ -105,6 +115,11 @@ where
                     while *is_paused {
                         is_paused = condvar.wait(is_paused).unwrap();
                     }
+                }
+
+                let scenes_to_commit = pending_scene_commits.swap(Arc::clone(&empty_scene_commits));
+                for scene in scenes_to_commit.iter() {
+                    scene.commit();
                 }
 
                 // The first thread to catch the flag commits.

--- a/audionimbus/src/wiring/runner/mod.rs
+++ b/audionimbus/src/wiring/runner/mod.rs
@@ -33,8 +33,8 @@ pub use reflections_reverb::*;
 pub struct SimulationRunner<I, O, T: RayTracer> {
     input: Arc<ArcSwap<I>>,
     output: Arc<ArcSwap<ReusableOwned<O>>>,
-    commit_needed: Arc<AtomicBool>,
-    on_commit: Box<dyn FnMut() + Send + 'static>,
+    simulator_commit_needed: Arc<AtomicBool>,
+    on_simulator_commit: Box<dyn FnMut() + Send + 'static>,
     pending_scene_commits: Arc<ArcSwap<HashSet<Scene<T>>>>,
     shutdown: Arc<AtomicBool>,
     paused: Arc<(Mutex<bool>, Condvar)>,
@@ -52,16 +52,16 @@ where
     ///
     /// - `input`: shared input frame updated each frame.
     /// - `output`: shared output written after each simulation run.
-    /// - `commit_needed`: set to `true` to trigger a simulator commit on the next run.
-    /// - `on_commit`: called when the commit flag is set to `true`.
+    /// - `simulator_commit_needed`: set to `true` to trigger a simulator commit on the next run.
+    /// - `on_simulator_commit`: called when the commit flag is set to `true`.
     /// - `pending_scene_commits`: scenes pending a commit.
     /// - `shutdown`: set to `true` to stop the thread after its current iteration.
     /// - `paused`: set to `true` to pause the thread after its current iteration.
     pub fn new(
         input: Arc<ArcSwap<I>>,
         output: Arc<ArcSwap<ReusableOwned<O>>>,
-        commit_needed: Arc<AtomicBool>,
-        on_commit: impl FnMut() + Send + 'static,
+        simulator_commit_needed: Arc<AtomicBool>,
+        on_simulator_commit: impl FnMut() + Send + 'static,
         pending_scene_commits: Arc<ArcSwap<HashSet<Scene<T>>>>,
         shutdown: Arc<AtomicBool>,
         paused: Arc<(Mutex<bool>, Condvar)>,
@@ -69,8 +69,8 @@ where
         Self {
             input,
             output,
-            commit_needed,
-            on_commit: Box::new(on_commit),
+            simulator_commit_needed,
+            on_simulator_commit: Box::new(on_simulator_commit),
             pending_scene_commits,
             shutdown,
             paused,
@@ -93,8 +93,8 @@ where
         let Self {
             input,
             output,
-            commit_needed,
-            mut on_commit,
+            simulator_commit_needed,
+            mut on_simulator_commit,
             pending_scene_commits,
             shutdown,
             paused,
@@ -123,11 +123,11 @@ where
                 }
 
                 // The first thread to catch the flag commits.
-                if commit_needed
+                if simulator_commit_needed
                     .compare_exchange(true, false, Ordering::Acquire, Ordering::Relaxed)
                     .is_ok()
                 {
-                    on_commit();
+                    on_simulator_commit();
                 }
 
                 let frame = input.load();

--- a/audionimbus/src/wiring/simulation/direct.rs
+++ b/audionimbus/src/wiring/simulation/direct.rs
@@ -42,7 +42,7 @@ where
         let handle = SimulationRunner::new(
             input.clone(),
             output.0.clone(),
-            self.commit_needed.clone(),
+            self.simulator_commit_needed.clone(),
             move || simulator_for_commit.commit(),
             self.pending_scene_commits.clone(),
             self.shutdown.clone(),

--- a/audionimbus/src/wiring/simulation/direct.rs
+++ b/audionimbus/src/wiring/simulation/direct.rs
@@ -44,6 +44,7 @@ where
             output.0.clone(),
             self.commit_needed.clone(),
             move || simulator_for_commit.commit(),
+            self.pending_scene_commits.clone(),
             self.shutdown.clone(),
             paused.clone(),
         )

--- a/audionimbus/src/wiring/simulation/mod.rs
+++ b/audionimbus/src/wiring/simulation/mod.rs
@@ -8,10 +8,12 @@
 #[cfg(doc)]
 use super::runner::SimulationRunner;
 
+use crate::geometry::Scene;
 use crate::ray_tracing::RayTracer;
 use crate::simulation::{SimulationInputs, Simulator, Source};
 use arc_swap::ArcSwap;
 use object_pool::{Pool, ReusableOwned};
+use std::collections::HashSet;
 use std::sync::{
     Arc, Condvar, Mutex,
     atomic::{AtomicBool, Ordering},
@@ -93,16 +95,24 @@ where
 {
     /// The underlying simulator shared across all spawned simulation threads.
     pub simulator: Simulator<T, D, R, P, RE>,
+
     /// Pool of source buffers, reused across frames to avoid allocation.
     pub sources_pool: SourcesPool<SourceId, D, R, P, RE>,
+
     /// The current source buffer, atomically swapped each frame via [`Self::update_sources`].
     pub sources: SharedSources<SourceId, D, R, P, RE>,
+
     /// Set to `true` via [`Self::request_commit`] to trigger a simulator commit on the next
     /// simulation run.
     pub commit_needed: Arc<AtomicBool>,
+
+    /// Scenes pending a commit.
+    pub pending_scene_commits: Arc<ArcSwap<HashSet<Scene<T>>>>,
+
     /// Set to `true` via [`Self::shutdown`] to stop all spawned simulation threads after their
     /// current iteration.
     pub shutdown: Arc<AtomicBool>,
+
     /// Pause flags for each spawned simulation thread, in spawn order.
     ///
     /// Simulation threads can be paused via [`Self::pause`] and resumed via [`Self::resume`].
@@ -125,6 +135,7 @@ where
             sources_pool.pull_owned(Default::default),
         )));
         let commit_needed = Arc::new(AtomicBool::new(false));
+        let pending_scene_commits = Arc::new(ArcSwap::new(Arc::new(HashSet::new())));
         let shutdown = Arc::new(AtomicBool::new(false));
         let paused = vec![];
 
@@ -133,6 +144,7 @@ where
             sources_pool,
             sources,
             commit_needed,
+            pending_scene_commits,
             shutdown,
             paused,
         }
@@ -196,9 +208,22 @@ where
         self.sources.store(Arc::new(sources));
     }
 
-    /// Signals all spawned simulation threads to commit on their next run.
+    /// Signals all spawned simulation threads to commit the [`Simulator`] changes on their next run.
     pub fn request_commit(&mut self) {
         self.commit_needed.store(true, Ordering::Relaxed);
+    }
+
+    /// Requests simulation threads to commit the provided scenes on their next run.
+    pub fn request_scene_commits(&self, scene_commits: &[Scene<T>]) {
+        self.pending_scene_commits.rcu(|pending_scene_commits| {
+            // SAFETY: Scene's Hash and Eq are based on pointer identity, not interior state.
+            #[allow(clippy::mutable_key_type)]
+            let mut new_pending_scene_commits =
+                HashSet::with_capacity(pending_scene_commits.len() + scene_commits.len());
+            new_pending_scene_commits.extend(pending_scene_commits.iter().cloned());
+            new_pending_scene_commits.extend(scene_commits.iter().cloned());
+            new_pending_scene_commits
+        });
     }
 
     /// Signals all spawned simulation threads to stop.
@@ -230,6 +255,7 @@ where
 pub struct SourceWithInputs<D, R, P, RE> {
     /// Spatial audio source.
     pub source: Source<D, R, P, RE>,
+
     /// Simulation inputs for the associated source.
     pub simulation_inputs: SimulationInputs<D, R, P>,
 }

--- a/audionimbus/src/wiring/simulation/mod.rs
+++ b/audionimbus/src/wiring/simulation/mod.rs
@@ -104,7 +104,7 @@ where
 
     /// Set to `true` via [`Self::request_commit`] to trigger a simulator commit on the next
     /// simulation run.
-    pub commit_needed: Arc<AtomicBool>,
+    pub simulator_commit_needed: Arc<AtomicBool>,
 
     /// Scenes pending a commit.
     pub pending_scene_commits: Arc<ArcSwap<HashSet<Scene<T>>>>,
@@ -134,7 +134,7 @@ where
         let sources = Arc::new(ArcSwap::new(Arc::new(
             sources_pool.pull_owned(Default::default),
         )));
-        let commit_needed = Arc::new(AtomicBool::new(false));
+        let simulator_commit_needed = Arc::new(AtomicBool::new(false));
         let pending_scene_commits = Arc::new(ArcSwap::new(Arc::new(HashSet::new())));
         let shutdown = Arc::new(AtomicBool::new(false));
         let paused = vec![];
@@ -143,7 +143,7 @@ where
             simulator,
             sources_pool,
             sources,
-            commit_needed,
+            simulator_commit_needed,
             pending_scene_commits,
             shutdown,
             paused,
@@ -209,8 +209,8 @@ where
     }
 
     /// Signals all spawned simulation threads to commit the [`Simulator`] changes on their next run.
-    pub fn request_commit(&mut self) {
-        self.commit_needed.store(true, Ordering::Relaxed);
+    pub fn request_simulator_commit(&mut self) {
+        self.simulator_commit_needed.store(true, Ordering::Relaxed);
     }
 
     /// Requests simulation threads to commit the provided scenes on their next run.

--- a/audionimbus/src/wiring/simulation/pathing.rs
+++ b/audionimbus/src/wiring/simulation/pathing.rs
@@ -43,6 +43,7 @@ where
             output.0.clone(),
             self.commit_needed.clone(),
             move || simulator_for_commit.commit(),
+            self.pending_scene_commits.clone(),
             self.shutdown.clone(),
             paused.clone(),
         )

--- a/audionimbus/src/wiring/simulation/pathing.rs
+++ b/audionimbus/src/wiring/simulation/pathing.rs
@@ -41,7 +41,7 @@ where
         let handle = SimulationRunner::new(
             input.clone(),
             output.0.clone(),
-            self.commit_needed.clone(),
+            self.simulator_commit_needed.clone(),
             move || simulator_for_commit.commit(),
             self.pending_scene_commits.clone(),
             self.shutdown.clone(),

--- a/audionimbus/src/wiring/simulation/reflections.rs
+++ b/audionimbus/src/wiring/simulation/reflections.rs
@@ -50,6 +50,7 @@ where
             output.0.clone(),
             self.commit_needed.clone(),
             move || simulator_for_commit.commit(),
+            self.pending_scene_commits.clone(),
             self.shutdown.clone(),
             paused.clone(),
         )

--- a/audionimbus/src/wiring/simulation/reflections.rs
+++ b/audionimbus/src/wiring/simulation/reflections.rs
@@ -48,7 +48,7 @@ where
         let handle = SimulationRunner::new(
             input.clone(),
             output.0.clone(),
-            self.commit_needed.clone(),
+            self.simulator_commit_needed.clone(),
             move || simulator_for_commit.commit(),
             self.pending_scene_commits.clone(),
             self.shutdown.clone(),

--- a/audionimbus/src/wiring/simulation/reflections_reverb.rs
+++ b/audionimbus/src/wiring/simulation/reflections_reverb.rs
@@ -56,6 +56,7 @@ where
             output.0.clone(),
             self.commit_needed.clone(),
             move || simulator_for_commit.commit(),
+            self.pending_scene_commits.clone(),
             self.shutdown.clone(),
             paused.clone(),
         )

--- a/audionimbus/src/wiring/simulation/reflections_reverb.rs
+++ b/audionimbus/src/wiring/simulation/reflections_reverb.rs
@@ -54,7 +54,7 @@ where
         let handle = SimulationRunner::new(
             input.clone(),
             output.0.clone(),
-            self.commit_needed.clone(),
+            self.simulator_commit_needed.clone(),
             move || simulator_for_commit.commit(),
             self.pending_scene_commits.clone(),
             self.shutdown.clone(),
@@ -150,7 +150,7 @@ mod tests {
         let listener_source =
             Source::<(), Reflections, (), Convolution>::try_new(&simulator_clone).unwrap();
         simulator_clone.add_source(&listener_source);
-        simulation.request_commit();
+        simulation.request_simulator_commit();
 
         let reverb_simulation = simulation.spawn_reflections_reverb::<(), ()>(|error| {
             eprintln!("{error}");
@@ -186,7 +186,7 @@ mod tests {
         let listener_source =
             Source::<(), Reflections, (), Convolution>::try_new(&simulator_clone).unwrap();
         simulator_clone.add_source(&listener_source);
-        simulation.request_commit();
+        simulation.request_simulator_commit();
 
         let reverb_simulation = simulation.spawn_reflections_reverb::<(), ()>(|error| {
             eprintln!("{error}");

--- a/audionimbus/tests/simulation.rs
+++ b/audionimbus/tests/simulation.rs
@@ -367,7 +367,7 @@ fn test_wiring_simulation() {
         Source::<(), Reflections, (), Convolution>::try_new_subset(&simulator_clone).unwrap();
     simulator_clone.add_source(&listener_source);
 
-    simulation.request_commit();
+    simulation.request_simulator_commit();
 
     simulation.update_sources(|sources| {
         sources.push((


### PR DESCRIPTION
Adds `Simulation::request_scene_commits(&[Scene<T>])`, which signals all spawned simulation threads to call `commit()` on the provided scenes on their next run.

Scenes are accumulated in a lock-free `ArcSwap<HashSet>` shared across all simulation threads. The first thread to run drains and commits the set atomically.