### PR TITLE
Fix buffer size mismatch in core demo

### DIFF
--- a/audionimbus-sys/build.rs
+++ b/audionimbus-sys/build.rs
@@ -790,6 +790,7 @@ fn system_flags() -> Vec<String> {
 }
 
 /// Forces to re-run the build script on the next build.
+#[cfg(feature = "auto-install")]
 fn force_rerun() {
     println!("cargo::rerun-if-changed=RERUN");
 }

--- a/audionimbus/examples/core/src/output.rs
+++ b/audionimbus/examples/core/src/output.rs
@@ -27,10 +27,11 @@ pub fn start_output_stream<F>(device: &cpal::Device, config: &StreamConfig, call
 where
     F: FnMut(&mut [Sample], &cpal::OutputCallbackInfo) + Send + 'static,
 {
+    let mut fixed_output = FrameAdapter::new(config, callback);
     let stream = device
         .build_output_stream(
             config,
-            callback,
+            move |output, info| fixed_output.render(output, info),
             |err| eprintln!("audio stream error: {err}"),
             None,
         )
@@ -38,4 +39,52 @@ where
 
     stream.play().expect("failed to start output stream");
     stream
+}
+
+/// Adapts CPAL's callback buffer size to the fixed block size used by Steam Audio.
+///
+/// CPAL doesn't guarantee [`cpal::BufferSize::Fixed`] is actually honored.
+/// Some backends may still invoke the output callback with a different number of samples.
+///
+/// This wraps the render callback so it always sees exactly `FRAME_SIZE * channels` samples,
+/// holding any unconsumed output in `buffer` until the next CPAL callback drains it.
+struct FrameAdapter<F> {
+    /// User render callback that fills exactly one fixed-size frame.
+    callback: F,
+    /// Block buffer.
+    buffer: Vec<Sample>,
+    /// Current read position in `buffer`.
+    cursor: usize,
+}
+
+impl<F> FrameAdapter<F>
+where
+    F: FnMut(&mut [Sample], &cpal::OutputCallbackInfo),
+{
+    fn new(config: &StreamConfig, callback: F) -> Self {
+        let buffer_len = FRAME_SIZE as usize * config.channels as usize;
+        Self {
+            callback,
+            buffer: vec![0.0; buffer_len],
+            // Start at the end so the first callback renders a fresh block.
+            cursor: buffer_len,
+        }
+    }
+
+    /// Fills CPAL's `output` buffer by consuming one or more fixed-size render blocks.
+    fn render(&mut self, output: &mut [Sample], info: &cpal::OutputCallbackInfo) {
+        let mut remaining = output;
+
+        while !remaining.is_empty() {
+            if self.cursor == self.buffer.len() {
+                (self.callback)(&mut self.buffer, info);
+                self.cursor = 0;
+            }
+
+            let n = remaining.len().min(self.buffer.len() - self.cursor);
+            remaining[..n].copy_from_slice(&self.buffer[self.cursor..self.cursor + n]);
+            remaining = &mut remaining[n..];
+            self.cursor += n;
+        }
+    }
 }

--- a/audionimbus/src/callback.rs
+++ b/audionimbus/src/callback.rs
@@ -68,9 +68,6 @@ macro_rules! callback {
         }
     };
 }
-
-pub(crate) use callback;
-
 /// Trait for types that can be converted to/from FFI representations.
 pub(crate) trait FfiConvert {
     type FfiType;


### PR DESCRIPTION
Fixes #63

### Problem

The core demo uses CPAL for audio playback.
Steam Audio is configured for fixed frame sizes; so when building the CPAL device, we use `cpal::BufferSize::Fixed` to request a fixed-size output buffer.
However, despite the name, CPAL doesn't guarantee the fixed buffer size is honored. Some backends may still invoke the output callback with a different number of samples.

This leads to a size mismatch error:

```
InterleaveLengthMismatch { dst_len: 512, expected_len: 2048 }
```

In this example, CPAL delivers 256 × 2 channels = 512 samples while Steam Audio expects 1024 × 2 channels = 2048 samples.

### Solution

This PR introduces a `FrameAdapter` that wraps the CPAL render callback so it always sees exactly `FRAME_SIZE * channels` samples.

---

The PR also fixes two unrelated warnings:
- unused import `callback`
- function `force_rerun` is never used (now gated behind the `auto-install` feature)